### PR TITLE
Porting:  Removing extra statefulset test #651

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -188,15 +188,7 @@ jobs:
           mkdir -p $TNF_CONFIG_DIR $TNF_OUTPUT_DIR
           cp cnf-certification-test/*.yml $TNF_CONFIG_DIR
         shell: bash
-
-      #- name: 'Test: Run without any TS, just get diagnostic information'
-      #  run: ./run-tnf-container.sh ${{ env.TESTING_CMD_PARAMS }}
-
-      - name: Delete the deployment and deploy Statefulset pods
-        uses: ./cnf-certification-test-partner/.github/actions/deploy-statefulset-pods
-        with:
-          working_directory: cnf-certification-test-partner
-          
+    
       - name: 'Test: Run generic test suite in a TNF container'
         run: ./run-tnf-container.sh ${{ env.TESTING_CMD_PARAMS }} -f access-control lifecycle platform observability networking affiliated-certification operator
 


### PR DESCRIPTION
This is the second part of the partner PR to improve testing stateful sets. Deployment and statefulset are now created (and exist) at the same time
Before, we were testing only deployments during the smoke test run not using image and
we were only using the statefulset (no deployment) during the smoke test run with the image
This PR remove the code deleting the deployment and creating the statefulset to test the image since both statefulset and deployment are always created at the same time.
Will remove reference to pod-recreation repo before mergingno deployments