### PR TITLE
Claim file: avoid dumping k8s/ocp versions in the configuration field.

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -98,9 +98,9 @@ type TestEnvironment struct { // rename this with testTarget
 	HorizontalScaler  map[string]*v1scaling.HorizontalPodAutoscaler `json:"testHorizontalScaler"`
 	Nodes             *v1.NodeList                                  `json:"-"`
 	Subscriptions     []*olmv1Alpha.Subscription                    `json:"testSubscriptions"`
-	K8sVersion        string
-	OpenshiftVersion  string
-	HelmChartReleases []*release.Release `json:"testHelmChartReleases"`
+	K8sVersion        string                                        `json:"-"`
+	OpenshiftVersion  string                                        `json:"-"`
+	HelmChartReleases []*release.Release                            `json:"testHelmChartReleases"`
 }
 
 type CsvInstallPlan struct {


### PR DESCRIPTION
The configuration field does not need to have the k8s/ocp versions as
this information is already dumped in the "versions" field at the end of
the claim file.