### PR TITLE
Added custom struct Operator as placeholder for CSV related fields

### DIFF
--- a/cnf-certification-test/operator/suite.go
+++ b/cnf-certification-test/operator/suite.go
@@ -59,11 +59,12 @@ var _ = ginkgo.Describe(common.OperatorTestKey, func() {
 
 func testOperatorInstallationPhaseSucceeded(env *provider.TestEnvironment) {
 	badCsvs := []string{}
-	if len(env.Csvs) == 0 {
+	if len(env.Operators) == 0 {
 		ginkgo.Skip("No CSVs to perform test, skipping.")
 	}
 
-	for _, csv := range env.Csvs {
+	for i := range env.Operators {
+		csv := env.Operators[i].Csv
 		phase := phasecheck.WaitOperatorReady(csv)
 		if phase != v1alpha1.CSVPhaseSucceeded {
 			badCsvs = append(badCsvs, fmt.Sprintf("%s.%s", csv.Namespace, csv.Name))
@@ -79,11 +80,12 @@ func testOperatorInstallationPhaseSucceeded(env *provider.TestEnvironment) {
 
 func testOperatorInstallationWithoutPrivileges(env *provider.TestEnvironment) {
 	badCsvs := []string{}
-	if len(env.Csvs) == 0 {
+	if len(env.Operators) == 0 {
 		ginkgo.Skip("No CSVs to perform test, skipping.")
 	}
 
-	for _, csv := range env.Csvs {
+	for i := range env.Operators {
+		csv := env.Operators[i].Csv
 		clusterPermissions := csv.Spec.InstallStrategy.StrategySpec.ClusterPermissions
 		if len(clusterPermissions) == 0 {
 			logrus.Debugf("No clusterPermissions found in csv %s (ns %s)", csv.Name, csv.Namespace)
@@ -116,12 +118,13 @@ func testOperatorInstallationWithoutPrivileges(env *provider.TestEnvironment) {
 
 func testOperatorOlmSubscription(env *provider.TestEnvironment) {
 	badCsvs := []string{}
-	if len(env.Csvs) == 0 {
+	if len(env.Operators) == 0 {
 		ginkgo.Skip("No CSVs to perform test, skipping.")
 	}
 
 	ocpClient := clientsholder.GetClientsHolder()
-	for _, csv := range env.Csvs {
+	for i := range env.Operators {
+		csv := env.Operators[i].Csv
 		ginkgo.By(fmt.Sprintf("Checking OLM subscription for CSV %s (ns %s)", csv.Name, csv.Namespace))
 		options := metav1.ListOptions{}
 		subscriptions, err := ocpClient.OlmClient.OperatorsV1alpha1().Subscriptions(csv.Namespace).List(context.TODO(), options)

--- a/cnf-certification-test/operator/suite.go
+++ b/cnf-certification-test/operator/suite.go
@@ -58,48 +58,48 @@ var _ = ginkgo.Describe(common.OperatorTestKey, func() {
 })
 
 func testOperatorInstallationPhaseSucceeded(env *provider.TestEnvironment) {
-	badCsvs := []string{}
+	badOperators := []string{}
 	if len(env.Operators) == 0 {
-		ginkgo.Skip("No CSVs to perform test, skipping.")
+		ginkgo.Skip("No operators found to perform test, skipping.")
 	}
 
 	for i := range env.Operators {
 		csv := env.Operators[i].Csv
 		phase := phasecheck.WaitOperatorReady(csv)
 		if phase != v1alpha1.CSVPhaseSucceeded {
-			badCsvs = append(badCsvs, fmt.Sprintf("%s.%s", csv.Namespace, csv.Name))
-			tnf.ClaimFilePrintf("CSV %s (ns %s) is in phase %s. Expected phase is %s",
-				csv.Name, csv.Namespace, csv.Status.Phase, v1alpha1.CSVPhaseSucceeded)
+			badOperators = append(badOperators, env.Operators[i].String())
+			tnf.ClaimFilePrintf("%s is in phase %s. Expected phase is %s",
+				&env.Operators[i], csv.Status.Phase, v1alpha1.CSVPhaseSucceeded)
 		}
 	}
 
-	if n := len(badCsvs); n > 0 {
-		ginkgo.Fail(fmt.Sprintf("Found %d CSVs whose phase is not %s.", n, v1alpha1.CSVPhaseSucceeded))
+	if n := len(badOperators); n > 0 {
+		ginkgo.Fail(fmt.Sprintf("Found %d operators whose CSV's phase is not %s.", n, v1alpha1.CSVPhaseSucceeded))
 	}
 }
 
 func testOperatorInstallationWithoutPrivileges(env *provider.TestEnvironment) {
-	badCsvs := []string{}
+	badOperators := []string{}
 	if len(env.Operators) == 0 {
-		ginkgo.Skip("No CSVs to perform test, skipping.")
+		ginkgo.Skip("No operators found to perform test, skipping.")
 	}
 
 	for i := range env.Operators {
 		csv := env.Operators[i].Csv
 		clusterPermissions := csv.Spec.InstallStrategy.StrategySpec.ClusterPermissions
 		if len(clusterPermissions) == 0 {
-			logrus.Debugf("No clusterPermissions found in csv %s (ns %s)", csv.Name, csv.Namespace)
+			logrus.Debugf("No clusterPermissions found in %s", &env.Operators[i])
 			continue
 		}
 
 		// Fails in case any cluster permission has a rule with any resource name.
 		badRuleFound := false
-		for i := range clusterPermissions {
-			permission := &clusterPermissions[i]
+		for permissionIndex := range clusterPermissions {
+			permission := &clusterPermissions[permissionIndex]
 			for ruleIndex := range permission.Rules {
 				if n := len(permission.Rules[ruleIndex].ResourceNames); n > 0 {
-					tnf.ClaimFilePrintf("CSV %s (ns %s) cluster permission (service account %s) has %d resource names (rule index %d).",
-						csv.Name, csv.Namespace, permission.ServiceAccountName, n, ruleIndex)
+					tnf.ClaimFilePrintf("%s: cluster permission (service account %s) has %d resource names (rule index %d).",
+						&env.Operators[i], permission.ServiceAccountName, n, ruleIndex)
 					// Keep reviewing other permissions' rules so we can log all the failing ones in the claim file.
 					badRuleFound = true
 				}
@@ -107,12 +107,12 @@ func testOperatorInstallationWithoutPrivileges(env *provider.TestEnvironment) {
 		}
 
 		if badRuleFound {
-			badCsvs = append(badCsvs, fmt.Sprintf("%s.%s", csv.Namespace, csv.Name))
+			badOperators = append(badOperators, env.Operators[i].String())
 		}
 	}
 
-	if n := len(badCsvs); n > 0 {
-		ginkgo.Fail(fmt.Sprintf("Found %d CSVs with priviledges on some resource names.", n))
+	if n := len(badOperators); n > 0 {
+		ginkgo.Fail(fmt.Sprintf("Found %d operators with priviledges on some resource names.", n))
 	}
 }
 
@@ -125,25 +125,25 @@ func testOperatorOlmSubscription(env *provider.TestEnvironment) {
 	ocpClient := clientsholder.GetClientsHolder()
 	for i := range env.Operators {
 		csv := env.Operators[i].Csv
-		ginkgo.By(fmt.Sprintf("Checking OLM subscription for CSV %s (ns %s)", csv.Name, csv.Namespace))
+		ginkgo.By(fmt.Sprintf("Checking OLM subscription for %s", provider.CsvToString(csv)))
 		options := metav1.ListOptions{}
 		subscriptions, err := ocpClient.OlmClient.OperatorsV1alpha1().Subscriptions(csv.Namespace).List(context.TODO(), options)
 		if err != nil {
-			ginkgo.Fail(fmt.Sprintf("Failed to get subscription for CSV %s (ns %s): %s", csv.Name, csv.Namespace, err))
+			ginkgo.Fail(fmt.Sprintf("Failed to get subscription for %s: %s", provider.CsvToString(csv), err))
 		}
 
 		// Iterate through namespace's subscriptions to get the installed CSV one.
 		subscriptionFound := false
 		for i := range subscriptions.Items {
 			if subscriptions.Items[i].Status.InstalledCSV == csv.Name {
-				logrus.Infof("OLM subscription %s found for CSV %s (ns %s)", subscriptions.Items[i].Name, csv.Name, csv.Namespace)
+				logrus.Infof("OLM subscription %s found for %s", subscriptions.Items[i].Name, provider.CsvToString(csv))
 				subscriptionFound = true
 				break
 			}
 		}
 		if !subscriptionFound {
-			tnf.ClaimFilePrintf("OLM subscription not found for operator csv %s (ns %s)", csv.Name, csv.Namespace)
-			badCsvs = append(badCsvs, fmt.Sprintf("%s.%s", csv.Namespace, csv.Name))
+			tnf.ClaimFilePrintf("OLM subscription not found for operator %s", provider.CsvToString(csv))
+			badCsvs = append(badCsvs, provider.CsvToString(csv))
 		}
 	}
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -392,6 +392,10 @@ func CsvToString(csv *olmv1Alpha.ClusterServiceVersion) string {
 	)
 }
 
+func (op *Operator) String() string {
+	return fmt.Sprintf("csv: %s ns:%s subscription:%s", op.Name, op.Namespace, op.SubscriptionName)
+}
+
 // getPodIPsPerNet gets the IPs of a pod.
 // CNI annotation "k8s.v1.cni.cncf.io/networks-status".
 // Returns (ips, error).

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -26,7 +26,6 @@ import (
 
 	"encoding/json"
 
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/pkg/autodiscover"
@@ -35,6 +34,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	olmv1Alpha "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	v1apps "k8s.io/api/apps/v1"
 	v1scaling "k8s.io/api/autoscaling/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -54,7 +54,7 @@ type TestEnvironment struct { // rename this with testTarget
 	Namespaces         []string
 	Pods               []*v1.Pod
 	Containers         []*Container
-	Csvs               []*v1alpha1.ClusterServiceVersion
+	Operators          []Operator
 	DebugPods          map[string]*v1.Pod // map from nodename to debugPod
 	Config             configuration.TestConfiguration
 	variables          configuration.TestParameters
@@ -67,12 +67,31 @@ type TestEnvironment struct { // rename this with testTarget
 	StatetfulSets      []*v1apps.StatefulSet
 	HorizontalScaler   map[string]*v1scaling.HorizontalPodAutoscaler
 	Nodes              *v1.NodeList
-	Subscriptions      []*v1alpha1.Subscription
+	Subscriptions      []*olmv1Alpha.Subscription
 	K8sVersion         string
 	OpenshiftVersion   string
 	HelmList           []*release.Release
 }
 
+type CsvInstallPlan struct {
+	// Operator's installPlan name
+	Name string `yaml:"name" json:"name"`
+	// BundleImage is the URL referencing the bundle image
+	BundleImage string `yaml:"bundleImage" json:"bundleImage"`
+	// IndexImage is the URL referencing the index image
+	IndexImage string `yaml:"indexImage" json:"indexImage"`
+}
+
+type Operator struct {
+	Name             string                            `yaml:"name" json:"name"`
+	Namespace        string                            `yaml:"namespace" json:"namespace"`
+	Csv              *olmv1Alpha.ClusterServiceVersion `yaml:"csv" json:"csv"`
+	SubscriptionName string                            `yaml:"subscriptionName" json:"subscriptionName"`
+	InstallPlans     []CsvInstallPlan                  `yaml:"installPlans,omitempty" json:"installPlans,omitempty"`
+	Package          string                            `yaml:"packag" json:"packag"`
+	Org              string                            `yaml:"Org" json:"Org"`
+	Version          string                            `yaml:"Version" json:"Version"`
+}
 type Container struct {
 	Data                     *v1.Container
 	Status                   v1.ContainerStatus
@@ -122,6 +141,7 @@ func buildTestEnvironment() { //nolint:funlen
 	env.SkipMultusNetTests = make(map[*v1.Pod]bool)
 	env.Nodes = data.Nodes
 	pods := data.Pods
+
 	for i := 0; i < len(pods); i++ {
 		env.Pods = append(env.Pods, &pods[i])
 		var err error
@@ -146,7 +166,6 @@ func buildTestEnvironment() { //nolint:funlen
 	csvs := data.Csvs
 	subscriptions := data.Subscriptions
 	for i := range csvs {
-		env.Csvs = append(env.Csvs, &csvs[i])
 		isCsv, sub := IsinstalledCsv(&csvs[i], subscriptions)
 		if isCsv {
 			env.Subscriptions = append(env.Subscriptions, &sub)
@@ -169,6 +188,12 @@ func buildTestEnvironment() { //nolint:funlen
 		env.StatetfulSets = append(env.StatetfulSets, &data.StatefulSet[i])
 	}
 	env.HorizontalScaler = data.Hpas
+
+	operators, err := createOperators(data.Csvs, data.Subscriptions)
+	if err != nil {
+		logrus.Errorf("Failed to get cluster operators: %s", err)
+	}
+	env.Operators = operators
 }
 
 func getPodContainers(aPod *v1.Pod) (containerList []*Container) {
@@ -222,8 +247,8 @@ func IsOCPCluster() bool {
 	return !env.variables.NonOcpCluster
 }
 
-func IsinstalledCsv(csv *v1alpha1.ClusterServiceVersion, subscriptions []v1alpha1.Subscription) (bool, v1alpha1.Subscription) {
-	var returnsub v1alpha1.Subscription
+func IsinstalledCsv(csv *olmv1Alpha.ClusterServiceVersion, subscriptions []olmv1Alpha.Subscription) (bool, olmv1Alpha.Subscription) {
+	var returnsub olmv1Alpha.Subscription
 	for i := range subscriptions {
 		if subscriptions[i].Status.InstalledCSV == csv.Name {
 			returnsub = subscriptions[i]
@@ -360,7 +385,7 @@ func StatefulsetToString(s *v1apps.StatefulSet) string {
 	)
 }
 
-func CsvToString(csv *v1alpha1.ClusterServiceVersion) string {
+func CsvToString(csv *olmv1Alpha.ClusterServiceVersion) string {
 	return fmt.Sprintf("operator csv: %s ns: %s",
 		csv.Name,
 		csv.Namespace,
@@ -397,4 +422,119 @@ func (env *TestEnvironment) SetNeedsRefresh() {
 
 func (env *TestEnvironment) IsIntrusive() bool {
 	return !env.variables.NonIntrusiveOnly
+}
+
+// getInstallPlansInNamespace is a helper function to get the installPlans in a namespace. The
+// map installPlans is used to store them in order to avoid repeating http requests for a namespace
+// whose installPlans were already obtained.
+func getInstallPlansInNamespace(namespace string, clusterInstallPlans map[string][]olmv1Alpha.InstallPlan) ([]olmv1Alpha.InstallPlan, error) {
+	// Check if installplans were stored before.
+	nsInstallPlans, exist := clusterInstallPlans[namespace]
+	if exist {
+		return nsInstallPlans, nil
+	}
+
+	clients := clientsholder.GetClientsHolder()
+	installPlanList, err := clients.OlmClient.OperatorsV1alpha1().InstallPlans(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("unable get installplans in namespace %s, err: %s", namespace, err)
+	}
+
+	nsInstallPlans = installPlanList.Items
+	clusterInstallPlans[namespace] = nsInstallPlans
+
+	return nsInstallPlans, nil
+}
+
+// getCsvInstallPlans is a helper function that returns the installPlans for a CSV in a namespace.
+// The map clusterInstallPlans is used to store previously retrieved installPlans, in order to save
+// http requests.
+func getCsvInstallPlans(namespace, csv string, clusterInstallPlans map[string][]olmv1Alpha.InstallPlan) ([]*olmv1Alpha.InstallPlan, error) {
+	nsInstallPlans, err := getInstallPlansInNamespace(namespace, clusterInstallPlans)
+	if err != nil {
+		return nil, err
+	}
+
+	installPlans := []*olmv1Alpha.InstallPlan{}
+	for i := range nsInstallPlans {
+		nsInstallPlan := &nsInstallPlans[i]
+		for _, csvName := range nsInstallPlan.Spec.ClusterServiceVersionNames {
+			if csv != csvName {
+				continue
+			}
+
+			if nsInstallPlan.Status.BundleLookups == nil {
+				logrus.Warnf("InstallPlan %s for csv %s (ns %s) does not have bundle lookups. It will be skipped.", nsInstallPlan.Name, csv, namespace)
+				continue
+			}
+
+			installPlans = append(installPlans, nsInstallPlan)
+		}
+	}
+
+	if len(installPlans) == 0 {
+		return nil, fmt.Errorf("no installplans found for csv %s (ns %s)", csv, namespace)
+	}
+
+	return installPlans, nil
+}
+
+func getCatalogSourceImageIndexFromInstallPlan(installPlan *olmv1Alpha.InstallPlan) (string, error) {
+	// ToDo/Technical debt: what to do if installPlan has more than one BundleLookups entries.
+	catalogSourceName := installPlan.Status.BundleLookups[0].CatalogSourceRef.Name
+	catalogSourceNamespace := installPlan.Status.BundleLookups[0].CatalogSourceRef.Namespace
+
+	clients := clientsholder.GetClientsHolder()
+	catalogSource, err := clients.OlmClient.OperatorsV1alpha1().CatalogSources(catalogSourceNamespace).Get(context.TODO(), catalogSourceName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get catalogsource: %s", err)
+	}
+
+	return catalogSource.Spec.Image, nil
+}
+
+func createOperators(csvs []olmv1Alpha.ClusterServiceVersion, subscriptions []olmv1Alpha.Subscription) ([]Operator, error) {
+	installPlans := map[string][]olmv1Alpha.InstallPlan{} // Helper: maps a namespace name to all its installplans.
+	operators := []Operator{}
+	for i := range csvs {
+		csv := &csvs[i]
+		op := Operator{Name: csv.Name, Namespace: csv.Namespace, Csv: csv}
+
+		packageAndVersion := strings.SplitN(csv.Name, ".", 2) //nolint:gomnd // ok
+		op.Version = packageAndVersion[1]
+
+		for s := range subscriptions {
+			subscription := &subscriptions[s]
+			if subscription.Status.InstalledCSV != csv.Name {
+				continue
+			}
+
+			op.SubscriptionName = subscription.Name
+			op.Package = subscription.Spec.Package
+			op.Org = subscription.Spec.CatalogSource
+
+			csvInstallPlans, err := getCsvInstallPlans(csv.Namespace, csv.Name, installPlans)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get installPlans for csv %s (ns %s)", csv.Name, csv.Namespace)
+			}
+
+			for _, installPlan := range csvInstallPlans {
+				indexImage, err := getCatalogSourceImageIndexFromInstallPlan(installPlan)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get installPlan image index for csv %s (ns %s) installPlan %s, err: %s",
+						csv.Name, csv.Namespace, installPlan.Name, err)
+				}
+
+				op.InstallPlans = append(op.InstallPlans, CsvInstallPlan{
+					Name:        installPlan.Name,
+					BundleImage: installPlan.Status.BundleLookups[0].Path,
+					IndexImage:  indexImage,
+				})
+			}
+		}
+
+		operators = append(operators, op)
+	}
+
+	return operators, nil
 }


### PR DESCRIPTION
I brought back the old Operator struct from the old repo so all this
CSV-related information can be grouped under it.