### PR TITLE
Address complexity in certification test suite

### DIFF
--- a/cnf-certification-test/certification/certtool/certtool.go
+++ b/cnf-certification-test/certification/certtool/certtool.go
@@ -17,12 +17,10 @@
 package certtool
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
 	version "github.com/hashicorp/go-version"
-	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/internal/api"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 	"helm.sh/helm/v3/pkg/release"
@@ -92,23 +90,18 @@ func CompareVersion(ver1, ver2 string) bool {
 }
 
 func IsReleaseCertified(helm *release.Release, ourKubeVersion string, out api.ChartStruct) bool {
-	certified := false
 	for _, entryList := range out.Entries {
 		for _, entry := range entryList {
 			if entry.Name == helm.Chart.Metadata.Name && entry.Version == helm.Chart.Metadata.Version {
 				if entry.KubeVersion != "" {
 					if CompareVersion(ourKubeVersion, entry.KubeVersion) {
-						certified = true
+						return true
 					}
 				} else {
-					certified = true
+					return true
 				}
 			}
 		}
-		if certified {
-			logrus.Info(fmt.Sprintf("Helm %s with version %s is certified", helm.Name, helm.Chart.Metadata.Version))
-			break
-		}
 	}
-	return certified
+	return false
 }

--- a/cnf-certification-test/certification/certtool/certtool_test.go
+++ b/cnf-certification-test/certification/certtool/certtool_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/cnf-certification-test/internal/api"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/release"
 )
 
 func TestGetContainerCertificationRequestFunction(t *testing.T) {
@@ -175,5 +177,68 @@ func TestWaitForCertificationRequestToSuccess(t *testing.T) {
 			// Note: Cannot cast the result here because the interface returned is nil.
 			assert.Nil(t, result)
 		}
+	}
+}
+
+//nolint:funlen
+func TestIsReleaseCertified(t *testing.T) {
+	// Create a helm object
+	generateHelm := func(name, version string) *release.Release {
+		return &release.Release{
+			Chart: &chart.Chart{
+				Metadata: &chart.Metadata{
+					Name:    name,
+					Version: version,
+				},
+			},
+		}
+	}
+	// Create a chart struct
+	generateChartStruct := func(name, version, kubeVersion string) api.ChartStruct {
+		return api.ChartStruct{
+			Entries: map[string][]struct {
+				Name        string "yaml:\"name\""
+				Version     string "yaml:\"version\""
+				KubeVersion string "yaml:\"kubeVersion\""
+			}{
+				"entry1": {
+					{
+						Name:        name,
+						Version:     version,
+						KubeVersion: kubeVersion,
+					},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		testKubeVersion   string
+		testRelease       *release.Release
+		testChartStruct   api.ChartStruct
+		expectedCertified bool
+	}{
+		{ // Test Case #1 - FAIL the entries mismatched helm1 vs. helm2
+			testRelease:       generateHelm("helm1", "0.0.1"),
+			testKubeVersion:   "1.18.1",
+			testChartStruct:   generateChartStruct("helm2", "0.0.1", ">= 1.19"),
+			expectedCertified: false,
+		},
+		{ // Test Case #2 - PASS the entries matched
+			testRelease:       generateHelm("helm1", "0.0.1"),
+			testKubeVersion:   "1.20.1",
+			testChartStruct:   generateChartStruct("helm1", "0.0.1", ">= 1.19"),
+			expectedCertified: true,
+		},
+		{ // Test Case #3 - FAIL the versions mismatch 0.0.1 vs 0.0.2
+			testRelease:       generateHelm("helm1", "0.0.1"),
+			testKubeVersion:   "1.18.1",
+			testChartStruct:   generateChartStruct("helm1", "0.0.2", ">= 1.19"),
+			expectedCertified: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedCertified, IsReleaseCertified(tc.testRelease, tc.testKubeVersion, tc.testChartStruct))
 	}
 }

--- a/cnf-certification-test/certification/suite.go
+++ b/cnf-certification-test/certification/suite.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/common"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/identifiers"
 	"github.com/test-network-function/cnf-certification-test/internal/api"
@@ -96,7 +96,7 @@ func testContainerCertificationStatus(env *provider.TestEnvironment) {
 					tnf.ClaimFilePrintf("Container %s (repository %s) is found in the certified container catalog but with low health index '%s'.", c.Name, c.Repository, entry.GetBestFreshnessGrade())
 					failedContainers = append(failedContainers, c)
 				}
-				log.Info(fmt.Sprintf("Container %s (repository %s) is certified.", c.Name, c.Repository))
+				logrus.Info(fmt.Sprintf("Container %s (repository %s) is certified.", c.Name, c.Repository))
 			}
 		}
 		if allContainersToQueryEmpty {
@@ -104,7 +104,7 @@ func testContainerCertificationStatus(env *provider.TestEnvironment) {
 		}
 
 		if n := len(failedContainers); n > 0 {
-			log.Warnf("Containers that are not certified: %+v", failedContainers)
+			logrus.Warnf("Containers that are not certified: %+v", failedContainers)
 			ginkgo.Fail(fmt.Sprintf("%d container images are not certified.", n))
 		}
 	})
@@ -132,10 +132,10 @@ func testAllOperatorCertified(env *provider.TestEnvironment) {
 				isCertified := certtool.WaitForCertificationRequestToSuccess(certtool.GetOperatorCertificationRequestFunction(org, pack, ocpversion), apiRequestTimeout).(bool)
 				if !isCertified {
 					testFailed = true
-					log.Info(fmt.Sprintf("Operator %s (organization %s) not certified for Openshift %s .", pack, org, ocpversion))
+					logrus.Info(fmt.Sprintf("Operator %s (organization %s) not certified for Openshift %s .", pack, org, ocpversion))
 					tnf.ClaimFilePrintf("Operator %s (organization %s) failed to be certified for Openshift %s", pack, org, ocpversion)
 				} else {
-					log.Info(fmt.Sprintf("Operator %s (organization %s) certified OK.", pack, org))
+					logrus.Info(fmt.Sprintf("Operator %s (organization %s) certified OK.", pack, org))
 				}
 			} else {
 				testFailed = true
@@ -168,10 +168,12 @@ func testHelmCertified(env *provider.TestEnvironment) {
 		for _, helm := range helmchartsReleases {
 			if !certtool.IsReleaseCertified(helm, env.K8sVersion, out) {
 				failedHelmCharts = append(failedHelmCharts, []string{helm.Chart.Metadata.Version, helm.Name})
+			} else {
+				logrus.Info(fmt.Sprintf("Helm %s with version %s is certified", helm.Name, helm.Chart.Metadata.Version))
 			}
 		}
 		if len(failedHelmCharts) > 0 {
-			log.Errorf("Helms that are not certified: %+v", failedHelmCharts)
+			logrus.Errorf("Helms that are not certified: %+v", failedHelmCharts)
 			tnf.ClaimFilePrintf("Helms that are not certified: %+v", failedHelmCharts)
 			ginkgo.Fail(fmt.Sprintf("%d helms chart are not certified.", len(failedHelmCharts)))
 		}


### PR DESCRIPTION
This section of the `suite.go` for the certification test suite was a bit too complex and needed some test cases.