### PR TITLE
Waiting for operator to be ready before testing sucessful phase

### DIFF
--- a/cnf-certification-test/operator/phasecheck/phasecheck.go
+++ b/cnf-certification-test/operator/phasecheck/phasecheck.go
@@ -1,0 +1,61 @@
+// Copyright (C) 2020-2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package phasecheck
+
+import (
+	"context"
+	"time"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/sirupsen/logrus"
+	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
+	"github.com/test-network-function/cnf-certification-test/pkg/provider"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	timeout = 5 * time.Minute
+)
+
+func WaitOperatorReady(csv *v1alpha1.ClusterServiceVersion) {
+	oc := clientsholder.GetClientsHolder()
+	isReady := false
+	start := time.Now()
+	for !isReady && time.Since(start) < timeout {
+		freshCsv, err := oc.OlmClient.OperatorsV1alpha1().ClusterServiceVersions(csv.Namespace).Get(context.TODO(), csv.Name, metav1.GetOptions{})
+		if err != nil {
+			logrus.Errorf("error getting %s", provider.CsvToString(freshCsv))
+		}
+		isReady = isOperatorSucceeded(freshCsv)
+		logrus.Debugf("Waiting for %s to be in Succeeded phase: %s", provider.CsvToString(freshCsv), freshCsv.Status.Phase)
+		time.Sleep(time.Second)
+	}
+	if time.Since(start) > timeout {
+		logrus.Fatalf("Timeout waiting for %s to be ready", provider.CsvToString(csv))
+	}
+	if isReady {
+		logrus.Infof("%s is ready", provider.CsvToString(csv))
+	}
+}
+
+func isOperatorSucceeded(csv *v1alpha1.ClusterServiceVersion) (isReady bool) {
+	isReady = false
+	if csv.Status.Phase == v1alpha1.CSVPhaseSucceeded {
+		isReady = true
+	}
+	return isReady
+}

--- a/cnf-certification-test/operator/phasecheck/phasecheck_test.go
+++ b/cnf-certification-test/operator/phasecheck/phasecheck_test.go
@@ -1,0 +1,165 @@
+// Copyright (C) 2020-2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package phasecheck
+
+import (
+	"testing"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_isOperatorSucceeded(t *testing.T) { //nolint:funlen
+	type args struct {
+		csv *v1alpha1.ClusterServiceVersion
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantIsReady bool
+	}{
+		{name: "ok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhaseSucceeded,
+				},
+			}},
+			wantIsReady: true,
+		},
+		{name: "nok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhaseInstalling,
+				},
+			}},
+			wantIsReady: false,
+		},
+		{name: "nok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhaseDeleting,
+				},
+			}},
+			wantIsReady: false,
+		},
+		{name: "nok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhaseInstallReady,
+				},
+			}},
+		},
+		{name: "nok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhaseUnknown,
+				},
+			}},
+			wantIsReady: false,
+		},
+		{name: "nok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhasePending,
+				},
+			}},
+			wantIsReady: false,
+		},
+		{name: "nok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhaseReplacing,
+				},
+			}},
+			wantIsReady: false,
+		},
+		{name: "nok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhaseAny,
+				},
+			}},
+			wantIsReady: false,
+		},
+		{name: "nok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhaseFailed,
+				},
+			}},
+
+			wantIsReady: false,
+		},
+		{name: "nok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhaseNone,
+				},
+			}},
+
+			wantIsReady: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotIsReady := isOperatorSucceeded(tt.args.csv); gotIsReady != tt.wantIsReady {
+				t.Errorf("isOperatorSucceeded() = %v, want %v", gotIsReady, tt.wantIsReady)
+			}
+		})
+	}
+}

--- a/cnf-certification-test/operator/suite.go
+++ b/cnf-certification-test/operator/suite.go
@@ -64,8 +64,8 @@ func testOperatorInstallationPhaseSucceeded(env *provider.TestEnvironment) {
 	}
 
 	for _, csv := range env.Csvs {
-		phasecheck.WaitOperatorReady(csv)
-		if csv.Status.Phase != v1alpha1.CSVPhaseSucceeded {
+		phase := phasecheck.WaitOperatorReady(csv)
+		if phase != v1alpha1.CSVPhaseSucceeded {
 			badCsvs = append(badCsvs, fmt.Sprintf("%s.%s", csv.Namespace, csv.Name))
 			tnf.ClaimFilePrintf("CSV %s (ns %s) is in phase %s. Expected phase is %s",
 				csv.Name, csv.Namespace, csv.Status.Phase, v1alpha1.CSVPhaseSucceeded)

--- a/cnf-certification-test/operator/suite.go
+++ b/cnf-certification-test/operator/suite.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/common"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/identifiers"
+	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/operator/phasecheck"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
 	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
@@ -63,6 +64,7 @@ func testOperatorInstallationPhaseSucceeded(env *provider.TestEnvironment) {
 	}
 
 	for _, csv := range env.Csvs {
+		phasecheck.WaitOperatorReady(csv)
 		if csv.Status.Phase != v1alpha1.CSVPhaseSucceeded {
 			badCsvs = append(badCsvs, fmt.Sprintf("%s.%s", csv.Namespace, csv.Name))
 			tnf.ClaimFilePrintf("CSV %s (ns %s) is in phase %s. Expected phase is %s",

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -346,6 +346,13 @@ func StatefulsetToString(s *v1apps.StatefulSet) string {
 	)
 }
 
+func CsvToString(csv *v1alpha1.ClusterServiceVersion) string {
+	return fmt.Sprintf("operator csv: %s ns: %s",
+		csv.Name,
+		csv.Namespace,
+	)
+}
+
 // getPodIPsPerNet gets the IPs of a pod.
 // CNI annotation "k8s.v1.cni.cncf.io/networks-status".
 // Returns (ips, error).


### PR DESCRIPTION
Pod recreation test case might destroy and re-create the operator pod. This PR is adding a wait so that the operator has time to go back to a succeeded phase before starting the test