### PR TITLE
Add make coverage-html path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ GO_PACKAGES=$(shell go list ./... | grep -v vendor)
 	clean \
 	lint \
 	test \
+	coverage-html \
 	build-cnf-tests \
 	run-cnf-tests \
 	run-generic-cnf-tests \
@@ -85,6 +86,9 @@ lint:
 test: mocks
 	go build ${COMMON_GO_ARGS} ./...
 	UNIT_TEST="true" go test -coverprofile=cover.out ./...
+
+coverage-html: test
+	go tool cover -html cover.out
 
 # generate the test catalog in JSON
 build-catalog-json: build-tnf-tool


### PR DESCRIPTION
Similar to: https://github.com/test-network-function/test-network-function/pull/552

Adds a `make coverage-html` path to the Makefile.