### PR TITLE
Switch back to using singleton clientsHolder

### DIFF
--- a/cnf-certification-test/accesscontrol/rbac/automount_test.go
+++ b/cnf-certification-test/accesscontrol/rbac/automount_test.go
@@ -80,16 +80,15 @@ func TestAutomountServiceAccountSetOnSA(t *testing.T) {
 		var testRuntimeObjects []runtime.Object
 		testRuntimeObjects = append(testRuntimeObjects, &testSA)
 
-		obj := NewAutomountTokenTester(clientsholder.GetTestClientsHolder(testRuntimeObjects))
-		assert.NotNil(t, obj)
-		isSet, err := obj.AutomountServiceAccountSetOnSA("testSA", "podNS")
+		_ = clientsholder.GetTestClientsHolder(testRuntimeObjects)
+		isSet, err := AutomountServiceAccountSetOnSA("testSA", "podNS")
 		assert.Nil(t, err)
 		assert.Equal(t, tc.automountServiceTokenSet, *isSet)
 	}
 }
 
 //nolint:funlen
-func TestEvaluateTokens(t *testing.T) {
+func TestEvaluateAutomountTokens(t *testing.T) {
 	falseVar := false
 	trueVar := true
 
@@ -140,8 +139,8 @@ func TestEvaluateTokens(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		at := NewAutomountTokenTester(clientsholder.GetTestClientsHolder(buildServiceAccountTokenTestObjects()))
-		podPassed, msg := at.EvaluateTokens(tc.testPod)
+		_ = clientsholder.GetTestClientsHolder(buildServiceAccountTokenTestObjects())
+		podPassed, msg := EvaluateAutomountTokens(tc.testPod)
 		assert.Equal(t, tc.expectedMsg, msg)
 		assert.Equal(t, tc.expectedResult, podPassed)
 	}

--- a/cnf-certification-test/accesscontrol/rbac/clusterrolebinding_test.go
+++ b/cnf-certification-test/accesscontrol/rbac/clusterrolebinding_test.go
@@ -24,9 +24,8 @@ import (
 )
 
 func TestGetClusterRoleBinding(t *testing.T) {
-	rb := NewClusterRoleBindingTester("testCR", "podNS", clientsholder.GetTestClientsHolder(buildTestObjects()))
-	assert.NotNil(t, rb)
-	gatheredCRBs, err := rb.GetClusterRoleBindings()
+	_ = clientsholder.GetTestClientsHolder(buildTestObjects())
+	gatheredCRBs, err := GetClusterRoleBindings("testCR", "podNS")
 	assert.Nil(t, err)
 	assert.Equal(t, "testNS:testCR", gatheredCRBs[0])
 }

--- a/cnf-certification-test/accesscontrol/rbac/rolebinding.go
+++ b/cnf-certification-test/accesscontrol/rbac/rolebinding.go
@@ -24,31 +24,11 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type RoleBindingFuncs interface {
-	GetRoleBindings(podNamespace, serviceAccountName string) ([]string, error)
-}
-
-// RoleBinding holds information derived from running "oc get rolebindings" on the command line.
-type RoleBinding struct {
-	ClientHolder *clientsholder.ClientsHolder
-}
-
-// NewRoleBindingTester creates a new RoleBinding object
-func NewRoleBindingTester(ch *clientsholder.ClientsHolder) *RoleBinding {
-	// Just as a note, the old test suite ran the following command to help determine service accounts that fell outside of the pod's namespace:
-	// oc get rolebindings --all-namespaces -o custom-columns='NAMESPACE:metadata.namespace,NAME:metadata.name,SERVICE_ACCOUNTS:subjects[?(@.kind=="ServiceAccount")]' | grep -E '` + serviceAccountSubString + `|SERVICE_ACCOUNTS'
-
-	rbt := &RoleBinding{
-		ClientHolder: ch,
-	}
-
-	return rbt
-}
-
 // GetRoleBindings returns any role bindings extracted from the desired pod.
-func (rb *RoleBinding) GetRoleBindings(podNamespace, serviceAccountName string) ([]string, error) {
+func GetRoleBindings(podNamespace, serviceAccountName string) ([]string, error) {
 	// Get all of the rolebindings from all namespaces.
-	roleList, roleErr := rb.ClientHolder.K8sClient.RbacV1().Roles("").List(context.TODO(), v1.ListOptions{})
+	clientsHolder := clientsholder.GetClientsHolder()
+	roleList, roleErr := clientsHolder.K8sClient.RbacV1().Roles("").List(context.TODO(), v1.ListOptions{})
 	if roleErr != nil {
 		logrus.Errorf("executing rolebinding command failed with error: %s", roleErr)
 		return nil, roleErr

--- a/cnf-certification-test/accesscontrol/rbac/rolebinding_test.go
+++ b/cnf-certification-test/accesscontrol/rbac/rolebinding_test.go
@@ -24,9 +24,8 @@ import (
 )
 
 func TestGetRoleBinding(t *testing.T) {
-	rb := NewRoleBindingTester(clientsholder.GetTestClientsHolder(buildTestObjects()))
-	assert.NotNil(t, rb)
-	gatheredRBs, err := rb.GetRoleBindings("podNS", "testRole")
+	_ = clientsholder.GetTestClientsHolder(buildTestObjects())
+	gatheredRBs, err := GetRoleBindings("podNS", "testRole")
 	assert.Nil(t, err)
 	assert.Equal(t, "testNS:testRole", gatheredRBs[0])
 }


### PR DESCRIPTION
Similar to: #81 

Removed all of the remaining structs for access-control's tests that were still building their own structs/copies of the clientsHolder and switched them to using the clientsHolder singleton per suggestion from @greyerof.