### PR TITLE
No need to recommend the timeout value

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -543,7 +543,7 @@ following:
 
 ```go
 // 1. Create the Test.
-pingTester := ping.NewPing(defaultTimeout, targetPodIPAddress, count)
+pingTester := ping.NewPing(targetPodIPAddress, count)
 test, err := tnf.NewTest(oc.GetExpecter(), pingTester, []reel.Handler{pingTester}, oc.GetErrorChannel())
 gomega.Expect(err).To(gomega.BeNil())
 


### PR DESCRIPTION
I don't think any of the tests now pass around the `DefaultTimeout` value with the exception of #116 which is removing it.  The README should reflect the best practice now.