### PR TITLE
Update GolangCI to 1.45.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -128,6 +128,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.44.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.45.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ COMMON_GO_ARGS=-race
 GIT_COMMIT=$(shell script/create-version-files.sh)
 GIT_RELEASE=$(shell script/get-git-release.sh)
 GIT_PREVIOUS_RELEASE=$(shell script/get-git-previous-release.sh)
-GOLANGCI_VERSION=v1.44.2
+GOLANGCI_VERSION=v1.45.2
 
 # Run the unit tests and build all binaries
 build:

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ At a minimum, the following dependencies must be installed *prior* to running `m
 Dependency|Minimum Version
 ---|---
 [GoLang](https://golang.org/dl/)|1.17
-[golangci-lint](https://golangci-lint.run/usage/install/)|1.44.2
+[golangci-lint](https://golangci-lint.run/usage/install/)|1.45.2
 [jq](https://stedolan.github.io/jq/)|1.6
 [OpenShift Client](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/)|4.7
 


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.45.2

Similar to:
https://github.com/test-network-function/test-network-function/pull/660
https://github.com/test-network-function/cnfcert-tests-verification/pull/55
https://github.com/test-network-function/test-network-function-claim/pull/41