### PR TITLE
Operator TS - TC migration: install-status-no-privileges

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -312,6 +312,15 @@ Description|http://test-network-function.com/testcases/operator/install-source t
 Result Type|normative
 Suggested Remediation|Ensure that your Operator is installed via OLM.
 Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2.12 and Section 6.3.3
+### http://test-network-function.com/testcases/operator/install-status-no-privileges
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/operator/install-status-no-privileges The operator is not installed with privileged rights. Test passes if clusterPermissions is not present in the CSV manifest or is present  with no resourceNames under its rules.
+Result Type|normative
+Suggested Remediation|Make sure all the CNF operators have no privileges on cluster resources.
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2.12 and Section 6.3.3
 ### http://test-network-function.com/testcases/operator/install-status-succeeded
 
 Property|Description

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -150,6 +150,11 @@ var (
 		Url:     formTestURL(common.OperatorTestKey, "install-status-succeeded"),
 		Version: versionOne,
 	}
+	// TestOperatorNoPrivileges tests Operator has no privileges on resources.
+	TestOperatorNoPrivileges = claim.Identifier{
+		Url:     formTestURL(common.OperatorTestKey, "install-status-no-privileges"),
+		Version: versionOne,
+	}
 	// TestOperatorIsCertifiedIdentifier tests that an Operator has passed Operator certification.
 	TestOperatorIsCertifiedIdentifier = claim.Identifier{
 		Url:     formTestURL(common.AffiliatedCertTestKey, "operator-is-certified"),
@@ -459,6 +464,16 @@ the same hacks.'`),
 		Remediation: `Make sure all the CNF operators have been successfully installed by OLM.`,
 		Description: formDescription(TestOperatorInstallStatusSucceededIdentifier,
 			`Ensures that the target CNF operators report "Succeeded" as their installation status.`),
+		BestPracticeReference: bestPracticeDocV1dot2URL + " Section 6.2.12 and Section 6.3.3",
+	},
+
+	TestOperatorNoPrivileges: {
+		Identifier:  TestOperatorNoPrivileges,
+		Type:        normativeResult,
+		Remediation: `Make sure all the CNF operators have no privileges on cluster resources.`,
+		Description: formDescription(TestOperatorNoPrivileges,
+			`The operator is not installed with privileged rights. Test passes if clusterPermissions is not present in the CSV manifest or is present 
+with no resourceNames under its rules.`),
 		BestPracticeReference: bestPracticeDocV1dot2URL + " Section 6.2.12 and Section 6.3.3",
 	},
 


### PR DESCRIPTION
This TC was part of the old combo TCs that were used to run against each
operator/csv under test. An independent (and public) test ID has been
created for this TC so in order to emulate the old combo TCs selection,
the use of the skip flag (-s) is required when launching the TNF.

**Backward Compatibility Notes:**
TNF v3.3 TC operator-install-status ID/TC has been divided into two different TCs + IDs, one for each part of the old arch TC:

operator-install-status-succeeded: Already implemented in PR #23
operator-install-status-no-privileges: Implemented in this PR.