### PR TITLE
Removed not needed interface fields of the clientsHolder struct.

### DIFF
--- a/cnf-certification-test/lifecycle/podsets/podsets.go
+++ b/cnf-certification-test/lifecycle/podsets/podsets.go
@@ -37,7 +37,7 @@ func WaitForDeploymentSetReady(ns, name string, timeout time.Duration) bool {
 	clients := clientsholder.GetClientsHolder()
 	start := time.Now()
 	for time.Since(start) < timeout {
-		dp, err := provider.GetUpdatedDeployment(clients.AppsClients, ns, name)
+		dp, err := provider.GetUpdatedDeployment(clients.K8sClient.AppsV1(), ns, name)
 		if err == nil && IsDeploymentReady(dp) {
 			logrus.Tracef("%s is ready", provider.DeploymentToString(dp))
 			return true
@@ -78,7 +78,7 @@ func WaitForStatefulSetReady(ns, name string, timeout time.Duration) bool {
 	clients := clientsholder.GetClientsHolder()
 	start := time.Now()
 	for time.Since(start) < timeout {
-		ss, err := provider.GetUpdatedStatefulset(clients.AppsClients, ns, name)
+		ss, err := provider.GetUpdatedStatefulset(clients.K8sClient.AppsV1(), ns, name)
 		if err == nil && IsStatefulSetReady(ss) {
 			logrus.Tracef("%s is ready, err: %s", provider.StatefulsetToString(ss), err)
 			return true

--- a/cnf-certification-test/lifecycle/scaling/deployment_scaling.go
+++ b/cnf-certification-test/lifecycle/scaling/deployment_scaling.go
@@ -39,7 +39,7 @@ import (
 func TestScaleDeployment(deployment *v1app.Deployment, timeout time.Duration) bool {
 	clients := clientsholder.GetClientsHolder()
 	name, namespace := deployment.Name, deployment.Namespace
-	dpClients := clients.AppsClients.Deployments(namespace)
+	dpClients := clients.K8sClient.AppsV1().Deployments(namespace)
 	logrus.Trace("scale deployment not using HPA ", namespace, ":", name)
 	var replicas int32
 	if deployment.Spec.Replicas != nil {
@@ -96,7 +96,7 @@ func scaleDeploymentHelper(clients *clientsholder.ClientsHolder, dpClient v1.Dep
 			return err
 		}
 		dp.Spec.Replicas = &replicas
-		_, err = clients.AppsClients.Deployments(namespace).Update(context.TODO(), dp, v1machinery.UpdateOptions{})
+		_, err = clients.K8sClient.AppsV1().Deployments(namespace).Update(context.TODO(), dp, v1machinery.UpdateOptions{})
 		if err != nil {
 			logrus.Error("can't update deployment ", namespace, ":", name)
 			return err

--- a/cnf-certification-test/lifecycle/scaling/statefulset_scaling.go
+++ b/cnf-certification-test/lifecycle/scaling/statefulset_scaling.go
@@ -40,7 +40,7 @@ import (
 func TestScaleStatefulSet(statefulset *v1app.StatefulSet, timeout time.Duration) bool {
 	clients := clientsholder.GetClientsHolder()
 	name, namespace := statefulset.Name, statefulset.Namespace
-	ssClients := clients.AppsClients.StatefulSets(namespace)
+	ssClients := clients.K8sClient.AppsV1().StatefulSets(namespace)
 	logrus.Trace("scale statefulset not using HPA ", namespace, ":", name)
 	replicas := int32(1)
 	if statefulset.Spec.Replicas != nil {
@@ -93,7 +93,7 @@ func scaleStateFulsetHelper(clients *clientsholder.ClientsHolder, ssClient v1.St
 			return err
 		}
 		ss.Spec.Replicas = &replicas
-		_, err = clients.AppsClients.StatefulSets(namespace).Update(context.TODO(), ss, v1machinery.UpdateOptions{})
+		_, err = clients.K8sClient.AppsV1().StatefulSets(namespace).Update(context.TODO(), ss, v1machinery.UpdateOptions{})
 		if err != nil {
 			logrus.Error("can't update statefulset ", namespace, ":", name)
 			return err

--- a/cnf-certification-test/observability/suite.go
+++ b/cnf-certification-test/observability/suite.go
@@ -67,7 +67,7 @@ func containerHasLoggingOutput(cut *provider.Container) (bool, error) {
 
 	numLogLines := int64(1)
 	podLogOptions := v1.PodLogOptions{TailLines: &numLogLines, Container: cut.Data.Name}
-	req := ocpClient.Coreclient.Pods(cut.Namespace).GetLogs(cut.Podname, &podLogOptions)
+	req := ocpClient.K8sClient.CoreV1().Pods(cut.Namespace).GetLogs(cut.Podname, &podLogOptions)
 
 	podLogsReaderCloser, err := req.Stream(context.TODO())
 	if err != nil {

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -21,42 +21,47 @@ import (
 	"time"
 
 	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	clientOlm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	olmClient "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	olmFakeClient "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
 	"github.com/sirupsen/logrus"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
-	testclient "k8s.io/client-go/kubernetes/fake"
-	appv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-	storageclient "k8s.io/client-go/kubernetes/typed/storage/v1"
+	k8sFakeClient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 type ClientsHolder struct {
-	RestConfig       *rest.Config
-	Coreclient       *corev1client.CoreV1Client
-	ClientConfig     clientconfigv1.ConfigV1Interface
-	DynamicClient    dynamic.Interface
-	APIExtClient     apiextv1.ApiextensionsV1Interface
-	OlmClient        *clientOlm.Clientset
-	AppsClients      *appv1client.AppsV1Client
-	OClient          *clientconfigv1.ConfigV1Client
-	K8sClient        kubernetes.Interface
-	K8sClientversion *kubernetes.Clientset
-	StorageClient    *storageclient.StorageV1Client
+	RestConfig    *rest.Config
+	DynamicClient dynamic.Interface
+	APIExtClient  apiextv1.ApiextensionsV1Interface
+	OlmClient     olmClient.Interface
+	OcpClient     clientconfigv1.ConfigV1Interface
+	K8sClient     kubernetes.Interface
 
 	ready bool
 }
 
 var clientsHolder = ClientsHolder{}
 
-func GetTestClientsHolder(mockObjects []runtime.Object, filenames ...string) *ClientsHolder {
-	// Overwrite the existing clients with mocked versions
-	clientsHolder.K8sClient = testclient.NewSimpleClientset(mockObjects...)
+// SetupFakeOlmClient Overrides the OLM client with the fake interface object for unit testing. Loads
+// the mocking objects so olmv interface methods can find them.
+func SetupFakeOlmClient(olmMockObjects []runtime.Object) {
+	clientsHolder.OlmClient = olmFakeClient.NewSimpleClientset(olmMockObjects...)
+}
+
+// GetTestClientHolder Overwrites the existing clientholders with a mocked version for unit testing.
+// Only pure k8s interfaces will be available. The runtime objects must be pure k8s ones.
+// For other (OLM, )
+// runtime mocking objects loading, use the proper clientset mocking function.
+func GetTestClientsHolder(k8sMockObjects []runtime.Object, filenames ...string) *ClientsHolder {
+	clientsHolder.K8sClient = k8sFakeClient.NewSimpleClientset(k8sMockObjects...)
+
+	clientsHolder.ready = true
 	return &clientsHolder
 }
 
@@ -99,14 +104,6 @@ func newClientsHolder(filenames ...string) (*ClientsHolder, error) { //nolint:fu
 	DefaultTimeout := 10 * time.Second
 	clientsHolder.RestConfig.Timeout = DefaultTimeout
 
-	clientsHolder.Coreclient, err = corev1client.NewForConfig(clientsHolder.RestConfig)
-	if err != nil {
-		return nil, fmt.Errorf("can't instantiate corev1client: %s", err)
-	}
-	clientsHolder.ClientConfig, err = clientconfigv1.NewForConfig(clientsHolder.RestConfig)
-	if err != nil {
-		return nil, fmt.Errorf("can't instantiate clientconfigv1: %s", err)
-	}
 	clientsHolder.DynamicClient, err = dynamic.NewForConfig(clientsHolder.RestConfig)
 	if err != nil {
 		return nil, fmt.Errorf("can't instantiate dynamic client (unstructured/dynamic): %s", err)
@@ -115,31 +112,20 @@ func newClientsHolder(filenames ...string) (*ClientsHolder, error) { //nolint:fu
 	if err != nil {
 		return nil, fmt.Errorf("can't instantiate apiextv1: %s", err)
 	}
-	clientsHolder.OlmClient, err = clientOlm.NewForConfig(clientsHolder.RestConfig)
+	clientsHolder.OlmClient, err = olmClient.NewForConfig(clientsHolder.RestConfig)
 	if err != nil {
 		return nil, fmt.Errorf("can't instantiate olm clientset: %s", err)
-	}
-	clientsHolder.AppsClients, err = appv1client.NewForConfig(clientsHolder.RestConfig)
-	if err != nil {
-		return nil, fmt.Errorf("can't instantiate appv1client: %s", err)
 	}
 	clientsHolder.K8sClient, err = kubernetes.NewForConfig(clientsHolder.RestConfig)
 	if err != nil {
 		return nil, fmt.Errorf("can't instantiate k8sclient: %s", err)
 	}
-	clientsHolder.K8sClientversion, err = kubernetes.NewForConfig(clientsHolder.RestConfig)
-	if err != nil {
-		return nil, fmt.Errorf("can't instantiate K8sClientversion: %s", err)
-	}
 	// create the oc client
-	clientsHolder.OClient, err = clientconfigv1.NewForConfig(clientsHolder.RestConfig)
+	clientsHolder.OcpClient, err = clientconfigv1.NewForConfig(clientsHolder.RestConfig)
 	if err != nil {
 		return nil, fmt.Errorf("can't instantiate ocClient: %s", err)
 	}
-	clientsHolder.StorageClient, err = storageclient.NewForConfig(clientsHolder.RestConfig)
-	if err != nil {
-		return nil, fmt.Errorf("can't instantiate csiClient: %s", err)
-	}
+
 	clientsHolder.ready = true
 	return &clientsHolder, nil
 }

--- a/internal/clientsholder/command.go
+++ b/internal/clientsholder/command.go
@@ -43,7 +43,7 @@ func (clientsholder *ClientsHolder) ExecCommandContainer(
 	var buffOut bytes.Buffer
 	var buffErr bytes.Buffer
 	logrus.Trace(fmt.Sprintf("execute commands on ns=%s, pod=%s container=%s", ctx.Namespace, ctx.Podname, ctx.Containername))
-	req := clientsholder.Coreclient.RESTClient().
+	req := clientsholder.K8sClient.CoreV1().RESTClient().
 		Post().
 		Namespace(ctx.Namespace).
 		Resource("pods").

--- a/pkg/autodiscover/autodiscover_operators.go
+++ b/pkg/autodiscover/autodiscover_operators.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func findOperatorsByLabel(olmClient *clientOlm.Clientset, labels []configuration.Label, namespaces []configuration.Namespace) []olmv1Alpha.ClusterServiceVersion {
+func findOperatorsByLabel(olmClient clientOlm.Interface, labels []configuration.Label, namespaces []configuration.Namespace) []olmv1Alpha.ClusterServiceVersion {
 	csvs := []olmv1Alpha.ClusterServiceVersion{}
 	for _, ns := range namespaces {
 		logrus.Debugf("Searching CSVs in namespace %s", ns)
@@ -54,7 +54,7 @@ func findOperatorsByLabel(olmClient *clientOlm.Clientset, labels []configuration
 
 	return csvs
 }
-func findSubscriptions(olmClient *clientOlm.Clientset, labels []configuration.Label, namespaces []string) []olmv1Alpha.Subscription {
+func findSubscriptions(olmClient clientOlm.Interface, labels []configuration.Label, namespaces []string) []olmv1Alpha.Subscription {
 	subscriptions := []olmv1Alpha.Subscription{}
 	for _, ns := range namespaces {
 		logrus.Debugf("Searching subscriptions in namespace %s", ns)

--- a/pkg/autodiscover/autodiscover_pods.go
+++ b/pkg/autodiscover/autodiscover_pods.go
@@ -26,7 +26,7 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-func findPodsByLabel(oc *corev1client.CoreV1Client,
+func findPodsByLabel(oc corev1client.CoreV1Interface,
 	labels []configuration.Label,
 	namespaces []string) []v1.Pod {
 	Pods := []v1.Pod{}

--- a/pkg/autodiscover/autodiscover_podset.go
+++ b/pkg/autodiscover/autodiscover_podset.go
@@ -28,7 +28,7 @@ import (
 	appv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 )
 
-func FindDeploymentByNameByNamespace(appClient *appv1client.AppsV1Client, namespace, name string) (*v1.Deployment, error) {
+func FindDeploymentByNameByNamespace(appClient appv1client.AppsV1Interface, namespace, name string) (*v1.Deployment, error) {
 	dpClient := appClient.Deployments(namespace)
 	options := metav1.GetOptions{}
 	dp, err := dpClient.Get(context.TODO(), name, options)
@@ -38,7 +38,7 @@ func FindDeploymentByNameByNamespace(appClient *appv1client.AppsV1Client, namesp
 	}
 	return dp, nil
 }
-func FindStatefulsetByNameByNamespace(appClient *appv1client.AppsV1Client, namespace, name string) (*v1.StatefulSet, error) {
+func FindStatefulsetByNameByNamespace(appClient appv1client.AppsV1Interface, namespace, name string) (*v1.StatefulSet, error) {
 	ssClient := appClient.StatefulSets(namespace)
 	ss, err := ssClient.Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
@@ -49,7 +49,7 @@ func FindStatefulsetByNameByNamespace(appClient *appv1client.AppsV1Client, names
 }
 
 func findDeploymentByLabel(
-	appClient *appv1client.AppsV1Client,
+	appClient appv1client.AppsV1Interface,
 	labels []configuration.Label,
 	namespaces []string,
 ) []v1.Deployment {
@@ -83,7 +83,7 @@ func findDeploymentByLabel(
 }
 
 func findStatefulSetByLabel(
-	appClient *appv1client.AppsV1Client,
+	appClient appv1client.AppsV1Interface,
 	labels []configuration.Label,
 	namespaces []string,
 ) []v1.StatefulSet {

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -186,7 +186,7 @@ func GetNodeJSON() (out map[string]interface{}) {
 // GetCsiDriver Gets the CSI driver list
 func GetCsiDriver() (out map[string]interface{}) {
 	o := clientsholder.GetClientsHolder()
-	csiDriver, err := o.StorageClient.CSIDrivers().List(context.TODO(), apimachineryv1.ListOptions{})
+	csiDriver, err := o.K8sClient.StorageV1().CSIDrivers().List(context.TODO(), apimachineryv1.ListOptions{})
 	if err != nil {
 		logrus.Errorf("Fail CSIDrivers.list err:%s", err)
 		return out

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -137,10 +137,10 @@ func GetContainer() *Container {
 	return &Container{}
 }
 
-func GetUpdatedDeployment(ac *appv1client.AppsV1Client, namespace, podName string) (*v1apps.Deployment, error) {
+func GetUpdatedDeployment(ac appv1client.AppsV1Interface, namespace, podName string) (*v1apps.Deployment, error) {
 	return autodiscover.FindDeploymentByNameByNamespace(ac, namespace, podName)
 }
-func GetUpdatedStatefulset(ac *appv1client.AppsV1Client, namespace, podName string) (*v1apps.StatefulSet, error) {
+func GetUpdatedStatefulset(ac appv1client.AppsV1Interface, namespace, podName string) (*v1apps.StatefulSet, error) {
 	return autodiscover.FindStatefulsetByNameByNamespace(ac, namespace, podName)
 }
 
@@ -277,7 +277,7 @@ func IsinstalledCsv(csv *olmv1Alpha.ClusterServiceVersion, subscriptions []olmv1
 func WaitDebugPodReady() {
 	oc := clientsholder.GetClientsHolder()
 	listOptions := metav1.ListOptions{}
-	nodes, err := oc.Coreclient.Nodes().List(context.TODO(), listOptions)
+	nodes, err := oc.K8sClient.CoreV1().Nodes().List(context.TODO(), listOptions)
 
 	if err != nil {
 		logrus.Fatalf("Error getting node list, err:%s", err)
@@ -289,7 +289,7 @@ func WaitDebugPodReady() {
 	isReady := false
 	start := time.Now()
 	for !isReady && time.Since(start) < timeout {
-		daemonSet, err := oc.AppsClients.DaemonSets(daemonSetNamespace).Get(context.TODO(), daemonSetName, getOptions)
+		daemonSet, err := oc.K8sClient.AppsV1().DaemonSets(daemonSetNamespace).Get(context.TODO(), daemonSetName, getOptions)
 		if err != nil && daemonSet != nil {
 			logrus.Fatal("Error getting Daemonset, please create debug daemonset")
 		}


### PR DESCRIPTION
All the interfaces for k8s can be found under the same k8sClient, so
there's no need to add separate fields for them. Also, OClient renamed to OcpClient.