### PR TITLE
Exclude _moq.go files from test file creation

### DIFF
--- a/script/create-missing-test-files.sh
+++ b/script/create-missing-test-files.sh
@@ -1,5 +1,5 @@
 for folder in  cnf-certification-test internal pkg ; do
    echo "./$folder"
-  find ./$folder -name "*.go" | grep -v "_test.go"| sed 's/.go//g'|xargs -I{} sh -c "echo {}; if ! test -f '{}_test.go'; then sed '/^package/q' {}.go > {}_test.go; fi"
+  find ./$folder -name "*.go" | grep -v "_test.go" | grep -v "_moq.go" | sed 's/.go//g'|xargs -I{} sh -c "echo {}; if ! test -f '{}_test.go'; then sed '/^package/q' {}.go > {}_test.go; fi"
 done
 rm -f {}_test.go


### PR DESCRIPTION
`moq.go` files don't need corresponding _test.go files.