### PR TITLE
Unit tests for isredhat package

### DIFF
--- a/cnf-certification-test/platform/isredhat/isredhat.go
+++ b/cnf-certification-test/platform/isredhat/isredhat.go
@@ -19,7 +19,6 @@ package isredhat
 import (
 	"errors"
 	"regexp"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
@@ -33,14 +32,12 @@ const (
 )
 
 type BaseImageInfo struct {
-	timeout      time.Duration
-	ClientHolder *clientsholder.ClientsHolder
+	ClientHolder clientsholder.Command
 	OCPContext   clientsholder.Context
 }
 
-func NewBaseImageTester(timeout time.Duration, client *clientsholder.ClientsHolder, ctx clientsholder.Context) *BaseImageInfo {
+func NewBaseImageTester(client clientsholder.Command, ctx clientsholder.Context) *BaseImageInfo {
 	return &BaseImageInfo{
-		timeout:      timeout,
 		ClientHolder: client,
 		OCPContext:   ctx,
 	}

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -196,7 +196,7 @@ func testIsRedHatRelease(env *provider.TestEnvironment) {
 	failedContainers := []string{}
 	for _, cut := range env.Containers {
 		ginkgo.By(fmt.Sprintf("%s is checked for Red Hat version", cut))
-		baseImageTester := isredhat.NewBaseImageTester(common.DefaultTimeout, clientsholder.GetClientsHolder(), clientsholder.Context{
+		baseImageTester := isredhat.NewBaseImageTester(clientsholder.GetClientsHolder(), clientsholder.Context{
 			Namespace:     cut.Namespace,
 			Podname:       cut.Podname,
 			Containername: cut.Data.Name,


### PR DESCRIPTION
Taking advantage of work done previously in #109 for the `Command` interface.

This brings the level of coverage for this package to 100%.