### PR TITLE
Remove 'goexpect' from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/test-network-function/cnf-certification-test
 
 go 1.17
 
-replace github.com/google/goexpect => github.com/test-network-function/goexpect v0.0.1
-
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/basgys/goxml2json v1.1.0


### PR DESCRIPTION
`goexpect` is no longer used in our repo.  It's a leftover from the old repo that isn't needed anymore.