### PR TITLE
Switch to ginkgo/gomega unit-test aware funcs

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/accesscontrol/namespace"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/accesscontrol/rbac"
@@ -121,7 +120,7 @@ var _ = ginkgo.Describe(common.AccessControlTestKey, func() {
 func TestSecConCapabilities(env *provider.TestEnvironment) {
 	var badContainers []string
 	if len(env.Containers) == 0 {
-		ginkgo.Skip("No containers to perform test, skipping")
+		tnf.GinkgoSkip("No containers to perform test, skipping")
 	}
 	for _, cut := range env.Containers {
 		if cut.Data.SecurityContext != nil && cut.Data.SecurityContext.Capabilities != nil {
@@ -134,14 +133,14 @@ func TestSecConCapabilities(env *provider.TestEnvironment) {
 		}
 	}
 	tnf.ClaimFilePrintf("bad containers: %v", badContainers)
-	gomega.Expect(badContainers).To(gomega.BeNil())
+	tnf.GomegaExpectSliceBeNil(badContainers)
 }
 
 // TestSecConRootUser verifies that the container is not running as root
 func TestSecConRootUser(env *provider.TestEnvironment) {
 	var badContainers, badPods []string
 	if len(env.Containers) == 0 {
-		ginkgo.Skip("No containers to perform test, skipping")
+		tnf.GinkgoSkip("No containers to perform test, skipping")
 	}
 	for _, put := range env.Pods {
 		if put.Spec.SecurityContext != nil && put.Spec.SecurityContext.RunAsUser != nil {
@@ -164,15 +163,15 @@ func TestSecConRootUser(env *provider.TestEnvironment) {
 	}
 	tnf.ClaimFilePrintf("bad pods: %v", badPods)
 	tnf.ClaimFilePrintf("bad containers: %v", badContainers)
-	gomega.Expect(badContainers).To(gomega.BeNil())
-	gomega.Expect(badPods).To(gomega.BeNil())
+	tnf.GomegaExpectSliceBeNil(badContainers)
+	tnf.GomegaExpectSliceBeNil(badPods)
 }
 
 // TestSecConPrivilegeEscalation verifies that the container is not allowed privilege escalation
 func TestSecConPrivilegeEscalation(env *provider.TestEnvironment) {
 	var badContainers []string
 	if len(env.Containers) == 0 {
-		ginkgo.Skip("No containers to perform test, skipping")
+		tnf.GinkgoSkip("No containers to perform test, skipping")
 	}
 	for _, cut := range env.Containers {
 		if cut.Data.SecurityContext != nil && cut.Data.SecurityContext.AllowPrivilegeEscalation != nil {
@@ -183,14 +182,14 @@ func TestSecConPrivilegeEscalation(env *provider.TestEnvironment) {
 		}
 	}
 	tnf.ClaimFilePrintf("bad containers: %v", badContainers)
-	gomega.Expect(badContainers).To(gomega.BeNil())
+	tnf.GomegaExpectSliceBeNil(badContainers)
 }
 
 // TestContainerHostPort tests that containers are not configured with host port privileges
 func TestContainerHostPort(env *provider.TestEnvironment) {
 	var badContainers []string
 	if len(env.Containers) == 0 {
-		ginkgo.Skip("No containers to perform test, skipping")
+		tnf.GinkgoSkip("No containers to perform test, skipping")
 	}
 	for _, cut := range env.Containers {
 		for _, aPort := range cut.Data.Ports {
@@ -201,14 +200,14 @@ func TestContainerHostPort(env *provider.TestEnvironment) {
 		}
 	}
 	tnf.ClaimFilePrintf("bad containers: %v", badContainers)
-	gomega.Expect(badContainers).To(gomega.BeNil())
+	tnf.GomegaExpectSliceBeNil(badContainers)
 }
 
 // TestPodHostNetwork verifies that the pod hostNetwork parameter is not set to true
 func TestPodHostNetwork(env *provider.TestEnvironment) {
 	var badPods []string
 	if len(env.Pods) == 0 {
-		ginkgo.Skip("No Pods to run test, skipping")
+		tnf.GinkgoSkip("No Pods to run test, skipping")
 	}
 	for _, put := range env.Pods {
 		if put.Spec.HostNetwork {
@@ -217,14 +216,14 @@ func TestPodHostNetwork(env *provider.TestEnvironment) {
 		}
 	}
 	tnf.ClaimFilePrintf("bad pods: %v", badPods)
-	gomega.Expect(badPods).To(gomega.BeNil())
+	tnf.GomegaExpectSliceBeNil(badPods)
 }
 
 // TestPodHostPath verifies that the pod hostpath parameter is not set to true
 func TestPodHostPath(env *provider.TestEnvironment) {
 	var badPods []string
 	if len(env.Pods) == 0 {
-		ginkgo.Skip("No Pods to run test, skipping")
+		tnf.GinkgoSkip("No Pods to run test, skipping")
 	}
 	for _, put := range env.Pods {
 		for idx := range put.Spec.Volumes {
@@ -236,14 +235,14 @@ func TestPodHostPath(env *provider.TestEnvironment) {
 		}
 	}
 	tnf.ClaimFilePrintf("bad pods: %v", badPods)
-	gomega.Expect(badPods).To(gomega.BeNil())
+	tnf.GomegaExpectSliceBeNil(badPods)
 }
 
 // TestPodHostIPC verifies that the pod hostIpc parameter is not set to true
 func TestPodHostIPC(env *provider.TestEnvironment) {
 	var badPods []string
 	if len(env.Pods) == 0 {
-		ginkgo.Skip("No Pods to run test, skipping")
+		tnf.GinkgoSkip("No Pods to run test, skipping")
 	}
 	for _, put := range env.Pods {
 		if put.Spec.HostIPC {
@@ -252,14 +251,14 @@ func TestPodHostIPC(env *provider.TestEnvironment) {
 		}
 	}
 	tnf.ClaimFilePrintf("bad pods: %v", badPods)
-	gomega.Expect(badPods).To(gomega.BeNil())
+	tnf.GomegaExpectSliceBeNil(badPods)
 }
 
 // TestPodHostPID verifies that the pod hostPid parameter is not set to true
 func TestPodHostPID(env *provider.TestEnvironment) {
 	var badPods []string
 	if len(env.Pods) == 0 {
-		ginkgo.Skip("No Pods to run test, skipping")
+		tnf.GinkgoSkip("No Pods to run test, skipping")
 	}
 	for _, put := range env.Pods {
 		if put.Spec.HostPID {
@@ -268,15 +267,15 @@ func TestPodHostPID(env *provider.TestEnvironment) {
 		}
 	}
 	tnf.ClaimFilePrintf("bad pods: %v", badPods)
-	gomega.Expect(badPods).To(gomega.BeNil())
+	tnf.GomegaExpectSliceBeNil(badPods)
 }
 
 // Tests namespaces for invalid prefixed and CRs are not defined in namespaces not under test with CRDs under test
 func TestNamespace(env *provider.TestEnvironment) {
-	ginkgo.By(fmt.Sprintf("CNF resources' Namespaces should not have any of the following prefixes: %v", invalidNamespacePrefixes))
+	tnf.GinkgoBy(fmt.Sprintf("CNF resources' Namespaces should not have any of the following prefixes: %v", invalidNamespacePrefixes))
 	var failedNamespaces []string
 	for _, namespace := range env.Namespaces {
-		ginkgo.By(fmt.Sprintf("Checking namespace %s", namespace))
+		tnf.GinkgoBy(fmt.Sprintf("Checking namespace %s", namespace))
 		for _, invalidPrefix := range invalidNamespacePrefixes {
 			if strings.HasPrefix(namespace, invalidPrefix) {
 				tnf.ClaimFilePrintf("Namespace %s has invalid prefix %s", namespace, invalidPrefix)
@@ -285,10 +284,10 @@ func TestNamespace(env *provider.TestEnvironment) {
 		}
 	}
 	if failedNamespacesNum := len(failedNamespaces); failedNamespacesNum > 0 {
-		ginkgo.Fail(fmt.Sprintf("Found %d Namespaces with an invalid prefix.", failedNamespacesNum))
+		tnf.GinkgoFail(fmt.Sprintf("Found %d Namespaces with an invalid prefix.", failedNamespacesNum))
 	}
-	ginkgo.By(fmt.Sprintf("CNF pods' should belong to any of the configured Namespaces: %v", env.Namespaces))
-	ginkgo.By(fmt.Sprintf("CRs from autodiscovered CRDs should belong only to the configured Namespaces: %v", env.Namespaces))
+	tnf.GinkgoBy(fmt.Sprintf("CNF pods' should belong to any of the configured Namespaces: %v", env.Namespaces))
+	tnf.GinkgoBy(fmt.Sprintf("CRs from autodiscovered CRDs should belong only to the configured Namespaces: %v", env.Namespaces))
 	invalidCrs, _ := namespace.TestCrsNamespaces(env.Crds, env.Namespaces)
 
 	invalidCrsNum := 0
@@ -301,16 +300,16 @@ func TestNamespace(env *provider.TestEnvironment) {
 				}
 			}
 		}
-		ginkgo.Fail(fmt.Sprintf("Found %d CRs belonging to invalid Namespaces.", invalidCrsNum))
+		tnf.GinkgoFail(fmt.Sprintf("Found %d CRs belonging to invalid Namespaces.", invalidCrsNum))
 	}
 }
 
 // TestPodServiceAccount verifies that the pod utilizes a valid service account
 func TestPodServiceAccount(env *provider.TestEnvironment) {
-	ginkgo.By("Tests that each pod utilizes a valid service account")
+	tnf.GinkgoBy("Tests that each pod utilizes a valid service account")
 	failedPods := []string{}
 	for _, put := range env.Pods {
-		ginkgo.By(fmt.Sprintf("Testing service account for pod %s (ns: %s)", put.Name, put.Namespace))
+		tnf.GinkgoBy(fmt.Sprintf("Testing service account for pod %s (ns: %s)", put.Name, put.Namespace))
 		if put.Spec.ServiceAccountName == "" {
 			tnf.ClaimFilePrintf("Pod %s (ns: %s) doesn't have a service account name.", put.Name, put.Namespace)
 			failedPods = append(failedPods, put.Name)
@@ -318,20 +317,20 @@ func TestPodServiceAccount(env *provider.TestEnvironment) {
 	}
 	if n := len(failedPods); n > 0 {
 		logrus.Debugf("Pods without service account: %+v", failedPods)
-		ginkgo.Fail(fmt.Sprintf("%d pods don't have a service account name.", n))
+		tnf.GinkgoFail(fmt.Sprintf("%d pods don't have a service account name.", n))
 	}
 }
 
 // TestPodRoleBindings verifies that the pod utilizes a valid role binding that does not cross namespaces
 //nolint:dupl
 func TestPodRoleBindings(env *provider.TestEnvironment) {
-	ginkgo.By("Should not have RoleBinding in other namespaces")
+	tnf.GinkgoBy("Should not have RoleBinding in other namespaces")
 	failedPods := []string{}
 
 	for _, put := range env.Pods {
-		ginkgo.By(fmt.Sprintf("Testing role binding for pod: %s namespace: %s", put.Name, put.Namespace))
+		tnf.GinkgoBy(fmt.Sprintf("Testing role binding for pod: %s namespace: %s", put.Name, put.Namespace))
 		if put.Spec.ServiceAccountName == "" {
-			ginkgo.Skip("Can not test when serviceAccountName is empty. Please check previous tests for failures")
+			tnf.GinkgoSkip("Can not test when serviceAccountName is empty. Please check previous tests for failures")
 		}
 
 		// Create a new object with the ability to gather rolebinding specs.
@@ -351,20 +350,20 @@ func TestPodRoleBindings(env *provider.TestEnvironment) {
 	}
 	if n := len(failedPods); n > 0 {
 		logrus.Debugf("Pods with role bindings: %+v", failedPods)
-		ginkgo.Fail(fmt.Sprintf("%d pods have role bindings in other namespaces.", n))
+		tnf.GinkgoFail(fmt.Sprintf("%d pods have role bindings in other namespaces.", n))
 	}
 }
 
 // TestPodClusterRoleBindings verifies that the pod utilizes a valid cluster role binding that does not cross namespaces
 //nolint:dupl
 func TestPodClusterRoleBindings(env *provider.TestEnvironment) {
-	ginkgo.By("Should not have ClusterRoleBinding in other namespaces")
+	tnf.GinkgoBy("Should not have ClusterRoleBinding in other namespaces")
 	failedPods := []string{}
 
 	for _, put := range env.Pods {
-		ginkgo.By(fmt.Sprintf("Testing cluster role binding for pod: %s namespace: %s", put.Name, put.Namespace))
+		tnf.GinkgoBy(fmt.Sprintf("Testing cluster role binding for pod: %s namespace: %s", put.Name, put.Namespace))
 		if put.Spec.ServiceAccountName == "" {
-			ginkgo.Skip("Can not test when serviceAccountName is empty. Please check previous tests for failures")
+			tnf.GinkgoSkip("Can not test when serviceAccountName is empty. Please check previous tests for failures")
 		}
 
 		// Create a new object with the ability to gather clusterrolebinding specs.
@@ -384,7 +383,7 @@ func TestPodClusterRoleBindings(env *provider.TestEnvironment) {
 	}
 	if n := len(failedPods); n > 0 {
 		logrus.Debugf("Pods with cluster role bindings: %+v", failedPods)
-		ginkgo.Fail(fmt.Sprintf("%d pods have cluster role bindings in other namespaces.", n))
+		tnf.GinkgoFail(fmt.Sprintf("%d pods have cluster role bindings in other namespaces.", n))
 	}
 }
 

--- a/cnf-certification-test/certification/suite.go
+++ b/cnf-certification-test/certification/suite.go
@@ -71,9 +71,9 @@ func testContainerCertificationStatus(env *provider.TestEnvironment) {
 			}
 		}
 		if len(containersToQuery) == 0 {
-			ginkgo.Skip("No containers to check configured in tnf_config.yml")
+			tnf.GinkgoSkip("No containers to check configured in tnf_config.yml")
 		}
-		ginkgo.By(fmt.Sprintf("Getting certification status. Number of containers to check: %d", len(containersToQuery)))
+		tnf.GinkgoBy(fmt.Sprintf("Getting certification status. Number of containers to check: %d", len(containersToQuery)))
 		certtool.CertAPIClient = api.NewHTTPClient()
 		failedContainers := []configuration.ContainerImageIdentifier{}
 		allContainersToQueryEmpty := true
@@ -83,7 +83,7 @@ func testContainerCertificationStatus(env *provider.TestEnvironment) {
 				continue
 			}
 			allContainersToQueryEmpty = false
-			ginkgo.By(fmt.Sprintf("Container %s/%s should eventually be verified as certified", c.Repository, c.Name))
+			tnf.GinkgoBy(fmt.Sprintf("Container %s/%s should eventually be verified as certified", c.Repository, c.Name))
 			entry := certtool.WaitForCertificationRequestToSuccess(certtool.GetContainerCertificationRequestFunction(c), apiRequestTimeout).(*api.ContainerCatalogEntry)
 			if entry == nil {
 				tnf.ClaimFilePrintf("Container %s (repository %s) is not found in the certified container catalog.", c.Name, c.Repository)
@@ -97,12 +97,12 @@ func testContainerCertificationStatus(env *provider.TestEnvironment) {
 			}
 		}
 		if allContainersToQueryEmpty {
-			ginkgo.Skip("No containers to check because either container name or repository is empty for all containers in tnf_config.yml")
+			tnf.GinkgoSkip("No containers to check because either container name or repository is empty for all containers in tnf_config.yml")
 		}
 
 		if n := len(failedContainers); n > 0 {
 			log.Warnf("Containers that are not certified: %+v", failedContainers)
-			ginkgo.Fail(fmt.Sprintf("%d container images are not certified.", n))
+			tnf.GinkgoFail(fmt.Sprintf("%d container images are not certified.", n))
 		}
 	})
 }
@@ -113,10 +113,10 @@ func testAllOperatorCertified(env *provider.TestEnvironment) {
 		operatorsToQuery := env.Subscriptions
 
 		if len(operatorsToQuery) == 0 {
-			ginkgo.Skip("No operators to check configured ")
+			tnf.GinkgoSkip("No operators to check configured ")
 		}
 		certtool.CertAPIClient = api.NewHTTPClient()
-		ginkgo.By(fmt.Sprintf("Verify operator as certified. Number of operators to check: %d", len(operatorsToQuery)))
+		tnf.GinkgoBy(fmt.Sprintf("Verify operator as certified. Number of operators to check: %d", len(operatorsToQuery)))
 		testFailed := false
 		for _, op := range operatorsToQuery {
 			ocpversion := ""
@@ -140,7 +140,7 @@ func testAllOperatorCertified(env *provider.TestEnvironment) {
 			}
 		}
 		if testFailed {
-			ginkgo.Skip("At least one  operator was not certified to run on this version of openshift. Check Claim.json file for details.")
+			tnf.GinkgoSkip("At least one  operator was not certified to run on this version of openshift. Check Claim.json file for details.")
 		}
 	})
 }
@@ -150,14 +150,14 @@ func testHelmCertified(env *provider.TestEnvironment) {
 		certtool.CertAPIClient = api.NewHTTPClient()
 		helmcharts := env.HelmList
 		if len(helmcharts) == 0 {
-			ginkgo.Skip("No helm charts to check")
+			tnf.GinkgoSkip("No helm charts to check")
 		}
 		out, err := certtool.CertAPIClient.GetYamlFile()
 		if err != nil {
-			ginkgo.Fail(fmt.Sprintf("error while reading the helm yaml file from the api %s", err))
+			tnf.GinkgoFail(fmt.Sprintf("error while reading the helm yaml file from the api %s", err))
 		}
 		if out.Entries == nil {
-			ginkgo.Skip("No helm charts from the api")
+			tnf.GinkgoSkip("No helm charts from the api")
 		}
 		ourKubeVersion := env.K8sVersion
 		failedHelmCharts := [][]string{}
@@ -190,7 +190,7 @@ func testHelmCertified(env *provider.TestEnvironment) {
 		if len(failedHelmCharts) > 0 {
 			log.Errorf("Helms that are not certified: %+v", failedHelmCharts)
 			tnf.ClaimFilePrintf("Helms that are not certified: %+v", failedHelmCharts)
-			ginkgo.Fail(fmt.Sprintf("%d helms chart are not certified.", len(failedHelmCharts)))
+			tnf.GinkgoFail(fmt.Sprintf("%d helms chart are not certified.", len(failedHelmCharts)))
 		}
 	})
 }

--- a/cnf-certification-test/lifecycle/podrecreation/podrecreation.go
+++ b/cnf-certification-test/lifecycle/podrecreation/podrecreation.go
@@ -21,10 +21,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/onsi/ginkgo/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
+	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	retry "k8s.io/client-go/util/retry"
 )
@@ -103,6 +103,6 @@ func CountPodsWithDelete(nodeName string, isDelete bool) (count int, err error) 
 func CordonCleanup(node string) {
 	err := CordonHelper(node, Uncordon)
 	if err != nil {
-		ginkgo.AbortSuite(fmt.Sprintf("cleanup: error uncordoning the node: %s", node))
+		tnf.GinkgoAbortSuite(fmt.Sprintf("cleanup: error uncordoning the node: %s", node))
 	}
 }

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -91,7 +91,7 @@ func testDefaultNetworkConnectivity(env *provider.TestEnvironment, count int, aI
 
 	if n := len(badNets); n > 0 {
 		logrus.Debugf("Failed nets: %+v", badNets)
-		ginkgo.Fail(fmt.Sprintf("%d nets failed the default network %s ping test.", n, aIPVersion))
+		tnf.GinkgoFail(fmt.Sprintf("%d nets failed the default network %s ping test.", n, aIPVersion))
 	}
 }
 
@@ -121,6 +121,6 @@ func testMultusNetworkConnectivity(env *provider.TestEnvironment, count int, aIP
 
 	if n := len(badNets); n > 0 {
 		logrus.Debugf("Failed nets: %+v", badNets)
-		ginkgo.Fail(fmt.Sprintf("%d nets failed the multus %s ping test.", n, aIPVersion))
+		tnf.GinkgoFail(fmt.Sprintf("%d nets failed the multus %s ping test.", n, aIPVersion))
 	}
 }

--- a/cnf-certification-test/observability/suite.go
+++ b/cnf-certification-test/observability/suite.go
@@ -79,14 +79,14 @@ func containerHasLoggingOutput(cut *provider.Container) (bool, error) {
 
 func testContainersLogging(env *provider.TestEnvironment) {
 	if len(env.Containers) == 0 {
-		ginkgo.Skip("No containers to run test, skipping")
+		tnf.GinkgoSkip("No containers to run test, skipping")
 	}
 
 	// Iterate through all the CUTs to get their log output. The TC checks that at least
 	// one log line is found.
 	badContainers := []string{}
 	for _, cut := range env.Containers {
-		ginkgo.By(fmt.Sprintf("Checking %s has some logging output", cut.StringShort()))
+		tnf.GinkgoBy(fmt.Sprintf("Checking %s has some logging output", cut.StringShort()))
 		hasLoggingOutput, err := containerHasLoggingOutput(cut)
 		if err != nil {
 			tnf.ClaimFilePrintf("Failed to get %s log output: %s", cut.StringShort(), err)
@@ -101,7 +101,7 @@ func testContainersLogging(env *provider.TestEnvironment) {
 
 	if n := len(badContainers); n > 0 {
 		logrus.Debugf("Containers without logging: %+v", badContainers)
-		ginkgo.Fail(fmt.Sprintf("%d containers don't have any log to stdout/stderr.", n))
+		tnf.GinkgoFail(fmt.Sprintf("%d containers don't have any log to stdout/stderr.", n))
 	}
 }
 
@@ -109,7 +109,7 @@ func testContainersLogging(env *provider.TestEnvironment) {
 func testCrds(env *provider.TestEnvironment) {
 	failedCrds := []string{}
 	for _, crd := range env.Crds {
-		ginkgo.By("Testing CRD " + crd.Name)
+		tnf.GinkgoBy("Testing CRD " + crd.Name)
 
 		for _, ver := range crd.Spec.Versions {
 			if _, ok := ver.Schema.OpenAPIV3Schema.Properties["status"]; !ok {
@@ -121,6 +121,6 @@ func testCrds(env *provider.TestEnvironment) {
 
 	if n := len(failedCrds); n > 0 {
 		logrus.Debugf("CRD.version without status subresource: %+v", failedCrds)
-		ginkgo.Fail(fmt.Sprintf("%d CRDs don't have status subresource", n))
+		tnf.GinkgoFail(fmt.Sprintf("%d CRDs don't have status subresource", n))
 	}
 }

--- a/cnf-certification-test/operator/suite.go
+++ b/cnf-certification-test/operator/suite.go
@@ -59,7 +59,7 @@ var _ = ginkgo.Describe(common.OperatorTestKey, func() {
 func testOperatorInstallationPhaseSucceeded(env *provider.TestEnvironment) {
 	badCsvs := []string{}
 	if len(env.Csvs) == 0 {
-		ginkgo.Skip("No CSVs to perform test, skipping.")
+		tnf.GinkgoSkip("No CSVs to perform test, skipping.")
 	}
 
 	for _, csv := range env.Csvs {
@@ -71,14 +71,14 @@ func testOperatorInstallationPhaseSucceeded(env *provider.TestEnvironment) {
 	}
 
 	if n := len(badCsvs); n > 0 {
-		ginkgo.Fail(fmt.Sprintf("Found %d CSVs whose phase is not %s.", n, v1alpha1.CSVPhaseSucceeded))
+		tnf.GinkgoFail(fmt.Sprintf("Found %d CSVs whose phase is not %s.", n, v1alpha1.CSVPhaseSucceeded))
 	}
 }
 
 func testOperatorInstallationWithoutPrivileges(env *provider.TestEnvironment) {
 	badCsvs := []string{}
 	if len(env.Csvs) == 0 {
-		ginkgo.Skip("No CSVs to perform test, skipping.")
+		tnf.GinkgoSkip("No CSVs to perform test, skipping.")
 	}
 
 	for _, csv := range env.Csvs {
@@ -108,23 +108,23 @@ func testOperatorInstallationWithoutPrivileges(env *provider.TestEnvironment) {
 	}
 
 	if n := len(badCsvs); n > 0 {
-		ginkgo.Fail(fmt.Sprintf("Found %d CSVs with priviledges on some resource names.", n))
+		tnf.GinkgoFail(fmt.Sprintf("Found %d CSVs with priviledges on some resource names.", n))
 	}
 }
 
 func testOperatorOlmSubscription(env *provider.TestEnvironment) {
 	badCsvs := []string{}
 	if len(env.Csvs) == 0 {
-		ginkgo.Skip("No CSVs to perform test, skipping.")
+		tnf.GinkgoSkip("No CSVs to perform test, skipping.")
 	}
 
 	ocpClient := clientsholder.GetClientsHolder()
 	for _, csv := range env.Csvs {
-		ginkgo.By(fmt.Sprintf("Checking OLM subscription for CSV %s (ns %s)", csv.Name, csv.Namespace))
+		tnf.GinkgoBy(fmt.Sprintf("Checking OLM subscription for CSV %s (ns %s)", csv.Name, csv.Namespace))
 		options := metav1.ListOptions{}
 		subscriptions, err := ocpClient.OlmClient.OperatorsV1alpha1().Subscriptions(csv.Namespace).List(context.TODO(), options)
 		if err != nil {
-			ginkgo.Fail(fmt.Sprintf("Failed to get subscription for CSV %s (ns %s): %s", csv.Name, csv.Namespace, err))
+			tnf.GinkgoFail(fmt.Sprintf("Failed to get subscription for CSV %s (ns %s): %s", csv.Name, csv.Namespace, err))
 		}
 
 		// Iterate through namespace's subscriptions to get the installed CSV one.
@@ -143,6 +143,6 @@ func testOperatorOlmSubscription(env *provider.TestEnvironment) {
 	}
 
 	if n := len(badCsvs); n > 0 {
-		ginkgo.Fail(fmt.Sprintf("Found %d CSVs not installed by OLM", n))
+		tnf.GinkgoFail(fmt.Sprintf("Found %d CSVs not installed by OLM", n))
 	}
 }

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -53,7 +53,7 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 		if provider.IsOCPCluster() {
 			testContainersFsDiff(&env)
 		} else {
-			ginkgo.Skip(" non ocp cluster ")
+			tnf.GinkgoSkip(" non ocp cluster ")
 		}
 	})
 
@@ -181,10 +181,10 @@ func testTainted(env *provider.TestEnvironment) {
 }
 
 func testIsRedHatRelease(env *provider.TestEnvironment) {
-	ginkgo.By("should report a proper Red Hat version")
+	tnf.GinkgoBy("should report a proper Red Hat version")
 	failedContainers := []string{}
 	for _, cut := range env.Containers {
-		ginkgo.By(fmt.Sprintf("%s is checked for Red Hat version", cut.StringShort()))
+		tnf.GinkgoBy(fmt.Sprintf("%s is checked for Red Hat version", cut.StringShort()))
 		baseImageTester := isredhat.NewBaseImageTester(common.DefaultTimeout, clientsholder.GetClientsHolder(), clientsholder.Context{
 			Namespace:     cut.Namespace,
 			Podname:       cut.Podname,

--- a/pkg/tnf/status.go
+++ b/pkg/tnf/status.go
@@ -46,3 +46,22 @@ func GinkgoFail(cmd string) {
 		ginkgo.Fail(cmd)
 	}
 }
+
+// GomegaExpectSliceBeNil is a wrapper for gomega
+func GomegaExpectSliceBeNil(incomingSlice []string) {
+	if !IsUnitTest() {
+		gomega.Expect(incomingSlice).To(gomega.BeNil())
+	}
+}
+
+func GinkgoSkip(cmd string) {
+	if !IsUnitTest() {
+		ginkgo.Skip(cmd)
+	}
+}
+
+func GinkgoAbortSuite(cmd string) {
+	if !IsUnitTest() {
+		ginkgo.AbortSuite(cmd)
+	}
+}


### PR DESCRIPTION
Similar to changes:
- https://github.com/test-network-function/cnf-certification-test/pull/63
- https://github.com/test-network-function/cnf-certification-test/pull/61

Adds a couple more functions:
- `GomegaExpectSliceBeNil`
- `GinkgoSkip`
- `GinkgoAbortSuite`

These functions are aware of whether or not they are being used in unit tests or not via the `IsUnitTest()` function.