### PR TITLE
Bump GolangCI-lint to v1.44.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ COMMON_GO_ARGS=-race
 GIT_COMMIT=$(shell script/create-version-files.sh)
 GIT_RELEASE=$(shell script/get-git-release.sh)
 GIT_PREVIOUS_RELEASE=$(shell script/get-git-previous-release.sh)
-GOLANGCI_VERSION=v1.43.0
+GOLANGCI_VERSION=v1.44.1
 
 # Run the unit tests and build all binaries
 build:

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ At a minimum, the following dependencies must be installed *prior* to running `m
 Dependency|Minimum Version
 ---|---
 [GoLang](https://golang.org/dl/)|1.17
-[golangci-lint](https://golangci-lint.run/usage/install/)|1.43.0
+[golangci-lint](https://golangci-lint.run/usage/install/)|1.44.1
 [jq](https://stedolan.github.io/jq/)|1.6
 [OpenShift Client](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/)|4.7
 


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.44.1

No code changes found/needed.