### PR TITLE
Wait for all the debug pods to be ready before autodiscovery starts.

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -50,7 +50,6 @@ var _ = ginkgo.Describe(common.AccessControlTestKey, func() {
 	var env provider.TestEnvironment
 	ginkgo.BeforeEach(func() {
 		env = provider.GetTestEnvironment()
-		provider.WaitDebugPodReady()
 	})
 	ginkgo.ReportAfterEach(results.RecordResult)
 

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -52,7 +52,6 @@ var _ = ginkgo.Describe(common.NetworkingTestKey, func() {
 	var env provider.TestEnvironment
 	ginkgo.BeforeEach(func() {
 		env = provider.GetTestEnvironment()
-		provider.WaitDebugPodReady()
 	})
 	ginkgo.ReportAfterEach(results.RecordResult)
 	// Default interface ICMP IPv4 test case

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -46,7 +46,6 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 	var env provider.TestEnvironment
 	ginkgo.BeforeEach(func() {
 		env = provider.GetTestEnvironment()
-		provider.WaitDebugPodReady()
 	})
 	ginkgo.ReportAfterEach(results.RecordResult)
 

--- a/cnf-certification-test/suite_test.go
+++ b/cnf-certification-test/suite_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/results"
+	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
+	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 	"github.com/test-network-function/cnf-certification-test/pkg/junit"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
 	"github.com/test-network-function/test-network-function-claim/pkg/claim"
@@ -134,6 +136,32 @@ func SetLogFormat() {
 	log.SetLevel(log.TraceLevel)
 }
 
+func getK8sClientsConfigFileNames() []string {
+	params := configuration.GetTestParameters()
+	fileNames := []string{}
+	if params.Kubeconfig != "" {
+		fileNames = append(fileNames, params.Kubeconfig)
+	}
+	if params.Home != "" {
+		kubeConfigFilePath := filepath.Join(params.Home, ".kube", "config")
+		fileNames = append(fileNames, kubeConfigFilePath)
+	}
+
+	return fileNames
+}
+
+// getGitVersion returns the git display version: the latest previously released
+// build in case this build is not released. Otherwise display the build version
+func getGitVersion() string {
+	if GitRelease == "" {
+		gitDisplayRelease = "Unreleased build post " + GitPreviousRelease
+	} else {
+		gitDisplayRelease = GitRelease
+	}
+
+	return gitDisplayRelease + " ( " + GitCommit + " )"
+}
+
 //nolint:funlen // TestTest invokes the CNF Certification Test Suite.
 func TestTest(t *testing.T) {
 	// When running unit tests, skip the suite
@@ -142,6 +170,8 @@ func TestTest(t *testing.T) {
 	}
 
 	ginkgoConfig, _ := ginkgo.GinkgoConfiguration()
+	log.Infof("TNF Version         : %v", getGitVersion())
+	log.Infof("Ginkgo Version      : %v", ginkgo.GINKGO_VERSION)
 	log.Infof("Focused test suites : %v", ginkgoConfig.FocusStrings)
 	log.Infof("TC skip patterns    : %v", ginkgoConfig.SkipStrings)
 	log.Infof("Labels filter       : %v", ginkgoConfig.LabelFilter)
@@ -150,17 +180,12 @@ func TestTest(t *testing.T) {
 	diagnosticMode := len(ginkgoConfig.FocusStrings) == 0
 
 	gomega.RegisterFailHandler(ginkgo.Fail)
-	// Display GinkGo Version
-	log.Info("Ginkgo Version: ", ginkgo.GINKGO_VERSION)
-	// Display the latest previously released build in case this build is not released
-	// Otherwise display the build version
-	if GitRelease == "" {
-		gitDisplayRelease = "Unreleased build post " + GitPreviousRelease
-	} else {
-		gitDisplayRelease = GitRelease
-	}
-	log.Info("Version: ", gitDisplayRelease, " ( ", GitCommit, " )")
+
 	SetLogFormat()
+
+	// Set clientsholder singletone with the filenames from the env vars.
+	_ = clientsholder.GetClientsHolder(getK8sClientsConfigFileNames()...)
+
 	// Initialize the claim with the start time, tnf version, etc.
 	claimRoot := createClaimRoot()
 	claimData := claimRoot.Claim

--- a/cnf-certification-test/suite_test.go
+++ b/cnf-certification-test/suite_test.go
@@ -183,7 +183,7 @@ func TestTest(t *testing.T) {
 
 	SetLogFormat()
 
-	// Set clientsholder singletone with the filenames from the env vars.
+	// Set clientsholder singleton with the filenames from the env vars.
 	_ = clientsholder.GetClientsHolder(getK8sClientsConfigFileNames()...)
 
 	// Initialize the claim with the start time, tnf version, etc.

--- a/internal/clientsholder/command.go
+++ b/internal/clientsholder/command.go
@@ -19,6 +19,7 @@ package clientsholder
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -43,7 +44,7 @@ func (clientsholder *ClientsHolder) ExecCommandContainer(
 	commandStr := []string{"sh", "-c", command}
 	var buffOut bytes.Buffer
 	var buffErr bytes.Buffer
-	logrus.Trace(fmt.Sprintf("execute commands on ns=%s, pod=%s container=%s", ctx.Namespace, ctx.Podname, ctx.Containername))
+	logrus.Trace(fmt.Sprintf("execute command on ns=%s, pod=%s container=%s, cmd: %s", ctx.Namespace, ctx.Podname, ctx.Containername, strings.Join(commandStr, " ")))
 	req := clientsholder.K8sClient.CoreV1().RESTClient().
 		Post().
 		Namespace(ctx.Namespace).

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -88,16 +88,13 @@ func buildLabelKeyValue(label configuration.Label) (key, value string) {
 //nolint:funlen
 // DoAutoDiscover finds objects under test
 func DoAutoDiscover() DiscoveredTestData {
-	var err error
 	data.Env = *configuration.GetTestParameters()
-	if err != nil {
-		logrus.Fatalln("can't load environment variable")
-	}
+
+	var err error
 	data.TestData, err = configuration.LoadConfiguration(data.Env.ConfigurationPath)
 	if err != nil {
 		logrus.Fatalln("can't load configuration")
 	}
-
 	oc := clientsholder.GetClientsHolder()
 	data.Namespaces = namespacesListToStringList(data.TestData.TargetNameSpaces)
 	data.Pods = findPodsByLabel(oc.K8sClient.CoreV1(), data.TestData.TargetPodLabels, data.Namespaces)

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -20,13 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
 
 	configv1 "github.com/openshift/api/config/v1"
 	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	olmv1Alpha "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/sirupsen/logrus"
-	clientsholder "github.com/test-network-function/cnf-certification-test/internal/clientsholder"
+	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 	"helm.sh/helm/v3/pkg/release"
 	v1apps "k8s.io/api/apps/v1"
@@ -90,7 +89,7 @@ func buildLabelKeyValue(label configuration.Label) (key, value string) {
 // DoAutoDiscover finds objects under test
 func DoAutoDiscover() DiscoveredTestData {
 	var err error
-	data.Env, err = configuration.LoadEnvironmentVariables()
+	data.Env = *configuration.GetTestParameters()
 	if err != nil {
 		logrus.Fatalln("can't load environment variable")
 	}
@@ -98,15 +97,8 @@ func DoAutoDiscover() DiscoveredTestData {
 	if err != nil {
 		logrus.Fatalln("can't load configuration")
 	}
-	filenames := []string{}
-	if data.Env.Kubeconfig != "" {
-		filenames = append(filenames, data.Env.Kubeconfig)
-	}
-	if data.Env.Home != "" {
-		path := filepath.Join(data.Env.Home, ".kube", "config")
-		filenames = append(filenames, path)
-	}
-	oc := clientsholder.GetClientsHolder(filenames...)
+
+	oc := clientsholder.GetClientsHolder()
 	data.Namespaces = namespacesListToStringList(data.TestData.TargetNameSpaces)
 	data.Pods = findPodsByLabel(oc.K8sClient.CoreV1(), data.TestData.TargetPodLabels, data.Namespaces)
 

--- a/pkg/configuration/utils.go
+++ b/pkg/configuration/utils.go
@@ -28,8 +28,16 @@ var (
 	configuration = TestConfiguration{}
 	confLoaded    = false
 	parameters    = TestParameters{}
-	paramLoaded   = false
 )
+
+func init() {
+	log.Info("Saving environment variables & parameters.")
+	err := envconfig.Process("tnf", &parameters)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	log.Infof("Environment: %+v", parameters)
+}
 
 // LoadConfiguration return a function that loads
 // the configuration from a file once
@@ -52,17 +60,6 @@ func LoadConfiguration(filePath string) (TestConfiguration, error) {
 	return configuration, nil
 }
 
-// LoadEnvironmentVariables return a function
-// that loads the environment variables
-func LoadEnvironmentVariables() (TestParameters, error) {
-	if paramLoaded {
-		log.Debug("environment variables already processed, return previous element")
-		return parameters, nil
-	}
-	err := envconfig.Process("tnf", &parameters)
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	paramLoaded = true
-	return parameters, nil
+func GetTestParameters() *TestParameters {
+	return &parameters
 }


### PR DESCRIPTION
When no ginkgo focus was provided, the diagnostic information retrieval
could start before the debug pods were ready, resulting in errors when
executing the commands inside the debug pods, so I've added the wait
right before the autodiscovery.

Calling WaitDebugPodsReady in the BeforeEach is no longer needed.

Other minor refactors:
- The k8s clients holder is initialized as part of the initial sequence
  of the program.
- Ginkgo/Git info traces improvements.
- Added command to trace in ExecCommandContainer().
- WaitDebugPodsReady refactored to return error.
- Removed explicit function to load/process the environment variables.
  Instead, the package's init() function is used, as they never need to
  be reloaed/reparsed.