### PR TITLE
Porting lifecycle grace period test cases

### DIFF
--- a/cnf-certification-test/accesscontrol/rbac/clusterrolebinding.go
+++ b/cnf-certification-test/accesscontrol/rbac/clusterrolebinding.go
@@ -1,18 +1,18 @@
-// // Copyright (C) 2022 Red Hat, Inc.
-// //
-// // This program is free software; you can redistribute it and/or modify
-// // it under the terms of the GNU General Public License as published by
-// // the Free Software Foundation; either version 2 of the License, or
-// // (at your option) any later version.
-// //
-// // This program is distributed in the hope that it will be useful,
-// // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// // GNU General Public License for more details.
-// //
-// // You should have received a copy of the GNU General Public License along
-// // with this program; if not, write to the Free Software Foundation, Inc.,
-// // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package rbac
 

--- a/cnf-certification-test/accesscontrol/rbac/clusterrolebinding_test.go
+++ b/cnf-certification-test/accesscontrol/rbac/clusterrolebinding_test.go
@@ -1,17 +1,17 @@
-// // Copyright (C) 2022 Red Hat, Inc.
-// //
-// // This program is free software; you can redistribute it and/or modify
-// // it under the terms of the GNU General Public License as published by
-// // the Free Software Foundation; either version 2 of the License, or
-// // (at your option) any later version.
-// //
-// // This program is distributed in the hope that it will be useful,
-// // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// // GNU General Public License for more details.
-// //
-// // You should have received a copy of the GNU General Public License along
-// // with this program; if not, write to the Free Software Foundation, Inc.,
-// // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package rbac

--- a/cnf-certification-test/accesscontrol/rbac/clusterrolebinding_test.go
+++ b/cnf-certification-test/accesscontrol/rbac/clusterrolebinding_test.go
@@ -1,0 +1,17 @@
+// // Copyright (C) 2022 Red Hat, Inc.
+// //
+// // This program is free software; you can redistribute it and/or modify
+// // it under the terms of the GNU General Public License as published by
+// // the Free Software Foundation; either version 2 of the License, or
+// // (at your option) any later version.
+// //
+// // This program is distributed in the hope that it will be useful,
+// // but WITHOUT ANY WARRANTY; without even the implied warranty of
+// // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// // GNU General Public License for more details.
+// //
+// // You should have received a copy of the GNU General Public License along
+// // with this program; if not, write to the Free Software Foundation, Inc.,
+// // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package rbac

--- a/cnf-certification-test/lifecycle/graceperiod/graceperiod.go
+++ b/cnf-certification-test/lifecycle/graceperiod/graceperiod.go
@@ -1,0 +1,120 @@
+// Copyright (C) 2020-2021 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package graceperiod
+
+import (
+	"encoding/json"
+
+	"github.com/sirupsen/logrus"
+	"github.com/test-network-function/cnf-certification-test/pkg/loghelper"
+	"github.com/test-network-function/cnf-certification-test/pkg/provider"
+	v1app "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	defaultTerminationGracePeriod      = 30
+	unconfiguredTerminationGracePeriod = -1
+)
+
+type lastAppliedConfigType struct {
+	Spec struct {
+		Template struct {
+			Spec struct {
+				TerminationGracePeriodSeconds int
+			}
+		}
+	}
+}
+
+func getTerminationGracePeriodConfiguredInYaml(lastAppliedConfigString string) (terminationGracePeriodSeconds int, err error) {
+	lastAppliedConfig := lastAppliedConfigType{}
+	// Use -1 as default value, in case the param was not set.
+	lastAppliedConfig.Spec.Template.Spec.TerminationGracePeriodSeconds = unconfiguredTerminationGracePeriod
+	err = json.Unmarshal([]byte(lastAppliedConfigString), &lastAppliedConfig)
+	if err != nil {
+		return unconfiguredTerminationGracePeriod, err
+	}
+	return lastAppliedConfig.Spec.Template.Spec.TerminationGracePeriodSeconds, nil
+}
+
+func TestTerminationGracePeriodOnStatefulsets(env *provider.TestEnvironment) (badStatefulsets []*v1app.StatefulSet, curatedLogs loghelper.CuratedLogLines) { //nolint:dupl
+	for _, sut := range env.SatetfulSets {
+		aTerminationGracePeriodSeconds, err := getTerminationGracePeriodConfiguredInYaml(sut.Annotations[`kubectl.kubernetes.io/last-applied-configuration`])
+
+		if err != nil {
+			curatedLogs = curatedLogs.AddLogLine("Statefulset %s failed to get TerminationGracePeriodSeconds err: %s", provider.StatefultsetToString(sut), err)
+			continue
+		}
+
+		if aTerminationGracePeriodSeconds == unconfiguredTerminationGracePeriod {
+			curatedLogs = curatedLogs.AddLogLine("Statefulset %s does not have a terminationGracePeriodSeconds value set. Default value (%d) is used.",
+				provider.StatefultsetToString(sut), defaultTerminationGracePeriod)
+			badStatefulsets = append(badStatefulsets, sut)
+		} else {
+			logrus.Debugf("Statefulset %s last-applied-configuration's terminationGracePeriodSeconds: %d", provider.StatefultsetToString(sut), *sut.Spec.Template.Spec.TerminationGracePeriodSeconds)
+		}
+	}
+	return badStatefulsets, curatedLogs
+}
+
+func TestTerminationGracePeriodOnDeployments(env *provider.TestEnvironment) (badDeployments []*v1app.Deployment, curatedLogs loghelper.CuratedLogLines) { //nolint:dupl
+	for _, dut := range env.Deployments {
+		aTerminationGracePeriodSeconds, err := getTerminationGracePeriodConfiguredInYaml(dut.Annotations[`kubectl.kubernetes.io/last-applied-configuration`])
+
+		if err != nil {
+			curatedLogs = curatedLogs.AddLogLine("Deployment %s failed to get TerminationGracePeriodSeconds err: %s", provider.DeploymentToString(dut), err)
+			continue
+		}
+
+		if aTerminationGracePeriodSeconds == unconfiguredTerminationGracePeriod {
+			curatedLogs = curatedLogs.AddLogLine("Deployment %s does not have a terminationGracePeriodSeconds value set. Default value (%d) is used.",
+				provider.DeploymentToString(dut), defaultTerminationGracePeriod)
+			badDeployments = append(badDeployments, dut)
+		} else {
+			logrus.Debugf("Deployment %s last-applied-configuration's terminationGracePeriodSeconds: %d", provider.DeploymentToString(dut), *dut.Spec.Template.Spec.TerminationGracePeriodSeconds)
+		}
+	}
+	return badDeployments, curatedLogs
+}
+
+func TestTerminationGracePeriodOnPods(env *provider.TestEnvironment) (badPods []*v1.Pod, curatedLogs loghelper.CuratedLogLines) {
+	numUnmanagedPods := 0
+	for _, put := range env.Pods {
+		// We'll process only "unmanaged" pods (not belonging to any deployment/statefulset) here.
+		if len(put.OwnerReferences) != 0 {
+			continue
+		}
+		numUnmanagedPods++
+		aTerminationGracePeriodSeconds, err := getTerminationGracePeriodConfiguredInYaml(put.Annotations[`kubectl.kubernetes.io/last-applied-configuration`])
+
+		if err != nil {
+			curatedLogs = curatedLogs.AddLogLine("Pod %s failed to get TerminationGracePeriodSeconds err: %s", provider.PodToString(put), err)
+			continue
+		}
+
+		if aTerminationGracePeriodSeconds == unconfiguredTerminationGracePeriod {
+			curatedLogs = curatedLogs.AddLogLine("Pod %s does not have a terminationGracePeriodSeconds value set. Default value (%d) is used.",
+				provider.PodToString(put), defaultTerminationGracePeriod)
+			badPods = append(badPods, put)
+		} else {
+			logrus.Debugf("Pod %s last-applied-configuration's terminationGracePeriodSeconds: %d", provider.PodToString(put), *put.Spec.TerminationGracePeriodSeconds)
+		}
+	}
+	logrus.Debugf("Number of unamanaged pods processed: %d", numUnmanagedPods)
+	return badPods, curatedLogs
+}

--- a/cnf-certification-test/lifecycle/graceperiod/graceperiod_test.go
+++ b/cnf-certification-test/lifecycle/graceperiod/graceperiod_test.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2020-2021 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package graceperiod

--- a/cnf-certification-test/lifecycle/graceperiod/graceperiod_test.go
+++ b/cnf-certification-test/lifecycle/graceperiod/graceperiod_test.go
@@ -15,3 +15,36 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package graceperiod
+
+import "testing"
+
+func Test_getTerminationGracePeriodConfiguredInYaml(t *testing.T) {
+	type args struct {
+		lastAppliedConfigString string
+	}
+	tests := []struct {
+		name                              string
+		args                              args
+		wantTerminationGracePeriodSeconds int
+		wantErr                           bool
+	}{
+		{
+			name:                              "ok",
+			args:                              args{lastAppliedConfigString: "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"name\":\"test\",\"namespace\":\"tnf\"},\"spec\":{\"replicas\":2,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"template\":{\"metadata\":{\"annotations\":{\"k8s.v1.cni.cncf.io/networks\":\"[ { \\\"name\\\" : \\\"mynet-ipv4-0\\\" },{ \\\"name\\\" : \\\"mynet-ipv4-1\\\" },{ \\\"name\\\" : \\\"mynet-ipv6-0\\\" },{ \\\"name\\\" : \\\"mynet-ipv6-1\\\" } ]\",\"test-network-function.com/container_tests\":\"[\\\"PRIVILEGED_POD\\\",\\\"PRIVILEGED_ROLE\\\"]\",\"test-network-function.com/defaultnetworkinterface\":\"\\\"eth0\\\"\"},\"labels\":{\"app\":\"test\",\"test-network-function.com/container\":\"target\",\"test-network-function.com/generic\":\"target\"},\"name\":\"test\"},\"spec\":{\"affinity\":{\"podAntiAffinity\":{\"requiredDuringSchedulingIgnoredDuringExecution\":[{\"labelSelector\":{\"matchExpressions\":[{\"key\":\"app\",\"operator\":\"In\",\"values\":[\"test\"]}]},\"topologyKey\":\"kubernetes.io/hostname\"}]}},\"automountServiceAccountToken\":false,\"containers\":[{\"command\":[\"./bin/app\"],\"image\":\"quay.io/testnetworkfunction/cnf-test-partner:latest\",\"imagePullPolicy\":\"IfNotPresent\",\"lifecycle\":{\"preStop\":{\"exec\":{\"command\":[\"/bin/sh\",\"-c\",\"killall -0 tail\"]}}},\"livenessProbe\":{\"httpGet\":{\"httpHeaders\":[{\"name\":\"health-check\",\"value\":\"liveness\"}],\"path\":\"/health\",\"port\":8080},\"initialDelaySeconds\":10,\"periodSeconds\":5},\"name\":\"test\",\"ports\":[{\"containerPort\":8080,\"name\":\"http-probe\"}],\"readinessProbe\":{\"httpGet\":{\"httpHeaders\":[{\"name\":\"health-check\",\"value\":\"readiness\"}],\"path\":\"/ready\",\"port\":8080},\"initialDelaySeconds\":10,\"periodSeconds\":5},\"resources\":{\"limits\":{\"cpu\":0.25,\"memory\":\"512Mi\"}}}],\"terminationGracePeriodSeconds\":30}}}}\n"}, //nolint:lll
+			wantTerminationGracePeriodSeconds: 30,
+			wantErr:                           false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotTerminationGracePeriodSeconds, err := getTerminationGracePeriodConfiguredInYaml(tt.args.lastAppliedConfigString)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getTerminationGracePeriodConfiguredInYaml() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotTerminationGracePeriodSeconds != tt.wantTerminationGracePeriodSeconds {
+				t.Errorf("getTerminationGracePeriodConfiguredInYaml() = %v, want %v", gotTerminationGracePeriodSeconds, tt.wantTerminationGracePeriodSeconds)
+			}
+		})
+	}
+}

--- a/cnf-certification-test/lifecycle/graceperiod/graceperiod_test.go
+++ b/cnf-certification-test/lifecycle/graceperiod/graceperiod_test.go
@@ -34,6 +34,18 @@ func Test_getTerminationGracePeriodConfiguredInYaml(t *testing.T) {
 			wantTerminationGracePeriodSeconds: 30,
 			wantErr:                           false,
 		},
+		{
+			name:                              "ok",
+			args:                              args{lastAppliedConfigString: "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"name\":\"test\",\"namespace\":\"tnf\"},\"spec\":{\"replicas\":2,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"template\":{\"metadata\":{\"annotations\":{\"k8s.v1.cni.cncf.io/networks\":\"[ { \\\"name\\\" : \\\"mynet-ipv4-0\\\" },{ \\\"name\\\" : \\\"mynet-ipv4-1\\\" },{ \\\"name\\\" : \\\"mynet-ipv6-0\\\" },{ \\\"name\\\" : \\\"mynet-ipv6-1\\\" } ]\",\"test-network-function.com/container_tests\":\"[\\\"PRIVILEGED_POD\\\",\\\"PRIVILEGED_ROLE\\\"]\",\"test-network-function.com/defaultnetworkinterface\":\"\\\"eth0\\\"\"},\"labels\":{\"app\":\"test\",\"test-network-function.com/container\":\"target\",\"test-network-function.com/generic\":\"target\"},\"name\":\"test\"},\"spec\":{\"affinity\":{\"podAntiAffinity\":{\"requiredDuringSchedulingIgnoredDuringExecution\":[{\"labelSelector\":{\"matchExpressions\":[{\"key\":\"app\",\"operator\":\"In\",\"values\":[\"test\"]}]},\"topologyKey\":\"kubernetes.io/hostname\"}]}},\"automountServiceAccountToken\":false,\"containers\":[{\"command\":[\"./bin/app\"],\"image\":\"quay.io/testnetworkfunction/cnf-test-partner:latest\",\"imagePullPolicy\":\"IfNotPresent\",\"lifecycle\":{\"preStop\":{\"exec\":{\"command\":[\"/bin/sh\",\"-c\",\"killall -0 tail\"]}}},\"livenessProbe\":{\"httpGet\":{\"httpHeaders\":[{\"name\":\"health-check\",\"value\":\"liveness\"}],\"path\":\"/health\",\"port\":8080},\"initialDelaySeconds\":10,\"periodSeconds\":5},\"name\":\"test\",\"ports\":[{\"containerPort\":8080,\"name\":\"http-probe\"}],\"readinessProbe\":{\"httpGet\":{\"httpHeaders\":[{\"name\":\"health-check\",\"value\":\"readiness\"}],\"path\":\"/ready\",\"port\":8080},\"initialDelaySeconds\":10,\"periodSeconds\":5},\"resources\":{\"limits\":{\"cpu\":0.25,\"memory\":\"512Mi\"}}}]}}}}\n"}, //nolint:lll
+			wantTerminationGracePeriodSeconds: -1,
+			wantErr:                           false,
+		},
+		{
+			name:                              "ok",
+			args:                              args{lastAppliedConfigString: ""},
+			wantTerminationGracePeriodSeconds: -1,
+			wantErr:                           true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -192,15 +192,15 @@ func testGracePeriod(env *provider.TestEnvironment) {
 
 	numDeps := len(badDeployments)
 	if numDeps > 0 {
-		logrus.Tracef("Deployments found without terminationGracePeriodSeconds param set: %+v", badDeployments)
+		logrus.Debugf("Deployments found without terminationGracePeriodSeconds param set: %+v", badDeployments)
 	}
 	numSts := len(badStatefulsets)
 	if numSts > 0 {
-		logrus.Tracef("Statefulsets found without terminationGracePeriodSeconds param set: %+v", badStatefulsets)
+		logrus.Debugf("Statefulsets found without terminationGracePeriodSeconds param set: %+v", badStatefulsets)
 	}
 	numPods := len(badPods)
 	if numPods > 0 {
-		logrus.Tracef("Pods found without terminationGracePeriodSeconds param set: %+v", badPods)
+		logrus.Debugf("Pods found without terminationGracePeriodSeconds param set: %+v", badPods)
 	}
 	ginkgo.By("Test results for grace period on deployments")
 	tnf.ClaimFilePrintf("%s", deploymentLogs)

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/common"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/identifiers"
+	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/lifecycle/graceperiod"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/lifecycle/ownerreference"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/lifecycle/scaling"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
@@ -184,97 +185,34 @@ func testPodNodeSelectorAndAffinityBestPractices(env *provider.TestEnvironment) 
 	}
 }
 
-
-func testTerminationGracePeriodOnPodSet(podsetsUnderTests []., env *provider.TestEnvironment) []configsections.PodSet {
-	const ocCommandTemplate = "oc get %s %s -n %s -o jsonpath={.metadata.annotations\\.\"kubectl\\.kubernetes\\.io/last-applied-configuration\"}"
-
-	type lastAppliedConfigType struct {
-		Spec struct {
-			Template struct {
-				Spec struct {
-					TerminationGracePeriodSeconds int
-				}
-			}
-		}
-	}
-
-	badPodsets := []configsections.PodSet{}
-	for _, podset := range podsetsUnderTests {
-		ocCommand := fmt.Sprintf(ocCommandTemplate, podset.Type, podset.Name, podset.Namespace)
-		lastAppliedConfigString, err := utils.ExecuteCommand(ocCommand, common.DefaultTimeout, context)
-		if err != nil {
-			ginkgo.Fail(fmt.Sprintf("%s %s (ns %s): failed to get last-applied-configuration field", podset.Type, podset.Name, podset.Namespace))
-		}
-		lastAppliedConfig := lastAppliedConfigType{}
-
-		// Use -1 as default value, in case the param was not set.
-		lastAppliedConfig.Spec.Template.Spec.TerminationGracePeriodSeconds = -1
-
-		err = json.Unmarshal([]byte(lastAppliedConfigString), &lastAppliedConfig)
-		if err != nil {
-			ginkgo.Fail(fmt.Sprintf("%s %s (ns %s): failed to unmarshall last-applied-configuration string (%s)", podset.Type, podset.Name, podset.Namespace, lastAppliedConfigString))
-		}
-
-		if lastAppliedConfig.Spec.Template.Spec.TerminationGracePeriodSeconds == -1 {
-			tnf.ClaimFilePrintf("%s %s (ns %s) template's spec does not have a terminationGracePeriodSeconds value set. Default value (%d) will be used.",
-				podset.Type, podset.Name, podset.Namespace, defaultTerminationGracePeriod)
-			badPodsets = append(badPodsets, podset)
-		} else {
-			log.Infof("%s %s (ns %s) last-applied-configuration's terminationGracePeriodSeconds: %d", podset.Type, podset.Name, podset.Namespace, lastAppliedConfig.Spec.Template.Spec.TerminationGracePeriodSeconds)
-		}
-	}
-
-	return badPodsets
-}
-
-func testTerminationGracePeriodOnPods(env *provider.TestEnvironment)([]*v1.Pod){
-	badPods := []*v1.Pod{}
-	numUnmanagedPods := 0
-	for _, put := range env.Pods {
-		// We'll process only "unmanaged" pods (not belonging to any deployment/statefulset) here.
-		if len(put.OwnerReferences) == 0 {
-			continue
-		}
-
-		numUnmanagedPods++
-
-		if *put.DeletionGracePeriodSeconds == -1 {
-			tnf.ClaimFilePrintf("Pod %s spec does not have a terminationGracePeriodSeconds value set. Default value (%d) will be used.",
-				provider.PodToString( put ), *put.DeletionGracePeriodSeconds)
-			badPods = append(badPods, put)
-		} else {
-			logrus.Debugf("Pod %s last-applied-configuration's terminationGracePeriodSeconds: %d", provider.PodToString( put ), *put.DeletionGracePeriodSeconds)
-		}
-
-		logrus.Debugf("Number of unamanaged pods processed: %d", numUnmanagedPods)
-	}
-	return badPods
-}
-
 func testGracePeriod(env *provider.TestEnvironment) {
+	badDeployments, deploymentLogs := graceperiod.TestTerminationGracePeriodOnDeployments(env)
+	badStatefulsets, statefulsetLogs := graceperiod.TestTerminationGracePeriodOnStatefulsets(env)
+	badPods, podLogs := graceperiod.TestTerminationGracePeriodOnPods(env)
 
-		badDeployments := testTerminationGracePeriodOnPodSet(env.DeploymentsUnderTest, context)
-		badStatefulsets := testTerminationGracePeriodOnPodSet(env.StateFulSetUnderTest, context)
-		badPods := testTerminationGracePeriodOnPods(env)
-
-		numDeps := len(badDeployments)
-		if numDeps > 0 {
-			logrus.Debugf("Deployments found without terminationGracePeriodSeconds param set: %+v", badDeployments)
-		}
-		numSts := len(badStatefulsets)
-		if numSts > 0 {
-			logrus.Debugf("Statefulsets found without terminationGracePeriodSeconds param set: %+v", badStatefulsets)
-		}
-		numPods := len(badPods)
-		if numPods > 0 {
-			logrus.Debugf("Pods found without terminationGracePeriodSeconds param set: %+v", badPods)
-		}
-
-		if numDeps > 0 || numSts > 0 || numPods > 0 {
-			ginkgo.Fail(fmt.Sprintf("Found %d deployments, %d statefulsets and %d pods without terminationGracePeriodSeconds param set.", numDeps, numSts, numPods))
-		}
+	numDeps := len(badDeployments)
+	if numDeps > 0 {
+		logrus.Tracef("Deployments found without terminationGracePeriodSeconds param set: %+v", badDeployments)
 	}
+	numSts := len(badStatefulsets)
+	if numSts > 0 {
+		logrus.Tracef("Statefulsets found without terminationGracePeriodSeconds param set: %+v", badStatefulsets)
+	}
+	numPods := len(badPods)
+	if numPods > 0 {
+		logrus.Tracef("Pods found without terminationGracePeriodSeconds param set: %+v", badPods)
+	}
+	ginkgo.By("Test results for grace period on deployments")
+	tnf.ClaimFilePrintf("%s", deploymentLogs)
+	ginkgo.By("Test results for grace period on statefulsets")
+	tnf.ClaimFilePrintf("%s", statefulsetLogs)
+	ginkgo.By("Test results for grace period on unmanaged pods")
+	tnf.ClaimFilePrintf("%s", podLogs)
 
+	if numDeps > 0 || numSts > 0 || numPods > 0 {
+		ginkgo.Fail(fmt.Sprintf("Found %d deployments, %d statefulsets and %d pods without terminationGracePeriodSeconds param set.", numDeps, numSts, numPods))
+	}
+}
 
 func testScaling(env *provider.TestEnvironment, timeout time.Duration) {
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestDeploymentScalingIdentifier)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -234,7 +234,7 @@ func GetRuntimeUID(cs *v1.ContainerStatus) (runtime, uid string) {
 }
 
 func (c *Container) String() string {
-	return fmt.Sprintf("node:%s ns:%s podName:%s containerName:%s containerUID:%s containerRuntime:%s",
+	return fmt.Sprintf("node: %s ns: %s podName: %s containerName: %s containerUID: %s containerRuntime: %s",
 		c.NodeName,
 		c.Namespace,
 		c.Podname,
@@ -244,7 +244,7 @@ func (c *Container) String() string {
 	)
 }
 func (c *Container) StringShort() string {
-	return fmt.Sprintf("ns:%s podName:%s containerName:%s",
+	return fmt.Sprintf("ns: %s podName: %s containerName: %s",
 		c.Namespace,
 		c.Podname,
 		c.Data.Name,
@@ -252,9 +252,23 @@ func (c *Container) StringShort() string {
 }
 
 func PodToString(pod *v1.Pod) string {
-	return fmt.Sprintf("ns:%s podName:%s",
+	return fmt.Sprintf("ns: %s podName: %s",
 		pod.Namespace,
 		pod.Name,
+	)
+}
+
+func DeploymentToString(d *v1apps.Deployment) string {
+	return fmt.Sprintf("ns: %s deployment name: %s",
+		d.Namespace,
+		d.Name,
+	)
+}
+
+func StatefultsetToString(s *v1apps.StatefulSet) string {
+	return fmt.Sprintf("ns: %s statefulset name: %s",
+		s.Namespace,
+		s.Name,
 	)
 }
 


### PR DESCRIPTION
In this test case, we look at the yaml applied configuration (found in annotation ) for the  terminationGracePeriodSeconds parameter. If it is not defined then fail the test. The test is done for deployments, statefulsets and unmanaged pods.