### PR TITLE
Operator TS - TC migration for operator-install-source

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ The section can be configured as well as auto discovered. For manual configurati
 
 * CSVs to be tested by the `operator` spec are identified with the `test-network-function.com/operator=target`
 label. Any value is permitted but `target` is used here for consistency with the other specs.
-* `test-network-function.com/subscription_name` is optional and should contain a JSON-encoded string that's the name of
-the subscription for this CSV. If unset, the CSV name will be used.
 
 ### certifiedcontainerinfo and certifiedoperatorinfo
 


### PR DESCRIPTION
The need for the subscription_name label has been removed, as the
subscription name is obtained iteration trought the subscriptions to get
the one that matches the CSV name for that namespace.