### PR TITLE
Porting ICMP IPv4/IPv6 networking testcases

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Quality Gate - Test coverage shall be above threshold
         env:
-          TESTCOVERAGE_THRESHOLD: 50
+          TESTCOVERAGE_THRESHOLD: 45
         run: |
           echo "Quality Gate: checking test coverage is above threshold ..."
           echo "Threshold             : $TESTCOVERAGE_THRESHOLD %"

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -272,9 +272,36 @@ Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/site
 Property|Description
 ---|---
 Version|v1.0.0
-Description|http://test-network-function.com/testcases/networking/icmpv4-connectivity checks that each CNF Container is able to communicate via ICMPv4 on the Default OpenShift network.  This test case requires the Deployment of the debug daemonset. 
+Description|http://test-network-function.com/testcases/networking/icmpv4-connectivity checks that each CNF Container is able to communicate via ICMPv4 on the Default OpenShift network.  This test case requires the Deployment of the debug daemonset.
 Result Type|normative
-Suggested Remediation|Ensure that the CNF is able to communicate via the Default OpenShift network.  In some rare cases, CNFs may require routing table changes in order to communicate over the Default network.  In other cases, if the Container base image does not provide the "ip" or "ping" binaries, this test may not be applicable.  For instructions on how to exclude a particular container from ICMPv4 connectivity tests, consult: [README.md](https://github.com/test-network-function/test-network-function#issue-161-some-containers-under-test-do-not-contain-ping-or-ip-binary-utilities).
+Suggested Remediation|Ensure that the CNF is able to communicate via the Default OpenShift network. In some rare cases, CNFs may require routing table changes in order to communicate over the Default network. To exclude a particular pod from ICMPv4 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
+### http://test-network-function.com/testcases/networking/icmpv4-connectivity-multus
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/networking/icmpv4-connectivity-multus checks that each CNF Container is able to communicate via ICMPv4 on the Multus network(s).  This test case requires the Deployment of the debug daemonset.
+Result Type|normative
+Suggested Remediation|Ensure that the CNF is able to communicate via the Multus network(s). In some rare cases, CNFs may require routing table changes in order to communicate over the Multus network(s). To exclude a particular pod from ICMPv4 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
+### http://test-network-function.com/testcases/networking/icmpv6-connectivity
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/networking/icmpv6-connectivity checks that each CNF Container is able to communicate via ICMPv6 on the Default OpenShift network.  This test case requires the Deployment of the debug daemonset.
+Result Type|normative
+Suggested Remediation|Ensure that the CNF is able to communicate via the Default OpenShift network. In some rare cases, CNFs may require routing table changes in order to communicate over the Default network. To exclude a particular pod from ICMPv6 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
+### http://test-network-function.com/testcases/networking/icmpv6-connectivity-multus
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/networking/icmpv6-connectivity-multus checks that each CNF Container is able to communicate via ICMPv6 on the Multus network(s).  This test case requires the Deployment of the debug daemonset.
+Result Type|normative
+Suggested Remediation|Ensure that the CNF is able to communicate via the Multus network(s). In some rare cases, CNFs may require routing table changes in order to communicate over the Multus network(s). To exclude a particular pod from ICMPv6 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it.The label value is not important, only its presence. 
 Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
 ### http://test-network-function.com/testcases/networking/service-type
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ENV PATH=${PATH}:"/usr/local/go/bin":${GOPATH}/"bin"
 
 # Git identifier to checkout
 ARG TNF_VERSION
-ARG TNF_SRC_URL=https://github.com/test-network-function/cnf-certification-test
+ARG TNF_SRC_URL=$TNF_SRC_URL
 ARG GIT_CHECKOUT_TARGET=$TNF_VERSION
 
 # Git identifier to checkout for partner

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -130,6 +130,21 @@ var (
 		Url:     formTestURL(common.NetworkingTestKey, "icmpv4-connectivity"),
 		Version: versionOne,
 	}
+	// TestICMPv6ConnectivityIdentifier tests icmpv6 connectivity.
+	TestICMPv6ConnectivityIdentifier = claim.Identifier{
+		Url:     formTestURL(common.NetworkingTestKey, "icmpv6-connectivity"),
+		Version: versionOne,
+	}
+	// TestICMPv4ConnectivityIdentifier tests icmpv4 Multus connectivity.
+	TestICMPv4ConnectivityMultusIdentifier = claim.Identifier{
+		Url:     formTestURL(common.NetworkingTestKey, "icmpv4-connectivity-multus"),
+		Version: versionOne,
+	}
+	// TestICMPv6ConnectivityIdentifier tests icmpv6 Multus connectivity.
+	TestICMPv6ConnectivityMultusIdentifier = claim.Identifier{
+		Url:     formTestURL(common.NetworkingTestKey, "icmpv6-connectivity-multus"),
+		Version: versionOne,
+	}
 	// TestNamespaceBestPracticesIdentifier ensures the namespace has followed best namespace practices.
 	TestNamespaceBestPracticesIdentifier = claim.Identifier{
 		Url:     formTestURL(common.AccessControlTestKey, "namespace"),
@@ -408,15 +423,49 @@ they are the same.`),
 	TestICMPv4ConnectivityIdentifier: {
 		Identifier: TestICMPv4ConnectivityIdentifier,
 		Type:       normativeResult,
-		Remediation: `Ensure that the CNF is able to communicate via the Default OpenShift network.  In some rare cases,
-CNFs may require routing table changes in order to communicate over the Default network.  In other cases, if the
-Container base image does not provide the "ip" or "ping" binaries, this test may not be applicable.  For instructions on
-how to exclude a particular container from ICMPv4 connectivity tests, consult:
-[README.md](https://github.com/test-network-function/test-network-function#issue-161-some-containers-under-test-do-not-contain-ping-or-ip-binary-utilities).`,
+		Remediation: `Ensure that the CNF is able to communicate via the Default OpenShift network. In some rare cases,
+CNFs may require routing table changes in order to communicate over the Default network. To exclude a particular pod
+from ICMPv4 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.`,
 		Description: formDescription(TestICMPv4ConnectivityIdentifier,
 			`checks that each CNF Container is able to communicate via ICMPv4 on the Default OpenShift network.  This
-test case requires the Deployment of the debug daemonset.
-`),
+test case requires the Deployment of the debug daemonset.`),
+		BestPracticeReference: bestPracticeDocV1dot2URL + " Section 6.2",
+	},
+
+	TestICMPv6ConnectivityIdentifier: {
+		Identifier: TestICMPv6ConnectivityIdentifier,
+		Type:       normativeResult,
+		Remediation: `Ensure that the CNF is able to communicate via the Default OpenShift network. In some rare cases,
+CNFs may require routing table changes in order to communicate over the Default network. To exclude a particular pod
+from ICMPv6 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.`,
+		Description: formDescription(TestICMPv6ConnectivityIdentifier,
+			`checks that each CNF Container is able to communicate via ICMPv6 on the Default OpenShift network.  This
+test case requires the Deployment of the debug daemonset.`),
+		BestPracticeReference: bestPracticeDocV1dot2URL + " Section 6.2",
+	},
+
+	TestICMPv4ConnectivityMultusIdentifier: {
+		Identifier: TestICMPv4ConnectivityMultusIdentifier,
+		Type:       normativeResult,
+		Remediation: `Ensure that the CNF is able to communicate via the Multus network(s). In some rare cases,
+CNFs may require routing table changes in order to communicate over the Multus network(s). To exclude a particular pod
+from ICMPv4 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.`,
+		Description: formDescription(TestICMPv4ConnectivityMultusIdentifier,
+			`checks that each CNF Container is able to communicate via ICMPv4 on the Multus network(s).  This
+test case requires the Deployment of the debug daemonset.`),
+		BestPracticeReference: bestPracticeDocV1dot2URL + " Section 6.2",
+	},
+
+	TestICMPv6ConnectivityMultusIdentifier: {
+		Identifier: TestICMPv6ConnectivityMultusIdentifier,
+		Type:       normativeResult,
+		Remediation: `Ensure that the CNF is able to communicate via the Multus network(s). In some rare cases,
+CNFs may require routing table changes in order to communicate over the Multus network(s). To exclude a particular pod
+from ICMPv6 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it.The label value is not important, only its presence.
+`,
+		Description: formDescription(TestICMPv6ConnectivityMultusIdentifier,
+			`checks that each CNF Container is able to communicate via ICMPv6 on the Multus network(s).  This
+test case requires the Deployment of the debug daemonset.`),
 		BestPracticeReference: bestPracticeDocV1dot2URL + " Section 6.2",
 	},
 

--- a/cnf-certification-test/lifecycle/ownerreference/ownerreference.go
+++ b/cnf-certification-test/lifecycle/ownerreference/ownerreference.go
@@ -18,7 +18,7 @@ package ownerreference
 
 import (
 	"github.com/sirupsen/logrus"
-	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
+	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -37,7 +37,7 @@ type OwnerReference struct {
 func NewOwnerReference(put *v1.Pod) *OwnerReference {
 	o := OwnerReference{
 		put:    put,
-		result: tnf.ERROR,
+		result: testhelper.ERROR,
 	}
 	return &o
 }
@@ -48,10 +48,10 @@ func (o *OwnerReference) RunTest() {
 	for _, k := range o.put.OwnerReferences {
 		logrus.Traceln("kind is ", k.Kind)
 		if k.Kind == statefulSet || k.Kind == replicaSet {
-			o.result = tnf.SUCCESS
+			o.result = testhelper.SUCCESS
 		} else {
 			logrus.Error("Pod ", o.put.Name, " has owner of type ", k.Kind)
-			o.result = tnf.FAILURE
+			o.result = testhelper.FAILURE
 			return
 		}
 	}

--- a/cnf-certification-test/lifecycle/ownerreference/ownerreference_test.go
+++ b/cnf-certification-test/lifecycle/ownerreference/ownerreference_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/lifecycle/ownerreference"
-	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
+	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -32,19 +32,19 @@ func TestRunTest(t *testing.T) {
 	// test when pods owner reference is not specified
 	o := ownerreference.NewOwnerReference(&pod)
 	o.RunTest()
-	assert.Equal(t, tnf.ERROR, o.GetResults())
+	assert.Equal(t, testhelper.ERROR, o.GetResults())
 	// test when pods owner is not StatefulSet Or ReplicaSet
 	pod.OwnerReferences = append(pod.OwnerReferences, metav1.OwnerReference{Kind: "bad_kind"})
 	o.RunTest()
-	assert.Equal(t, tnf.FAILURE, o.GetResults())
+	assert.Equal(t, testhelper.FAILURE, o.GetResults())
 	// test when pods owner is StatefulSet Or ReplicaSet
 	pod.OwnerReferences = pod.OwnerReferences[1:]
 	pod.OwnerReferences = append(pod.OwnerReferences, metav1.OwnerReference{Kind: "StatefulSet"}, metav1.OwnerReference{Kind: "ReplicaSet"})
 	o.RunTest()
-	assert.Equal(t, tnf.SUCCESS, o.GetResults())
+	assert.Equal(t, testhelper.SUCCESS, o.GetResults())
 
 	// test when pods owner is StatefulSet And bad kind
 	pod.OwnerReferences = append(pod.OwnerReferences, metav1.OwnerReference{Kind: "bad_kind"})
 	o.RunTest()
-	assert.Equal(t, tnf.SUCCESS, o.GetResults())
+	assert.Equal(t, testhelper.SUCCESS, o.GetResults())
 }

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -24,6 +24,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/identifiers"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/lifecycle/ownerreference"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
+	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
 	v1 "k8s.io/api/core/v1"
 )
@@ -130,7 +131,7 @@ func testPodsOwnerReference(env *provider.TestEnvironment) {
 			logrus.Debugln("check pod ", put.Namespace, " ", put.Name, " owner reference")
 			o := ownerreference.NewOwnerReference(put)
 			o.RunTest()
-			if o.GetResults() != tnf.SUCCESS {
+			if o.GetResults() != testhelper.SUCCESS {
 				s := put.Namespace + ":" + put.Name
 				badPods = append(badPods, s)
 			}

--- a/cnf-certification-test/networking/icmp/icmp.go
+++ b/cnf-certification-test/networking/icmp/icmp.go
@@ -1,0 +1,181 @@
+// Copyright (C) 2020-2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package icmp
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/networking/netcommons"
+	"github.com/test-network-function/cnf-certification-test/internal/crclient"
+	"github.com/test-network-function/cnf-certification-test/pkg/loghelper"
+	"github.com/test-network-function/cnf-certification-test/pkg/provider"
+	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
+)
+
+const (
+	// ConnectInvalidArgumentRegex is a regex which matches when an invalid IP address or hostname is provided as input.
+	ConnectInvalidArgumentRegex = `(?m)connect: Invalid argument$`
+	// SuccessfulOutputRegex matches a successfully run "ping" command.  That does not mean that no errors or drops
+	// occurred during the test.
+	SuccessfulOutputRegex = `(?m)(\d+) packets transmitted, (\d+)( packets){0,1} received, (?:\+(\d+) errors)?.*$`
+)
+
+type PingResults struct {
+	outcome     int
+	transmitted int
+	received    int
+	errors      int
+}
+
+func (results PingResults) String() string {
+	return fmt.Sprintf("outcome: %s transmitted: %d received: %d errors: %d", testhelper.ResultToString(results.outcome), results.transmitted, results.received, results.errors)
+}
+
+// processContainerIpsPerNet takes a container ip addresses for a given network attachment's and uses it as a test target.
+// The first container in the loop is selected as the test initiator. the Oc context of the container is used to initiate the pings
+func ProcessContainerIpsPerNet(containerID *provider.Container,
+	netKey string,
+	ipAddresses []string,
+	netsUnderTest map[string]netcommons.NetTestContext,
+	aIPVersion netcommons.IPVersion) {
+	ipAddressesFiltered := netcommons.FilterIPListByIPVersion(ipAddresses, aIPVersion)
+	if len(ipAddressesFiltered) == 0 {
+		// if no multus addresses found, skip this container
+		logrus.Debugf("Skipping %s, Network %s because no multus IPs are present", containerID.StringShort(), netKey)
+		return
+	}
+	// Create an entry at "key" if it is not present
+	if _, ok := netsUnderTest[netKey]; !ok {
+		netsUnderTest[netKey] = netcommons.NetTestContext{}
+	}
+	// get a copy of the content
+	entry := netsUnderTest[netKey]
+	// Then modify the copy
+	firstIPIndex := 0
+	if entry.TesterSource.ContainerIdentifier == nil {
+		logrus.Debugf("%s selected to initiate ping tests", containerID.StringShort())
+		entry.TesterSource.ContainerIdentifier = containerID
+		// if multiple interfaces are present for this network on this container/pod, pick the first one as the tester source ip
+		entry.TesterSource.IP = ipAddressesFiltered[firstIPIndex]
+		// do no include tester's IP in the list of destination IPs to ping
+		firstIPIndex++
+	}
+
+	for _, aIP := range ipAddressesFiltered[firstIPIndex:] {
+		ipDestEntry := netcommons.ContainerIP{}
+		ipDestEntry.ContainerIdentifier = containerID
+		ipDestEntry.IP = aIP
+		entry.DestTargets = append(entry.DestTargets, ipDestEntry)
+	}
+
+	// Then reassign map entry
+	netsUnderTest[netKey] = entry
+}
+
+// runNetworkingTests takes a map netcommons.NetTestContext, e.g. one context per network attachment
+// and runs pings test with it. Returns a network name to a slice of bad target IPs map.
+func RunNetworkingTests(env *provider.TestEnvironment,
+	netsUnderTest map[string]netcommons.NetTestContext,
+	count int,
+	aIPVersion netcommons.IPVersion) (badNets map[string][]string, claimsLog loghelper.CuratedLogLines) {
+	logrus.Debugf("%s", netcommons.PrintNetTestContextMap(netsUnderTest))
+	if len(netsUnderTest) == 0 {
+		logrus.Debugf("There are no %s networks to test, skipping test", aIPVersion)
+		return badNets, claimsLog
+	}
+	// maps a net name to a list of failed destination IPs
+	badNets = map[string][]string{}
+	// if no network can be tested, then we need to skip the test entirely.
+	// If at least one network can be tested (e.g. > 2 IPs/ interfaces present), then we do not skip the test
+	atLeastOneNetworkTested := false
+	for netName, netUnderTest := range netsUnderTest {
+		if len(netUnderTest.DestTargets) == 0 {
+			logrus.Debugf("There are no containers to ping for %s network %s. A minimum of 2 containers is needed to run a ping test (a source and a destination) Skipping test", aIPVersion, netName)
+			continue
+		}
+		atLeastOneNetworkTested = true
+		logrus.Debugf("%s Ping tests on network %s. Number of target IPs: %d", aIPVersion, netName, len(netUnderTest.DestTargets))
+		for _, aDestIP := range netUnderTest.DestTargets {
+			logrus.Debugf("%s ping test on network %s from ( %s  srcip: %s ) to ( %s dstip: %s )",
+				aIPVersion, netName,
+				netUnderTest.TesterSource.ContainerIdentifier.StringShort(), netUnderTest.TesterSource.IP,
+				aDestIP.ContainerIdentifier.StringShort(), aDestIP.IP)
+			result, err := testPing(env, netUnderTest.TesterSource.ContainerIdentifier, aDestIP, count)
+			logrus.Debugf("Ping results: %s", result.String())
+			claimsLog = claimsLog.AddLogLine("%s ping test on network %s from ( %s  srcip: %s ) to ( %s dstip: %s ) result: %s",
+				aIPVersion, netName,
+				netUnderTest.TesterSource.ContainerIdentifier.StringShort(), netUnderTest.TesterSource.IP,
+				aDestIP.ContainerIdentifier.StringShort(), aDestIP.IP, result.String())
+			if err != nil {
+				logrus.Debugf("Ping failed with err:%s", err)
+			}
+			if result.outcome != testhelper.SUCCESS {
+				if failedDestIps, netFound := badNets[netName]; netFound {
+					badNets[netName] = append(failedDestIps, aDestIP.IP)
+				} else {
+					badNets[netName] = []string{aDestIP.IP}
+				}
+			}
+		}
+	}
+	if !atLeastOneNetworkTested {
+		logrus.Debugf("There are no network to test for any %s networks, skipping test", aIPVersion)
+	}
+	return badNets, claimsLog
+}
+
+// testPing Initiates a ping test between a source container and network (1 ip) and a destination container and network (1 ip)
+func testPing(env *provider.TestEnvironment, sourceContainerID *provider.Container, targetContainerIP netcommons.ContainerIP, count int) (results PingResults, err error) { //nolint:funlen
+	command := fmt.Sprintf("ping -c %d %s", count, targetContainerIP.IP)
+	stdout, stderr, err := crclient.ExecCommandContainerNSEnter(command, sourceContainerID, env)
+	if err != nil || stderr != "" {
+		results.outcome = testhelper.ERROR
+		return results, errors.Errorf("Ping failed with stderr:%s err:%s", stderr, err)
+	}
+	re := regexp.MustCompile(ConnectInvalidArgumentRegex)
+	matched := re.FindStringSubmatch(stdout)
+	// If we find a error log we fail
+	if matched != nil {
+		results.outcome = testhelper.ERROR
+		return results, errors.Errorf("Ping failed with invalid arguments, stdout: %s, stderr: %s", stdout, stderr)
+	}
+	re = regexp.MustCompile(SuccessfulOutputRegex)
+	matched = re.FindStringSubmatch(stdout)
+	// If we do not find a successful log, we fail
+	if matched == nil {
+		results.outcome = testhelper.FAILURE
+		return results, errors.Errorf("Ping output did not match successful regex, stdout: %s, stderr: %s", stdout, stderr)
+	}
+	// Ignore errors in converting matches to decimal integers.
+	// Regular expression `stat` is required to underwrite this assumption.
+	results.transmitted, _ = strconv.Atoi(matched[1])
+	results.received, _ = strconv.Atoi(matched[2])
+	results.errors, _ = strconv.Atoi(matched[4])
+	switch {
+	case results.transmitted == 0 || results.errors > 0:
+		results.outcome = testhelper.ERROR
+	case results.received > 0 && (results.transmitted-results.received) <= 1:
+		results.outcome = testhelper.SUCCESS
+	default:
+		results.outcome = testhelper.FAILURE
+	}
+	return results, nil
+}

--- a/cnf-certification-test/networking/icmp/icmp.go
+++ b/cnf-certification-test/networking/icmp/icmp.go
@@ -143,13 +143,18 @@ func RunNetworkingTests(env *provider.TestEnvironment,
 }
 
 // testPing Initiates a ping test between a source container and network (1 ip) and a destination container and network (1 ip)
-func testPing(env *provider.TestEnvironment, sourceContainerID *provider.Container, targetContainerIP netcommons.ContainerIP, count int) (results PingResults, err error) { //nolint:funlen
+func testPing(env *provider.TestEnvironment, sourceContainerID *provider.Container, targetContainerIP netcommons.ContainerIP, count int) (results PingResults, err error) {
 	command := fmt.Sprintf("ping -c %d %s", count, targetContainerIP.IP)
 	stdout, stderr, err := crclient.ExecCommandContainerNSEnter(command, sourceContainerID, env)
 	if err != nil || stderr != "" {
 		results.outcome = testhelper.ERROR
 		return results, errors.Errorf("Ping failed with stderr:%s err:%s", stderr, err)
 	}
+	results, err = parsePingResult(stdout, stderr)
+	return results, err
+}
+
+func parsePingResult(stdout, stderr string) (results PingResults, err error) {
 	re := regexp.MustCompile(ConnectInvalidArgumentRegex)
 	matched := re.FindStringSubmatch(stdout)
 	// If we find a error log we fail

--- a/cnf-certification-test/networking/icmp/icmp_test.go
+++ b/cnf-certification-test/networking/icmp/icmp_test.go
@@ -1,0 +1,81 @@
+// Copyright (C) 2020-2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package icmp
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
+)
+
+func Test_parsePingResult(t *testing.T) { //nolint:funlen
+	type args struct {
+		stdout string
+		stderr string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantResults PingResults
+		wantErr     bool
+	}{
+		{
+			name: "pingOk",
+			args: args{stdout: `PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
+		 64 bytes from 8.8.8.8: icmp_seq=1 ttl=57 time=36.1 ms
+		 64 bytes from 8.8.8.8: icmp_seq=2 ttl=57 time=32.6 ms
+		 64 bytes from 8.8.8.8: icmp_seq=3 ttl=57 time=35.9 ms
+		 64 bytes from 8.8.8.8: icmp_seq=4 ttl=57 time=38.2 ms
+		 64 bytes from 8.8.8.8: icmp_seq=5 ttl=57 time=36.0 ms
+		 
+		 --- 8.8.8.8 ping statistics ---
+		 5 packets transmitted, 5 received, 0% packet loss, time 4005ms
+		 rtt min/avg/max/mdev = 32.593/35.761/38.212/1.802 ms`, stderr: ""},
+			wantResults: PingResults{outcome: testhelper.SUCCESS, transmitted: 5, received: 5, errors: 0},
+			wantErr:     false,
+		},
+		{
+			name: "pingOk",
+			args: args{stdout: `PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
+		 64 bytes from 8.8.8.8: icmp_seq=1 ttl=57 time=36.1 ms
+		 64 bytes from 8.8.8.8: icmp_seq=2 ttl=57 time=32.6 ms
+		 64 bytes from 8.8.8.8: icmp_seq=3 ttl=57 time=35.9 ms
+		 64 bytes from 8.8.8.8: icmp_seq=4 ttl=57 time=38.2 ms
+
+		 
+		 --- 8.8.8.8 ping statistics ---
+		 5 packets transmitted, 4 received, 0% packet loss, time 4005ms
+		 rtt min/avg/max/mdev = 32.593/35.761/38.212/1.802 ms`, stderr: ""},
+			wantResults: PingResults{outcome: testhelper.SUCCESS, transmitted: 5, received: 4, errors: 0},
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotResults, err := parsePingResult(tt.args.stdout, tt.args.stderr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parsePingResult() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotResults, tt.wantResults) {
+				t.Errorf("parsePingResult() = %v, want %v", gotResults, tt.wantResults)
+			}
+		})
+	}
+}

--- a/cnf-certification-test/networking/icmp/icmp_test.go
+++ b/cnf-certification-test/networking/icmp/icmp_test.go
@@ -50,18 +50,100 @@ func Test_parsePingResult(t *testing.T) { //nolint:funlen
 			wantErr:     false,
 		},
 		{
-			name: "pingOk",
-			args: args{stdout: `PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
-		 64 bytes from 8.8.8.8: icmp_seq=1 ttl=57 time=36.1 ms
-		 64 bytes from 8.8.8.8: icmp_seq=2 ttl=57 time=32.6 ms
-		 64 bytes from 8.8.8.8: icmp_seq=3 ttl=57 time=35.9 ms
-		 64 bytes from 8.8.8.8: icmp_seq=4 ttl=57 time=38.2 ms
-
-		 
-		 --- 8.8.8.8 ping statistics ---
-		 5 packets transmitted, 4 received, 0% packet loss, time 4005ms
-		 rtt min/avg/max/mdev = 32.593/35.761/38.212/1.802 ms`, stderr: ""},
-			wantResults: PingResults{outcome: testhelper.SUCCESS, transmitted: 5, received: 4, errors: 0},
+			name: "pingErrorPacket",
+			args: args{stdout: `PING 192.168.1.1 (192.168.1.1) 56(84) bytes of data.
+			64 bytes from 192.168.1.1: icmp_seq=1 ttl=61 time=1.79 ms
+			64 bytes from 192.168.1.1: icmp_seq=2 ttl=61 time=3.37 ms
+			64 bytes from 192.168.1.1: icmp_seq=3 ttl=61 time=2.14 ms
+			64 bytes from 192.168.1.1: icmp_seq=4 ttl=61 time=3.62 ms
+			From 10.0.2.2 icmp_seq=5 Destination Net Unreachable
+			From 10.0.2.2 icmp_seq=6 Destination Net Unreachable
+			From 10.0.2.2 icmp_seq=7 Destination Net Unreachable
+			From 10.0.2.2 icmp_seq=8 Destination Net Unreachable
+			64 bytes from 192.168.1.1: icmp_seq=9 ttl=61 time=297 ms
+			64 bytes from 192.168.1.1: icmp_seq=10 ttl=61 time=258 ms
+			64 bytes from 192.168.1.1: icmp_seq=11 ttl=61 time=276 ms
+			64 bytes from 192.168.1.1: icmp_seq=12 ttl=61 time=1.58 ms
+			64 bytes from 192.168.1.1: icmp_seq=13 ttl=61 time=445 ms
+			64 bytes from 192.168.1.1: icmp_seq=14 ttl=61 time=3.57 ms
+			64 bytes from 192.168.1.1: icmp_seq=15 ttl=61 time=60.5 ms
+			64 bytes from 192.168.1.1: icmp_seq=16 ttl=61 time=585 ms
+			64 bytes from 192.168.1.1: icmp_seq=17 ttl=61 time=155 ms
+			64 bytes from 192.168.1.1: icmp_seq=18 ttl=61 time=20.4 ms
+			64 bytes from 192.168.1.1: icmp_seq=19 ttl=61 time=26.7 ms
+			64 bytes from 192.168.1.1: icmp_seq=20 ttl=61 time=2.14 ms
+			
+			--- 192.168.1.1 ping statistics ---
+			20 packets transmitted, 16 received, +4 errors, 20% packet loss, time 19118ms
+			rtt min/avg/max/mdev = 1.582/134.079/585.861/179.394 ms`, stderr: ""},
+			wantResults: PingResults{outcome: testhelper.ERROR, transmitted: 20, received: 16, errors: 4},
+			wantErr:     false,
+		},
+		{
+			name: "pingIncorrectIp",
+			args: args{stdout: `connect: Invalid argument
+			command terminated with exit code 2`, stderr: ""},
+			wantResults: PingResults{outcome: testhelper.ERROR, transmitted: 0, received: 0, errors: 0},
+			wantErr:     true,
+		},
+		{
+			name: "pingPassingPacketLoss",
+			args: args{stdout: `PING 192.168.1.5 (192.168.1.5) 56(84) bytes of data.
+			64 bytes from 192.168.1.5: icmp_seq=1 ttl=61 time=14.8 ms
+			64 bytes from 192.168.1.5: icmp_seq=2 ttl=61 time=11.2 ms
+			64 bytes from 192.168.1.5: icmp_seq=3 ttl=61 time=10.9 ms
+			64 bytes from 192.168.1.5: icmp_seq=5 ttl=61 time=9.68 ms
+			64 bytes from 192.168.1.5: icmp_seq=6 ttl=61 time=4.55 ms
+			64 bytes from 192.168.1.5: icmp_seq=7 ttl=61 time=3.38 ms
+			64 bytes from 192.168.1.5: icmp_seq=8 ttl=61 time=3.67 ms
+			64 bytes from 192.168.1.5: icmp_seq=9 ttl=61 time=3.77 ms
+			64 bytes from 192.168.1.5: icmp_seq=10 ttl=61 time=3.77 ms
+			64 bytes from 192.168.1.5: icmp_seq=11 ttl=61 time=3.77 ms
+			64 bytes from 192.168.1.5: icmp_seq=12 ttl=61 time=3.77 ms
+			64 bytes from 192.168.1.5: icmp_seq=13 ttl=61 time=3.77 ms
+			64 bytes from 192.168.1.5: icmp_seq=14 ttl=61 time=3.77 ms
+			64 bytes from 192.168.1.5: icmp_seq=15 ttl=61 time=3.77 ms
+			64 bytes from 192.168.1.5: icmp_seq=16 ttl=61 time=3.77 ms
+			64 bytes from 192.168.1.5: icmp_seq=17 ttl=61 time=3.77 ms
+			64 bytes from 192.168.1.5: icmp_seq=18 ttl=61 time=3.77 ms
+			64 bytes from 192.168.1.5: icmp_seq=19 ttl=61 time=3.77 ms
+			
+			--- 192.168.1.5 ping statistics ---
+			20 packets transmitted, 19 received, 5% packet loss, time 19297ms
+			rtt min/avg/max/mdev = 3.381/7.772/14.867/4.167 ms`, stderr: ""},
+			wantResults: PingResults{outcome: testhelper.SUCCESS, transmitted: 20, received: 19, errors: 0},
+			wantErr:     false,
+		},
+		{
+			name: "pingFailingPacketLoss",
+			args: args{stdout: `
+			PING 192.168.1.2 (192.168.1.2) 56(84) bytes of data.
+			
+			--- 192.168.1.2 ping statistics ---
+			1 packets transmitted, 0 received, 100% packet loss, time 0ms
+			
+			command terminated with exit code 1`, stderr: ""},
+			wantResults: PingResults{outcome: testhelper.FAILURE, transmitted: 1, received: 0, errors: 0},
+			wantErr:     false,
+		},
+		{
+			name: "pingHostnameNoPacketLoss",
+			args: args{stdout: `PING www.google.com (172.217.12.132) 56(84) bytes of data.
+			64 bytes from lga34s19-in-f4.1e100.net (172.217.12.132): icmp_seq=1 ttl=61 time=25.4 ms
+			64 bytes from lga34s19-in-f4.1e100.net (172.217.12.132): icmp_seq=2 ttl=61 time=27.1 ms
+			64 bytes from lga34s19-in-f4.1e100.net (172.217.12.132): icmp_seq=3 ttl=61 time=26.7 ms
+			64 bytes from lga34s19-in-f4.1e100.net (172.217.12.132): icmp_seq=4 ttl=61 time=24.2 ms
+			64 bytes from lga34s19-in-f4.1e100.net (172.217.12.132): icmp_seq=5 ttl=61 time=28.0 ms
+			64 bytes from lga34s19-in-f4.1e100.net (172.217.12.132): icmp_seq=6 ttl=61 time=37.0 ms
+			64 bytes from lga34s19-in-f4.1e100.net (172.217.12.132): icmp_seq=7 ttl=61 time=21.6 ms
+			64 bytes from lga34s19-in-f4.1e100.net (172.217.12.132): icmp_seq=8 ttl=61 time=30.6 ms
+			64 bytes from lga34s19-in-f4.1e100.net (172.217.12.132): icmp_seq=9 ttl=61 time=27.3 ms
+			64 bytes from lga34s19-in-f4.1e100.net (172.217.12.132): icmp_seq=10 ttl=61 time=27.9 ms
+			
+			--- www.google.com ping statistics ---
+			10 packets transmitted, 10 received, 0% packet loss, time 9014ms
+			rtt min/avg/max/mdev = 21.650/27.619/37.003/3.885 ms`, stderr: ""},
+			wantResults: PingResults{outcome: testhelper.SUCCESS, transmitted: 10, received: 10, errors: 0},
 			wantErr:     false,
 		},
 	}

--- a/cnf-certification-test/networking/netcommons/netcommons.go
+++ b/cnf-certification-test/networking/netcommons/netcommons.go
@@ -1,0 +1,118 @@
+// Copyright (C) 2020-2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package netcommons
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/test-network-function/cnf-certification-test/pkg/provider"
+	v1 "k8s.io/api/core/v1"
+)
+
+type IPVersion string
+
+const (
+	IPv4 IPVersion = "IPv4"
+	IPv6 IPVersion = "IPv6"
+)
+
+// netTestContext this is a data structure describing a network test context for a given subnet (e.g. network attachment)
+// The test context defines a tester or test initiator, that is initiating the pings. It is selected randomly (first container in the list)
+// It also defines a list of destination ping targets corresponding to the other containers IPs on this subnet
+type NetTestContext struct {
+	// testerContainerNodeOc session context to access the node running the container selected to initiate tests
+	TesterContainerNodeName string
+	// testerSource is the container select to initiate the ping tests on this given network
+	TesterSource ContainerIP
+	// ipDestTargets List of containers to be pinged by the testerSource on this given network
+	DestTargets []ContainerIP
+}
+
+// containerIP holds a container identification and its IP for networking tests.
+type ContainerIP struct {
+	// ip address of the target container
+	IP string
+	// targetContainerIdentifier container identifier including namespace, pod name, container name, node name, and container UID
+	ContainerIdentifier *provider.Container
+}
+
+// String displays the NetTestContext data structure
+func (testContext NetTestContext) String() string {
+	output := fmt.Sprintf("From initiating container: %s\n", testContext.TesterSource.String())
+	if len(testContext.DestTargets) == 0 {
+		output = "--> No target containers to test for this network" //nolint:goconst // this is only one time
+	}
+	for _, target := range testContext.DestTargets {
+		output += fmt.Sprintf("--> To target container: %s\n", target.String())
+	}
+	return output
+}
+
+// String Displays the ContainerIP data structure
+func (cip *ContainerIP) String() string {
+	return fmt.Sprintf("%s ( %s )",
+		cip.IP,
+		cip.ContainerIdentifier.String(),
+	)
+}
+
+// PrintNetTestContextMap displays the NetTestContext full map
+func PrintNetTestContextMap(netsUnderTest map[string]NetTestContext) string {
+	var output string
+	if len(netsUnderTest) == 0 {
+		output = "No networks to test.\n" //nolint:goconst // this is only one time
+	}
+	for netName, netUnderTest := range netsUnderTest {
+		output += fmt.Sprintf("***Test for Network attachment: %s\n", netName)
+		output += fmt.Sprintf("%s\n", netUnderTest.String())
+	}
+	return output
+}
+
+// PodIPsToStringList converts a list of v1.PodIP objects into a list of strings
+func PodIPsToStringList(ips []v1.PodIP) (ipList []string) {
+	for _, ip := range ips {
+		ipList = append(ipList, ip.IP)
+	}
+	return ipList
+}
+
+// GetIPVersion parses a ip address from a string and returns its version
+func GetIPVersion(aIP string) (IPVersion, error) {
+	ip := net.ParseIP(aIP)
+	if ip == nil {
+		return "", fmt.Errorf("%s is Not an IPv4 or an IPv6", aIP)
+	}
+	if ip.To4() != nil {
+		return IPv4, nil
+	}
+	return IPv6, nil
+}
+
+// FilterIPListByIPVersion filters a list of ip strings by the provided version
+// e.g. a list of mixed ipv4 and ipv6 when filtered with ipv6 version will return a list with
+// the ipv6 addresses
+func FilterIPListByIPVersion(ipList []string, aIPVersion IPVersion) []string {
+	var filteredIPList []string
+	for _, aIP := range ipList {
+		if ver, _ := GetIPVersion(aIP); aIPVersion == ver {
+			filteredIPList = append(filteredIPList, aIP)
+		}
+	}
+	return filteredIPList
+}

--- a/cnf-certification-test/networking/netcommons/netcommons_test.go
+++ b/cnf-certification-test/networking/netcommons/netcommons_test.go
@@ -16,7 +16,10 @@
 
 package netcommons
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func Test_getIPVersion(t *testing.T) {
 	type args struct {
@@ -59,6 +62,36 @@ func Test_getIPVersion(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("getIPVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterIPListByIPVersion(t *testing.T) {
+	type args struct {
+		ipList     []string
+		aIPVersion IPVersion
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "okIpv4",
+			args: args{ipList: []string{"1.1.1.1", "2.2.2.2", "fd00:10:244:1::3"}, aIPVersion: IPv4},
+			want: []string{"1.1.1.1", "2.2.2.2"},
+		},
+		{
+			name: "okIpv6",
+			args: args{ipList: []string{"1.1.1.1", "2.2.2.2", "fd00:10:244:1::3"}, aIPVersion: IPv6},
+			want: []string{"fd00:10:244:1::3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FilterIPListByIPVersion(tt.args.ipList, tt.args.aIPVersion); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FilterIPListByIPVersion() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cnf-certification-test/networking/netcommons/netcommons_test.go
+++ b/cnf-certification-test/networking/netcommons/netcommons_test.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2020-2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package netcommons
+
+import "testing"
+
+func Test_getIPVersion(t *testing.T) {
+	type args struct {
+		aIP string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    IPVersion
+		wantErr bool
+	}{
+		{name: "GoodIPv4",
+			args:    args{aIP: "2.2.2.2"},
+			want:    IPv4,
+			wantErr: false,
+		},
+		{name: "GoodIPv6",
+			args:    args{aIP: "fd00:10:244:1::3"},
+			want:    IPv6,
+			wantErr: false,
+		},
+		{name: "BadIPv4",
+			args:    args{aIP: "2.hfh.2.2"},
+			want:    "",
+			wantErr: true,
+		},
+		{name: "BadIPv6",
+			args:    args{aIP: "fd00:10:ono;ogmo:1::3"},
+			want:    "",
+			wantErr: true,
+		},
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetIPVersion(tt.args.aIP)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getIPVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getIPVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -18,14 +18,110 @@ package networking
 
 import (
 	"github.com/sirupsen/logrus"
-	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/common"
+	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/networking/netcommons"
 
 	"github.com/onsi/ginkgo/v2"
+
+	"fmt"
+
+	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/common"
+	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/identifiers"
+	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/networking/icmp"
+	"github.com/test-network-function/cnf-certification-test/pkg/provider"
+	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
+)
+
+const (
+	defaultNumPings = 5
 )
 
 //
 // All actual test code belongs below here.  Utilities belong above.
 //
 var _ = ginkgo.Describe(common.NetworkingTestKey, func() {
-	logrus.Debugf("%s not moved yet to new framework", common.NetworkingTestKey)
+	logrus.Debugf("Entering %s suite", common.NetworkingTestKey)
+
+	var env provider.TestEnvironment
+	ginkgo.BeforeEach(func() {
+		provider.BuildTestEnvironment()
+		env = provider.GetTestEnvironment()
+		provider.WaitDebugPodReady()
+	})
+
+	// Default interface ICMP IPv4 test case
+	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestICMPv4ConnectivityIdentifier)
+	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testDefaultNetworkConnectivity(&env, defaultNumPings, netcommons.IPv4)
+	})
+	// Multus interfaces ICMP IPv4 test case
+	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestICMPv4ConnectivityMultusIdentifier)
+	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testMultusNetworkConnectivity(&env, defaultNumPings, netcommons.IPv4)
+	})
+	// Default interface ICMP IPv6 test case
+	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestICMPv6ConnectivityIdentifier)
+	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testDefaultNetworkConnectivity(&env, defaultNumPings, netcommons.IPv6)
+	})
+	// Multus interfaces ICMP IPv6 test case
+	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestICMPv6ConnectivityMultusIdentifier)
+	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testMultusNetworkConnectivity(&env, defaultNumPings, netcommons.IPv6)
+	})
 })
+
+// testDefaultNetworkConnectivity test the connectivity between the default interfaces of containers under test
+func testDefaultNetworkConnectivity(env *provider.TestEnvironment, count int, aIPVersion netcommons.IPVersion) {
+	netsUnderTest := make(map[string]netcommons.NetTestContext)
+	for _, put := range env.Pods {
+		// The first container is used to get the network namespace
+		aContainerInPod := &put.Spec.Containers[0]
+		if _, ok := env.SkipNetTests[put]; ok {
+			tnf.ClaimFilePrintf("Skipping pod %s because it is excluded from all connectivity tests", put.Name)
+			continue
+		}
+		netKey := "default" //nolint:goconst // only used once
+		defaultIPAddress := put.Status.PodIPs
+
+		icmp.ProcessContainerIpsPerNet(env.ContainersMap[aContainerInPod], netKey, netcommons.PodIPsToStringList(defaultIPAddress), netsUnderTest, aIPVersion)
+	}
+	badNets, claimsLog := icmp.RunNetworkingTests(env, netsUnderTest, count, aIPVersion)
+
+	// Saving all curated logs to claims file
+	tnf.ClaimFilePrintf("%s", claimsLog)
+
+	if n := len(badNets); n > 0 {
+		logrus.Debugf("Failed nets: %+v", badNets)
+		ginkgo.Fail(fmt.Sprintf("%d nets failed the default network %s ping test.", n, aIPVersion))
+	}
+}
+
+// testMultusNetworkConnectivity tests the connectivity between the multus interfaces of the containers under test
+func testMultusNetworkConnectivity(env *provider.TestEnvironment, count int, aIPVersion netcommons.IPVersion) {
+	netsUnderTest := make(map[string]netcommons.NetTestContext)
+	for _, put := range env.Pods {
+		// The first container is used to get the network namespace
+		aContainerInPod := &put.Spec.Containers[0]
+
+		if _, ok := env.SkipNetTests[put]; ok {
+			tnf.ClaimFilePrintf("Skipping pod %s because it is excluded from all connectivity tests", put.Name)
+			continue
+		}
+		if _, ok := env.SkipMultusNetTests[put]; ok {
+			tnf.ClaimFilePrintf("Skipping pod %s because it is excluded from multus connectivity tests only", put.Name)
+			continue
+		}
+		for netKey, multusIPAddress := range env.MultusIPs[put] {
+			icmp.ProcessContainerIpsPerNet(env.ContainersMap[aContainerInPod], netKey, multusIPAddress, netsUnderTest, aIPVersion)
+		}
+	}
+	badNets, claimsLog := icmp.RunNetworkingTests(env, netsUnderTest, count, aIPVersion)
+
+	// Saving all curated logs to claims file
+	tnf.ClaimFilePrintf("%s", claimsLog)
+
+	if n := len(badNets); n > 0 {
+		logrus.Debugf("Failed nets: %+v", badNets)
+		ginkgo.Fail(fmt.Sprintf("%d nets failed the multus %s ping test.", n, aIPVersion))
+	}
+}

--- a/cnf-certification-test/platform/cnffsdiff/fsdiff.go
+++ b/cnf-certification-test/platform/cnffsdiff/fsdiff.go
@@ -23,7 +23,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
-	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
+	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
 )
 
 const (
@@ -53,7 +53,7 @@ func NewFsDiff(c *provider.Container) (*FsDiff, error) {
 	return &FsDiff{
 		containerID: uid,
 		command:     command,
-		result:      tnf.ERROR,
+		result:      testhelper.ERROR,
 	}, nil
 }
 
@@ -62,11 +62,11 @@ func (f *FsDiff) RunTest(o clientsholder.Command, ctx clientsholder.Context) {
 	output, outerr, err := o.ExecCommandContainer(ctx, f.command)
 	if err != nil {
 		logrus.Errorln("can't execute command on container ", err)
-		f.result = tnf.ERROR
+		f.result = testhelper.ERROR
 		return
 	}
 	if outerr != "" {
-		f.result = tnf.ERROR
+		f.result = testhelper.ERROR
 		logrus.Errorln("error when running fsdiff test ", outerr)
 		return
 	}
@@ -76,13 +76,13 @@ func (f *FsDiff) RunTest(o clientsholder.Command, ctx clientsholder.Context) {
 		r := regexp.MustCompile(exp)
 		if r.MatchString(output) {
 			logrus.Error("an installed package found on ", exp)
-			f.result = tnf.FAILURE
+			f.result = testhelper.FAILURE
 			return
 		}
 	}
 	// see if there's a match in the output
 	logrus.Traceln("the output is ", output)
-	f.result = tnf.SUCCESS
+	f.result = testhelper.SUCCESS
 }
 
 func (f *FsDiff) GetResults() int {

--- a/cnf-certification-test/platform/cnffsdiff/fsdiff_test.go
+++ b/cnf-certification-test/platform/cnffsdiff/fsdiff_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	. "github.com/test-network-function/cnf-certification-test/cnf-certification-test/platform/cnffsdiff"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
-	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
+	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
 )
 
 type ClientHoldersMock struct {
@@ -45,18 +45,18 @@ func TestRunTest(t *testing.T) {
 	}
 	// test when no package is installed
 	fsdiff.RunTest(o, clientsholder.Context{})
-	assert.Equal(t, tnf.SUCCESS, fsdiff.GetResults())
+	assert.Equal(t, testhelper.SUCCESS, fsdiff.GetResults())
 
 	// test when an error occurred when running the command
 	o.err = errors.New("error executing the command")
 	fsdiff.RunTest(&o, clientsholder.Context{})
-	assert.Equal(t, tnf.ERROR, fsdiff.GetResults())
+	assert.Equal(t, testhelper.ERROR, fsdiff.GetResults())
 
 	// test when an error message was returned
 	o.err = nil
 	o.stderr = "container id not found"
 	fsdiff.RunTest(&o, clientsholder.Context{})
-	assert.Equal(t, tnf.ERROR, fsdiff.GetResults())
+	assert.Equal(t, testhelper.ERROR, fsdiff.GetResults())
 
 	// test when a package was installed
 	o.err = nil
@@ -73,5 +73,5 @@ func TestRunTest(t *testing.T) {
 	}`
 	// "/usr/local/bin/docker-entrypoint.sh"
 	fsdiff.RunTest(&o, clientsholder.Context{})
-	assert.Equal(t, tnf.FAILURE, fsdiff.GetResults())
+	assert.Equal(t, testhelper.FAILURE, fsdiff.GetResults())
 }

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 	clientsholder "github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
+	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
 
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/common"
@@ -80,11 +81,11 @@ func testContainersFsDiff(env *provider.TestEnvironment) {
 		fsdiff.RunTest(clientsholder.NewClientsHolder(), clientsholder.Context{Namespace: debugPod.Namespace,
 			Podname: debugPod.Name, Containername: debugPod.Spec.Containers[0].Name})
 		switch fsdiff.GetResults() {
-		case tnf.SUCCESS:
+		case testhelper.SUCCESS:
 			continue
-		case tnf.FAILURE:
+		case testhelper.FAILURE:
 			badContainers = append(badContainers, cut.Data.Name)
-		case tnf.ERROR:
+		case testhelper.ERROR:
 			errContainers = append(errContainers, cut.Data.Name)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
 	github.com/operator-framework/api v0.13.0
 	github.com/operator-framework/operator-lifecycle-manager v0.20.0
+	github.com/pkg/errors v0.9.1
 	k8s.io/api v0.23.4
 	k8s.io/apimachinery v0.23.4
 )

--- a/go.sum
+++ b/go.sum
@@ -897,6 +897,7 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=

--- a/internal/crclient/crclient.go
+++ b/internal/crclient/crclient.go
@@ -1,0 +1,62 @@
+// Copyright (C) 2020-2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package crclient
+
+import (
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
+	"github.com/test-network-function/cnf-certification-test/pkg/provider"
+)
+
+// ExecCommandContainerNSEnter executes a command in the specified container namespace using nsenter
+func ExecCommandContainerNSEnter(command string,
+	aContainer *provider.Container,
+	env *provider.TestEnvironment) (outStr, errStr string, err error) {
+	// Getting the debug pod corresponding to the container's node
+	debugPod := env.DebugPods[aContainer.NodeName]
+	if debugPod == nil {
+		err = errors.Errorf("debug pod not found on Node: %s trying to run command: \" %s \" Namespace: %s Pod: %s container %s err:%s", aContainer.NodeName, command, aContainer.Namespace, aContainer.Podname, aContainer.Data.Name, err)
+		return "", "", err
+	}
+	o := clientsholder.NewClientsHolder()
+	ctx := clientsholder.Context{Namespace: debugPod.Namespace, Podname: debugPod.Name, Containername: debugPod.Spec.Containers[0].Name}
+
+	// Starting to build nsenter command based on the container runtime: getting the container PID
+	var nsenterCommand string
+	switch aContainer.Runtime {
+	case "docker": //nolint:goconst // used only once
+		nsenterCommand = "PID=`chroot /host docker inspect -f '{{.State.Pid}}' " + aContainer.UID + " 2>/dev/null`"
+	case "docker-pullable": //nolint:goconst // used only once
+		nsenterCommand = "PID=`chroot /host docker inspect -f '{{.State.Pid}}' " + aContainer.UID + " 2>/dev/null`"
+	case "cri-o", "containerd": //nolint:goconst // used only once
+		nsenterCommand = "PID=`chroot /host crictl inspect --output go-template --template '{{.info.pid}}' " + aContainer.UID + " 2>/dev/null`"
+	default:
+		logrus.Debugf("Container runtime %s not supported yet for this test, skipping", aContainer.Runtime)
+		return "", "", errors.Errorf("Container runtime not supported")
+	}
+
+	// Adding the nsenter command with the container PID
+	nsenterCommand = nsenterCommand + ";nsenter -t $PID -n " + command
+
+	// Run the nsenter command on on the debug pod
+	outStr, errStr, err = o.ExecCommandContainer(ctx, nsenterCommand)
+	if err != nil {
+		return "", "", errors.Errorf("can't execute command: \" %s \"  on %s err:%s", command, aContainer.StringShort(), err)
+	}
+	return outStr, errStr, err
+}

--- a/pkg/loghelper/loghelper.go
+++ b/pkg/loghelper/loghelper.go
@@ -1,0 +1,36 @@
+// Copyright (C) 2020-2021 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package loghelper
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+// CuratedLogLines
+type CuratedLogLines struct {
+	lines []string
+}
+
+// AddLogLine checks a slice for a given string.
+func (list CuratedLogLines) AddLogLine(format string, args ...interface{}) CuratedLogLines {
+	message := fmt.Sprintf(format+"\n", args...)
+	list.lines = append(list.lines, message)
+	logrus.Debug(message)
+	return list
+}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -97,6 +98,7 @@ func TestGetUID(t *testing.T) {
 
 	for _, tc := range testCases {
 		c := GetContainer()
+		c.Data = &v1.Container{}
 		c.Status.ContainerID = tc.testCID
 		uid, err := c.GetUID()
 		assert.Equal(t, tc.expectedErr, err)

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2020-2021 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package testhelper
+
+const (
+	SUCCESS = iota
+	FAILURE
+	ERROR
+)
+
+func ResultToString(result int) (str string) {
+	switch result {
+	case SUCCESS:
+		return "SUCCESS" //nolint:goconst
+	case FAILURE:
+		return "FAILURE" //nolint:goconst
+	case ERROR:
+		return "ERROR" //nolint:goconst
+	}
+	return ""
+}

--- a/pkg/tnf/status.go
+++ b/pkg/tnf/status.go
@@ -7,12 +7,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	SUCCESS = iota
-	FAILURE
-	ERROR
-)
-
 // ClaimFilePrintf prints to claim and junit report files.
 func ClaimFilePrintf(format string, args ...interface{}) {
 	message := fmt.Sprintf(format+"\n", args...)
@@ -20,6 +14,6 @@ func ClaimFilePrintf(format string, args ...interface{}) {
 	if err != nil {
 		logrus.Errorf("Ginkgo writer could not write msg '%s' because: %s", message, err)
 	} else {
-		logrus.Error(message)
+		logrus.Trace(message)
 	}
 }


### PR DESCRIPTION
This is to port the ipv4/ipv6 icmp testcases to the new project. 
Also includes:
- a fix for the ExecCommandContainer function due to issues running tests in github (took long time to debug).
- a new pattern (loghelper.CuratedLogLines) to store the lines of logs to store in the claims file without involving ginkgo
- a fix for building images corresponding to the current repo instead of the upstream 