### PR TITLE
Minor changes in the createOperators() function plus UTs.

### DIFF
--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -17,6 +17,7 @@
 package provider
 
 import (
+	"fmt"
 	"testing"
 
 	"errors"
@@ -24,7 +25,66 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 
+	olmv1Alpha "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	olmFakeClient "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
 	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sTesting "k8s.io/client-go/testing"
+)
+
+var (
+	// All this catalogSources and installPlans are used by more than one unit test, so make sure
+	// you fully understand them before changing these values.
+	// They define runtime objects for 2 CSVs "op1.v1.0.1" and "op2.v2.0.2" that are installed in
+	// namespaces ns1 (op1) and ns2 (op1 + op2). So there's one catalogSource + installPlan for
+	// each installation. Subscriptions and CSVs are only needed by TestCreateOperators, so they're
+	// defined there only.
+	catalogSource1 = olmv1Alpha.CatalogSource{
+		TypeMeta:   metav1.TypeMeta{Kind: "CatalogSource"},
+		ObjectMeta: metav1.ObjectMeta{Name: "catalogSource1", Namespace: "ns1"},
+		Spec:       olmv1Alpha.CatalogSourceSpec{Image: "catalogSource1Image"},
+		Status:     olmv1Alpha.CatalogSourceStatus{},
+	}
+
+	catalogSource2 = olmv1Alpha.CatalogSource{
+		TypeMeta:   metav1.TypeMeta{Kind: "CatalogSource"},
+		ObjectMeta: metav1.ObjectMeta{Name: "catalogSource2", Namespace: "ns2"},
+		Spec:       olmv1Alpha.CatalogSourceSpec{Image: "catalogSource2Image"},
+		Status:     olmv1Alpha.CatalogSourceStatus{},
+	}
+
+	catalogSource3 = olmv1Alpha.CatalogSource{
+		TypeMeta:   metav1.TypeMeta{Kind: "CatalogSource"},
+		ObjectMeta: metav1.ObjectMeta{Name: "catalogSource3", Namespace: "ns2"},
+		Spec:       olmv1Alpha.CatalogSourceSpec{Image: "catalogSource3Image"},
+		Status:     olmv1Alpha.CatalogSourceStatus{},
+	}
+
+	ns1InstallPlan1 = olmv1Alpha.InstallPlan{
+		TypeMeta: metav1.TypeMeta{Kind: "InstallPlan"}, ObjectMeta: metav1.ObjectMeta{Name: "ns1Plan1", Namespace: "ns1"},
+		Spec: olmv1Alpha.InstallPlanSpec{CatalogSource: "catalogSource1", CatalogSourceNamespace: "ns1",
+			ClusterServiceVersionNames: []string{"op1.v1.0.1"}, Approval: olmv1Alpha.ApprovalAutomatic, Approved: true},
+		Status: olmv1Alpha.InstallPlanStatus{BundleLookups: []olmv1Alpha.BundleLookup{{Path: "lookuppath1",
+			CatalogSourceRef: &v1.ObjectReference{Name: "catalogSource1", Namespace: "ns1"}}}},
+	}
+
+	ns2InstallPlan1 = olmv1Alpha.InstallPlan{
+		TypeMeta: metav1.TypeMeta{Kind: "InstallPlan"}, ObjectMeta: metav1.ObjectMeta{Name: "ns2Plan1", Namespace: "ns2"},
+		Spec: olmv1Alpha.InstallPlanSpec{CatalogSource: "catalogSource2", CatalogSourceNamespace: "ns2",
+			ClusterServiceVersionNames: []string{"op1.v1.0.1"}, Approval: olmv1Alpha.ApprovalAutomatic, Approved: true},
+		Status: olmv1Alpha.InstallPlanStatus{BundleLookups: []olmv1Alpha.BundleLookup{{Path: "lookuppath2",
+			CatalogSourceRef: &v1.ObjectReference{Name: "catalogSource2", Namespace: "ns2"}}}},
+	}
+
+	ns2InstallPlan2 = olmv1Alpha.InstallPlan{
+		TypeMeta: metav1.TypeMeta{Kind: "InstallPlan"}, ObjectMeta: metav1.ObjectMeta{Name: "ns2Plan2", Namespace: "ns2"},
+		Spec: olmv1Alpha.InstallPlanSpec{CatalogSource: "catalogSource3", CatalogSourceNamespace: "ns2",
+			ClusterServiceVersionNames: []string{"op2.v2.0.2"}, Approval: olmv1Alpha.ApprovalAutomatic, Approved: true},
+		Status: olmv1Alpha.InstallPlanStatus{BundleLookups: []olmv1Alpha.BundleLookup{{Path: "lookuppath3",
+			CatalogSourceRef: &v1.ObjectReference{Name: "catalogSource3", Namespace: "ns2"}}}},
+	}
 )
 
 func Test_isDaemonSetReady(t *testing.T) {
@@ -103,5 +163,453 @@ func TestGetUID(t *testing.T) {
 		uid, err := c.GetUID()
 		assert.Equal(t, tc.expectedErr, err)
 		assert.Equal(t, tc.expectedUID, uid)
+	}
+}
+
+func loadAllOlmRuntimeTestObjects() {
+	loadCustomOlmRuntimeTestObjects(&ns1InstallPlan1, &ns2InstallPlan1, &ns2InstallPlan2,
+		&catalogSource1, &catalogSource2, &catalogSource3)
+}
+
+func loadCustomOlmRuntimeTestObjects(olmObjects ...runtime.Object) {
+	_ = clientsholder.GetTestClientsHolder(nil)
+
+	clientsholder.SetupFakeOlmClient(olmObjects)
+}
+
+//nolint:funlen
+func TestGetInstallPlansInNamespace(t *testing.T) {
+	fakeErrorReactionFn := func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf("fake error")
+	}
+
+	testCases := []struct {
+		namespace                   string
+		useErrorReactionFn          bool
+		expectedNsInstallplans      []olmv1Alpha.InstallPlan
+		expectedClusterInstallPlans map[string][]olmv1Alpha.InstallPlan
+		expectedErrorStr            string
+	}{
+		{
+			namespace:              "ns1",
+			expectedNsInstallplans: []olmv1Alpha.InstallPlan{ns1InstallPlan1},
+			expectedClusterInstallPlans: map[string][]olmv1Alpha.InstallPlan{
+				"ns1": {ns1InstallPlan1},
+			},
+		},
+		{
+			namespace:              "ns2",
+			expectedNsInstallplans: []olmv1Alpha.InstallPlan{ns2InstallPlan1, ns2InstallPlan2},
+			expectedClusterInstallPlans: map[string][]olmv1Alpha.InstallPlan{
+				"ns1": {ns1InstallPlan1},
+				"ns2": {ns2InstallPlan1, ns2InstallPlan2},
+			},
+		},
+		{
+			namespace:              "ns3",
+			useErrorReactionFn:     true,
+			expectedNsInstallplans: []olmv1Alpha.InstallPlan{},
+			expectedClusterInstallPlans: map[string][]olmv1Alpha.InstallPlan{
+				"ns1": {ns1InstallPlan1},
+				"ns2": {ns2InstallPlan1, ns2InstallPlan2},
+			},
+			expectedErrorStr: "unable get installplans in namespace ns3, err: fake error",
+		},
+	}
+
+	clusterInstallPlans := map[string][]olmv1Alpha.InstallPlan{}
+	for _, tc := range testCases {
+		loadAllOlmRuntimeTestObjects()
+		// In case the TC needs a particular set of olm runtime objects:
+		if tc.useErrorReactionFn {
+			oc := clientsholder.GetClientsHolder()
+			oc.OlmClient.(*olmFakeClient.Clientset).PrependReactor("list", "installplans", fakeErrorReactionFn)
+		}
+
+		installPlans, err := getInstallPlansInNamespace(tc.namespace, clusterInstallPlans)
+		if tc.expectedErrorStr == "" {
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expectedNsInstallplans, installPlans)
+			assert.Equal(t, tc.expectedClusterInstallPlans, clusterInstallPlans)
+		} else {
+			assert.NotNil(t, err)
+			assert.Equal(t, errors.New(tc.expectedErrorStr), err)
+		}
+	}
+}
+
+//nolint:funlen
+func TestGetCsvInstallPlans(t *testing.T) {
+	loadAllOlmRuntimeTestObjects()
+
+	op4InstallPlan1 := olmv1Alpha.InstallPlan{
+		TypeMeta:   metav1.TypeMeta{Kind: "InstallPlan"},
+		ObjectMeta: metav1.ObjectMeta{Name: "installPlan1", Namespace: "ns4"},
+		Spec:       olmv1Alpha.InstallPlanSpec{ClusterServiceVersionNames: []string{"op4.v4.0.4"}},
+		Status: olmv1Alpha.InstallPlanStatus{BundleLookups: []olmv1Alpha.BundleLookup{{Path: "lookuppath1",
+			CatalogSourceRef: &v1.ObjectReference{Name: "catalogSource1", Namespace: "ns4"}}}},
+	}
+	op4InstallPlan2 := op4InstallPlan1
+	op4InstallPlan2.ObjectMeta.Name = "installPlan2"
+
+	testCases := []struct {
+		namespace            string
+		csv                  string
+		olmObjects           []runtime.Object
+		expectedInstallPlans []*olmv1Alpha.InstallPlan
+		expectedErrorFmt     string
+	}{
+		{
+			namespace:            "ns1",
+			csv:                  "op1.v1.0.1",
+			expectedInstallPlans: []*olmv1Alpha.InstallPlan{&ns1InstallPlan1},
+		},
+		{
+			namespace:            "ns2",
+			csv:                  "op1.v1.0.1",
+			expectedInstallPlans: []*olmv1Alpha.InstallPlan{&ns2InstallPlan1},
+		},
+		{
+			namespace:            "ns2",
+			csv:                  "op2.v2.0.2",
+			expectedInstallPlans: []*olmv1Alpha.InstallPlan{&ns2InstallPlan2},
+		},
+		{
+			namespace:            "ns1",
+			csv:                  "csv2",
+			expectedInstallPlans: nil,
+			expectedErrorFmt:     "no installplans found for csv %s (ns %s)",
+		},
+		// Operator with a "bad" install plan.
+		{
+			namespace: "ns3",
+			csv:       "op3.v3.0.3",
+			olmObjects: []runtime.Object{
+				&olmv1Alpha.InstallPlan{
+					TypeMeta:   metav1.TypeMeta{Kind: "InstallPlan"},
+					ObjectMeta: metav1.ObjectMeta{Name: "badInstallPlan", Namespace: "ns3"},
+					Spec:       olmv1Alpha.InstallPlanSpec{ClusterServiceVersionNames: []string{"op3.v3.0.3"}},
+					// This installPlan won't be retrieved as it lacks of the bundle lookups info in the status field.
+					Status: olmv1Alpha.InstallPlanStatus{},
+				},
+			},
+			expectedInstallPlans: nil,
+			expectedErrorFmt:     "no installplans found for csv %s (ns %s)",
+		},
+		// Two intallPlans for the same csv, in a new namespace.
+		{
+			namespace:            "ns4",
+			csv:                  "op4.v4.0.4",
+			olmObjects:           []runtime.Object{&op4InstallPlan1, &op4InstallPlan2},
+			expectedInstallPlans: []*olmv1Alpha.InstallPlan{&op4InstallPlan1, &op4InstallPlan2},
+			expectedErrorFmt:     "",
+		},
+	}
+
+	clusterInstallPlans := map[string][]olmv1Alpha.InstallPlan{}
+	for _, tc := range testCases {
+		// In case the TC needs a particular set of olm runtime objects:
+		if tc.olmObjects != nil {
+			loadCustomOlmRuntimeTestObjects(tc.olmObjects...)
+		} else {
+			loadAllOlmRuntimeTestObjects()
+		}
+		installPlans, err := getCsvInstallPlans(tc.namespace, tc.csv, clusterInstallPlans)
+		assert.Equal(t, tc.expectedInstallPlans, installPlans)
+		if tc.expectedErrorFmt == "" {
+			assert.Nil(t, err)
+		} else {
+			assert.NotNil(t, err)
+			assert.Equal(t, err, fmt.Errorf(tc.expectedErrorFmt, tc.csv, tc.namespace))
+		}
+	}
+}
+
+func TestGetCatalogSourceImageIndexFromInstallPlan(t *testing.T) {
+	loadAllOlmRuntimeTestObjects()
+
+	testCases := []struct {
+		installPlan        *olmv1Alpha.InstallPlan
+		expectedImageIndex string
+		expectedErrorStr   string
+	}{
+		{
+			installPlan:        &ns1InstallPlan1,
+			expectedImageIndex: "catalogSource1Image",
+		},
+		{
+			installPlan:        &ns2InstallPlan1,
+			expectedImageIndex: "catalogSource2Image",
+		},
+		{
+			installPlan:        &ns2InstallPlan2,
+			expectedImageIndex: "catalogSource3Image",
+		},
+		{
+			installPlan: &olmv1Alpha.InstallPlan{
+				Status: olmv1Alpha.InstallPlanStatus{
+					BundleLookups: []olmv1Alpha.BundleLookup{
+						{Path: "path", CatalogSourceRef: &v1.ObjectReference{Name: "catalogName", Namespace: "notExistingNamespace"}}}},
+			},
+			expectedImageIndex: "",
+			expectedErrorStr:   "failed to get catalogsource: catalogsources.operators.coreos.com \"catalogName\" not found",
+		},
+	}
+
+	for _, tc := range testCases {
+		imageIndex, err := getCatalogSourceImageIndexFromInstallPlan(tc.installPlan)
+		assert.Equal(t, tc.expectedImageIndex, imageIndex)
+		if tc.expectedErrorStr == "" {
+			assert.Nil(t, err)
+		} else {
+			assert.NotNil(t, err)
+			assert.Equal(t, err, errors.New(tc.expectedErrorStr))
+		}
+	}
+}
+
+//nolint:funlen
+func TestCreateOperators(t *testing.T) {
+	// op1 in namespace ns1
+	op1Ns1 := olmv1Alpha.ClusterServiceVersion{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterServiceVersion"},
+		ObjectMeta: metav1.ObjectMeta{Name: "op1.v1.0.1", Namespace: "ns1"},
+	}
+
+	// op1 in namespace ns2
+	op1Ns2 := olmv1Alpha.ClusterServiceVersion{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterServiceVersion"},
+		ObjectMeta: metav1.ObjectMeta{Name: "op1.v1.0.1", Namespace: "ns2"},
+	}
+
+	// op2 in namespace ns2
+	op2Ns2 := olmv1Alpha.ClusterServiceVersion{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterServiceVersion"},
+		ObjectMeta: metav1.ObjectMeta{Name: "op2.v2.0.2", Namespace: "ns2"},
+	}
+
+	subscription1 := olmv1Alpha.Subscription{
+		TypeMeta:   metav1.TypeMeta{Kind: "Subscription"},
+		ObjectMeta: metav1.ObjectMeta{Name: "subs1", Namespace: "ns1"},
+		Spec:       &olmv1Alpha.SubscriptionSpec{Package: "op1", CatalogSource: "catalogSource1"},
+		Status:     olmv1Alpha.SubscriptionStatus{InstalledCSV: "op1.v1.0.1"},
+	}
+
+	subscription2 := olmv1Alpha.Subscription{
+		TypeMeta:   metav1.TypeMeta{Kind: "Subscription"},
+		ObjectMeta: metav1.ObjectMeta{Name: "subs2", Namespace: "ns2"},
+		Spec:       &olmv1Alpha.SubscriptionSpec{Package: "op1", CatalogSource: "catalogSource2"},
+		Status:     olmv1Alpha.SubscriptionStatus{InstalledCSV: "op1.v1.0.1"},
+	}
+
+	subscription3 := olmv1Alpha.Subscription{
+		TypeMeta:   metav1.TypeMeta{Kind: "Subscription"},
+		ObjectMeta: metav1.ObjectMeta{Name: "subs3", Namespace: "ns2"},
+		Spec:       &olmv1Alpha.SubscriptionSpec{Package: "op2", CatalogSource: "catalogSource3"},
+		Status:     olmv1Alpha.SubscriptionStatus{InstalledCSV: "op2.v2.0.2"},
+	}
+
+	testCases := []struct {
+		csvs              []olmv1Alpha.ClusterServiceVersion
+		subscriptions     []olmv1Alpha.Subscription
+		olmObjects        []runtime.Object
+		expectedOperators []Operator
+		expectedErrorStr  string
+	}{
+		{
+			csvs:              []olmv1Alpha.ClusterServiceVersion{},
+			subscriptions:     []olmv1Alpha.Subscription{subscription1},
+			expectedOperators: []Operator{},
+			expectedErrorStr:  "",
+		},
+		// ns1: csv1/subs1
+		{
+			csvs:          []olmv1Alpha.ClusterServiceVersion{op1Ns1},
+			subscriptions: []olmv1Alpha.Subscription{subscription1},
+			expectedOperators: []Operator{
+				{
+					Name:             "op1.v1.0.1",
+					Namespace:        "ns1",
+					Csv:              &op1Ns1,
+					SubscriptionName: "subs1",
+					InstallPlans: []CsvInstallPlan{
+						{
+							Name:        "ns1Plan1",
+							BundleImage: "lookuppath1",
+							IndexImage:  "catalogSource1Image",
+						},
+					},
+					Package: "op1",
+					Org:     "catalogSource1",
+					Version: "v1.0.1",
+				},
+			},
+		},
+		// ns1: csv1/subs1 - installPlan not found.
+		{
+			csvs:              []olmv1Alpha.ClusterServiceVersion{op1Ns1},
+			subscriptions:     []olmv1Alpha.Subscription{subscription1},
+			olmObjects:        make([]runtime.Object, 0),
+			expectedOperators: nil,
+			expectedErrorStr:  "failed to get installPlans for csv op1.v1.0.1 (ns ns1), err: no installplans found for csv op1.v1.0.1 (ns ns1)",
+		},
+		// ns1: csv1/subs1 - bundleImage not found.
+		{
+			csvs:              []olmv1Alpha.ClusterServiceVersion{op1Ns1},
+			subscriptions:     []olmv1Alpha.Subscription{subscription1},
+			olmObjects:        []runtime.Object{&ns1InstallPlan1},
+			expectedOperators: nil,
+			expectedErrorStr:  "failed to get installPlan image index for csv op1.v1.0.1 (ns ns1) installPlan ns1Plan1, err: failed to get catalogsource: catalogsources.operators.coreos.com \"catalogSource1\" not found",
+		},
+		// ns1: csv1/subs1, ns2: csv2 (without subscription)
+		{
+			csvs:          []olmv1Alpha.ClusterServiceVersion{op1Ns1, op1Ns2},
+			subscriptions: []olmv1Alpha.Subscription{subscription1},
+			expectedOperators: []Operator{
+				{
+					Name:             "op1.v1.0.1",
+					Namespace:        "ns1",
+					Csv:              &op1Ns1,
+					SubscriptionName: "subs1",
+					InstallPlans: []CsvInstallPlan{
+						{
+							Name:        "ns1Plan1",
+							BundleImage: "lookuppath1",
+							IndexImage:  "catalogSource1Image",
+						},
+					},
+					Package: "op1",
+					Org:     "catalogSource1",
+					Version: "v1.0.1",
+				},
+				{
+					Name:             "op1.v1.0.1",
+					Namespace:        "ns2",
+					Csv:              &op1Ns2,
+					SubscriptionName: "",
+					InstallPlans: []CsvInstallPlan{
+						{
+							Name:        "ns2Plan1",
+							BundleImage: "lookuppath2",
+							IndexImage:  "catalogSource2Image",
+						},
+					},
+					Package: "",
+					Version: "v1.0.1",
+				},
+			},
+		},
+		// ns1: csv1/subs1, ns2: csv2/subs2
+		{
+			csvs:          []olmv1Alpha.ClusterServiceVersion{op1Ns1, op1Ns2},
+			subscriptions: []olmv1Alpha.Subscription{subscription1, subscription2},
+			expectedOperators: []Operator{
+				{
+					Name:             "op1.v1.0.1",
+					Namespace:        "ns1",
+					Csv:              &op1Ns1,
+					SubscriptionName: "subs1",
+					InstallPlans: []CsvInstallPlan{
+						{
+							Name:        "ns1Plan1",
+							BundleImage: "lookuppath1",
+							IndexImage:  "catalogSource1Image",
+						},
+					},
+					Package: "op1",
+					Org:     "catalogSource1",
+					Version: "v1.0.1",
+				},
+				{
+					Name:             "op1.v1.0.1",
+					Namespace:        "ns2",
+					Csv:              &op1Ns2,
+					SubscriptionName: "subs2",
+					InstallPlans: []CsvInstallPlan{
+						{
+							Name:        "ns2Plan1",
+							BundleImage: "lookuppath2",
+							IndexImage:  "catalogSource2Image",
+						},
+					},
+					Package: "op1",
+					Org:     "catalogSource2",
+					Version: "v1.0.1",
+				},
+			},
+		},
+		// ns1: csv1/subs1, ns2: csv2/subs2 + csv3/subs3
+		{
+			csvs:          []olmv1Alpha.ClusterServiceVersion{op1Ns1, op1Ns2, op2Ns2},
+			subscriptions: []olmv1Alpha.Subscription{subscription1, subscription2, subscription3},
+			expectedOperators: []Operator{
+				{
+					Name:             "op1.v1.0.1",
+					Namespace:        "ns1",
+					Csv:              &op1Ns1,
+					SubscriptionName: "subs1",
+					InstallPlans: []CsvInstallPlan{
+						{
+							Name:        "ns1Plan1",
+							BundleImage: "lookuppath1",
+							IndexImage:  "catalogSource1Image",
+						},
+					},
+					Package: "op1",
+					Org:     "catalogSource1",
+					Version: "v1.0.1",
+				},
+				{
+					Name:             "op1.v1.0.1",
+					Namespace:        "ns2",
+					Csv:              &op1Ns2,
+					SubscriptionName: "subs2",
+					InstallPlans: []CsvInstallPlan{
+						{
+							Name:        "ns2Plan1",
+							BundleImage: "lookuppath2",
+							IndexImage:  "catalogSource2Image",
+						},
+					},
+					Package: "op1",
+					Org:     "catalogSource2",
+					Version: "v1.0.1",
+				},
+				{
+					Name:             "op2.v2.0.2",
+					Namespace:        "ns2",
+					Csv:              &op2Ns2,
+					SubscriptionName: "subs3",
+					InstallPlans: []CsvInstallPlan{
+						{
+							Name:        "ns2Plan2",
+							BundleImage: "lookuppath3",
+							IndexImage:  "catalogSource3Image",
+						},
+					},
+					Package: "op2",
+					Org:     "catalogSource3",
+					Version: "v2.0.2",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		// In case the TC needs a particular set of olm runtime objects:
+		if tc.olmObjects != nil {
+			loadCustomOlmRuntimeTestObjects(tc.olmObjects...)
+		} else {
+			loadAllOlmRuntimeTestObjects()
+		}
+
+		ops, err := createOperators(tc.csvs, tc.subscriptions)
+		assert.Equal(t, tc.expectedOperators, ops)
+		if tc.expectedErrorStr == "" {
+			assert.Nil(t, err)
+		} else {
+			assert.NotNil(t, err)
+			assert.Equal(t, errors.New(tc.expectedErrorStr), err)
+		}
 	}
 }


### PR DESCRIPTION
1. Filter csv subscriptiosn based on namespace.
2. I've separated the retrieval of the subscription info from the installPlans.
   They should be related, as installPlans are automatically created by OLM
   once a subscription is created, but it's technically (but not
   recommended) possible to install CSV by hand without using
   subscriptions.

Also, added all unit tests for the csv related functions of the provider
package.