### PR TITLE
Bumping the CRD API to v1

### DIFF
--- a/cnf-certification-test/accesscontrol/namespace/namespace.go
+++ b/cnf-certification-test/accesscontrol/namespace/namespace.go
@@ -23,14 +23,14 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/internal/ocpclient"
 	"github.com/test-network-function/cnf-certification-test/pkg/stringhelper"
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // TestCrsNamespaces finds the list of the input CRDs (crds parameter) instances (CRs) and verify that they are only in namespaces provided as input.
 // The list of CRs not belonging to the namespaces passed as input is returned as invalid
-func TestCrsNamespaces(crds []*apiextv1beta1.CustomResourceDefinition, configNamespaces []string) (invalidCrs map[string]map[string][]string, err error) {
+func TestCrsNamespaces(crds []*apiextv1.CustomResourceDefinition, configNamespaces []string) (invalidCrs map[string]map[string][]string, err error) {
 	// Initialize the top level map
 	invalidCrs = make(map[string]map[string][]string)
 	for _, crd := range crds {
@@ -40,7 +40,7 @@ func TestCrsNamespaces(crds []*apiextv1beta1.CustomResourceDefinition, configNam
 		}
 		for namespace, crNames := range crNamespaces {
 			if !stringhelper.StringInSlice(configNamespaces, namespace, false) {
-				logrus.Tracef("CRD: %s (kind:%s/ plural:%s) has CRs %v deployed in namespace (%s) not in configured namespaces %v",
+				logrus.Debugf("CRD: %s (kind:%s/ plural:%s) has CRs %v deployed in namespace (%s) not in configured namespaces %v",
 					crd.Name, crd.Spec.Names.Kind, crd.Spec.Names.Plural, crNames, namespace, configNamespaces)
 				// Initialize this map dimenension before use
 				if invalidCrs[crd.Name] == nil {
@@ -55,34 +55,37 @@ func TestCrsNamespaces(crds []*apiextv1beta1.CustomResourceDefinition, configNam
 
 // getCrsPerNamespaces gets the list of CRs instantiated in the cluster per namespace.
 // Returns a map indexed by namespace and data is a list of CR names
-func getCrsPerNamespaces(aCrd *apiextv1beta1.CustomResourceDefinition) (crdNamespaces map[string][]string, err error) {
+func getCrsPerNamespaces(aCrd *apiextv1.CustomResourceDefinition) (crdNamespaces map[string][]string, err error) {
 	oc := ocpclient.NewOcpClient()
-	gvr := schema.GroupVersionResource{
-		Group:    aCrd.Spec.Group,
-		Version:  aCrd.Spec.Version,
-		Resource: aCrd.Spec.Names.Plural,
-	}
-	crs, err := oc.DynamicClient.Resource(gvr).List(context.Background(), v1.ListOptions{})
-	if err != nil {
-		logrus.Errorf("error getting %s: %v\n", aCrd.Name, err)
-		return crdNamespaces, err
-	}
-	crdNamespaces = make(map[string][]string)
-	for _, cr := range crs.Items {
-		name := cr.Object["metadata"].(map[string]interface{})["name"]
-		namespace := cr.Object["metadata"].(map[string]interface{})["namespace"]
-		var namespaceStr, nameStr string
-		if namespace == nil {
-			namespaceStr = ""
-		} else {
-			namespaceStr = fmt.Sprintf("%s", namespace)
+	for _, version := range aCrd.Spec.Versions {
+		gvr := schema.GroupVersionResource{
+			Group:    aCrd.Spec.Group,
+			Version:  version.Name,
+			Resource: aCrd.Spec.Names.Plural,
 		}
-		if name == nil {
-			nameStr = ""
-		} else {
-			nameStr = fmt.Sprintf("%s", name)
+		logrus.Debugf("Looking for CRs from CRD: %s api version:%s group:%s plural:%s", aCrd.Name, version.Name, aCrd.Spec.Group, aCrd.Spec.Names.Plural)
+		crs, err := oc.DynamicClient.Resource(gvr).List(context.Background(), v1.ListOptions{})
+		if err != nil {
+			logrus.Errorf("error getting %s: %v\n", aCrd.Name, err)
+			return crdNamespaces, err
 		}
-		crdNamespaces[namespaceStr] = append(crdNamespaces[namespaceStr], nameStr)
+		crdNamespaces = make(map[string][]string)
+		for _, cr := range crs.Items {
+			name := cr.Object["metadata"].(map[string]interface{})["name"]
+			namespace := cr.Object["metadata"].(map[string]interface{})["namespace"]
+			var namespaceStr, nameStr string
+			if namespace == nil {
+				namespaceStr = ""
+			} else {
+				namespaceStr = fmt.Sprintf("%s", namespace)
+			}
+			if name == nil {
+				nameStr = ""
+			} else {
+				nameStr = fmt.Sprintf("%s", name)
+			}
+			crdNamespaces[namespaceStr] = append(crdNamespaces[namespaceStr], nameStr)
+		}
 	}
 	return crdNamespaces, nil
 }

--- a/internal/ocpclient/ocpclient.go
+++ b/internal/ocpclient/ocpclient.go
@@ -6,7 +6,7 @@ import (
 	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	clientOlm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/sirupsen/logrus"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	"k8s.io/client-go/dynamic"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
@@ -17,7 +17,7 @@ type OcpClient struct {
 	Coreclient    *corev1client.CoreV1Client
 	ClientConfig  clientconfigv1.ConfigV1Interface
 	DynamicClient dynamic.Interface
-	APIExtClient  apiextensionsv1beta1.ApiextensionsV1beta1Interface
+	APIExtClient  apiextv1.ApiextensionsV1Interface
 	OlmClient     *clientOlm.Clientset
 	RestConfig    *rest.Config
 
@@ -67,7 +67,7 @@ func NewOcpClient(filenames ...string) OcpClient { //nolint:funlen // this is a 
 	if err != nil {
 		logrus.Panic("can't instantiate dynamic client (unstructured/dynamic): ", err)
 	}
-	ocpClient.APIExtClient, err = apiextensionsv1beta1.NewForConfig(ocpClient.RestConfig)
+	ocpClient.APIExtClient, err = apiextv1.NewForConfig(ocpClient.RestConfig)
 	if err != nil {
 		logrus.Panic("can't instantiate dynamic client (unstructured/dynamic): ", err)
 	}

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -20,12 +20,13 @@ import (
 	"fmt"
 	"path/filepath"
 
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	olmv1Alpha "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/internal/ocpclient"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 	v1 "k8s.io/api/core/v1"
-	apiextv1beta "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 )
 
 const (
@@ -56,7 +57,7 @@ func buildLabelQuery(label configuration.Label) string {
 func DoAutoDiscover() (env configuration.TestParameters,
 	testData configuration.TestConfiguration,
 	pods,
-	debugPods []v1.Pod, crds []*apiextv1beta.CustomResourceDefinition, namespaces []string,
+	debugPods []v1.Pod, crds []*apiextv1.CustomResourceDefinition, namespaces []string,
 	csvs []olmv1Alpha.ClusterServiceVersion) {
 	env, err := configuration.LoadEnvironmentVariables()
 	if err != nil {

--- a/pkg/autodiscover/autodiscover_crds.go
+++ b/pkg/autodiscover/autodiscover_crds.go
@@ -24,13 +24,14 @@ import (
 
 	"context"
 
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	"github.com/test-network-function/cnf-certification-test/internal/ocpclient"
-	apiextv1beta "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // getClusterCrdNames returns a list of crd names found in the cluster.
-func getClusterCrdNames() (crdList []*apiextv1beta.CustomResourceDefinition, err error) {
+func getClusterCrdNames() (crdList []*apiextv1.CustomResourceDefinition, err error) {
 	oc := ocpclient.NewOcpClient()
 	options := metav1.ListOptions{}
 	crds, err := oc.APIExtClient.CustomResourceDefinitions().List(context.TODO(), options)
@@ -45,11 +46,11 @@ func getClusterCrdNames() (crdList []*apiextv1beta.CustomResourceDefinition, err
 }
 
 // FindTestCrdNames gets a list of CRD names based on configured groups.
-func FindTestCrdNames(crdFilters []configuration.CrdFilter) (targetCrds []*apiextv1beta.CustomResourceDefinition) {
+func FindTestCrdNames(crdFilters []configuration.CrdFilter) (targetCrds []*apiextv1.CustomResourceDefinition) {
 	clusterCrds, err := getClusterCrdNames()
 	if err != nil {
 		logrus.Errorf("Unable to get cluster CRD.")
-		return []*apiextv1beta.CustomResourceDefinition{}
+		return []*apiextv1.CustomResourceDefinition{}
 	}
 	for _, crd := range clusterCrds {
 		for _, crdFilter := range crdFilters {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -17,11 +17,12 @@
 package provider
 
 import (
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/test-network-function/cnf-certification-test/pkg/autodiscover"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 	v1 "k8s.io/api/core/v1"
-	apiextv1beta "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 )
 
 type TestEnvironment struct { // rename this with testTarget
@@ -32,7 +33,7 @@ type TestEnvironment struct { // rename this with testTarget
 	DebugPods  map[string]*v1.Pod // map from nodename to debugPod
 	Config     configuration.TestConfiguration
 	variables  configuration.TestParameters
-	Crds       []*apiextv1beta.CustomResourceDefinition
+	Crds       []*apiextv1.CustomResourceDefinition
 }
 
 type Container struct {


### PR DESCRIPTION
Upgrading api to v1. Only change is that multiple versions are supported for CRDs. We now loop through each version to list CR objects for that version.