### PR TITLE
Add StringInSlice tests from old repo

### DIFF
--- a/pkg/tnf/utils/utils_test.go
+++ b/pkg/tnf/utils/utils_test.go
@@ -18,3 +18,64 @@
 Package tnf contains the core Test runner interfaces.
 */
 package tnf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//nolint:funlen
+func TestStringInSlice(t *testing.T) {
+	testCases := []struct {
+		testSlice       []string
+		testString      string
+		containsFeature bool
+		expected        bool
+	}{
+		{
+			testSlice: []string{
+				"apples",
+				"bananas",
+				"oranges",
+			},
+			testString:      "apples",
+			containsFeature: false,
+			expected:        true,
+		},
+		{
+			testSlice: []string{
+				"apples",
+				"bananas",
+				"oranges",
+			},
+			testString:      "tacos",
+			containsFeature: false,
+			expected:        false,
+		},
+		{
+			testSlice: []string{
+				"intree: Y",
+				"intree: N",
+				"outoftree: Y",
+			},
+			testString:      "intree:",
+			containsFeature: true, // Note: Turn 'on' the contains check
+			expected:        true,
+		},
+		{
+			testSlice: []string{
+				"intree: Y",
+				"intree: N",
+				"outoftree: Y",
+			},
+			testString:      "intree:",
+			containsFeature: false, // Note: Turn 'off' the contains check
+			expected:        false,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expected, StringInSlice(tc.testSlice, tc.testString, tc.containsFeature))
+	}
+}


### PR DESCRIPTION
The [old repo](https://github.com/test-network-function/test-network-function/blob/c1fe06ccf63eb75efe9a544503ad4c5b6cb9376b/pkg/utils/utils_test.go#L185) had this func tested.  Copying the tests over.  Brings this file to 100% coverage.