### PR TITLE
Add unit test for diagnostics package

### DIFF
--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -96,7 +96,7 @@ func GetHwInfoAllNodes() (out map[string]NodeHwInfo) {
 		if err != nil {
 			logrus.Errorf("problem getting lsblk for node %s", debugPod.Spec.NodeName)
 		}
-		hw.Lspci, err = getLspci(debugPod, o)
+		hw.Lspci, err = getHWTextOutput(debugPod, o, lspciCommand)
 		if err != nil {
 			logrus.Errorf("problem getting lspci for node %s", debugPod.Spec.NodeName)
 		}
@@ -119,10 +119,10 @@ func getHWJsonOutput(debugPod *v1.Pod, o clientsholder.Command, cmd string) (out
 	return out, nil
 }
 
-// getLspci gets lspci in Json format for a given node
-func getLspci(debugPod *v1.Pod, o clientsholder.Command) (out []string, err error) {
+// getHWTextOutput performs a query via debug and returns plaintext lines
+func getHWTextOutput(debugPod *v1.Pod, o clientsholder.Command, cmd string) (out []string, err error) {
 	ctx := clientsholder.Context{Namespace: debugPod.Namespace, Podname: debugPod.Name, Containername: debugPod.Spec.Containers[0].Name}
-	outStr, errStr, err := o.ExecCommandContainer(ctx, lspciCommand)
+	outStr, errStr, err := o.ExecCommandContainer(ctx, cmd)
 	if err != nil || errStr != "" {
 		return out, fmt.Errorf("command %s failed with error err: %s , stderr: %s", lspciCommand, err, errStr)
 	}

--- a/pkg/diagnostics/diagnostics_test.go
+++ b/pkg/diagnostics/diagnostics_test.go
@@ -16,3 +16,145 @@
 
 // Package diagnostic provides a test suite which gathers OpenShift cluster information.
 package diagnostics
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestGetVersionOcClient(t *testing.T) {
+	assert.Equal(t, "n/a, (not using oc or kubectl client)", GetVersionOcClient())
+}
+
+//nolint:funlen
+func TestGetHWJsonOutput(t *testing.T) {
+	type TestingJSON struct {
+		Testing string `json:"testing"`
+	}
+
+	testCases := []struct {
+		execStdout string
+		execStderr string
+		execErr    error
+
+		expectedErr    error
+		expectedResult TestingJSON
+	}{
+		{
+			execStdout: `{"testing":"hello world"}`,
+			execStderr: "",
+			execErr:    nil,
+
+			expectedErr: nil,
+			expectedResult: TestingJSON{
+				Testing: "hello world",
+			},
+		},
+		{
+			execStdout: `{"testing":"hello world"}`,
+			execStderr: "this is an error",
+			execErr:    nil,
+
+			expectedErr:    errors.New("command does not matter failed with error err: %!s(<nil>) , stderr: this is an error"),
+			expectedResult: TestingJSON{},
+		},
+		{
+			execStdout: `{"testing":"hello world"}`,
+			execStderr: "this is an error",
+			execErr:    errors.New("this is an error2"),
+
+			expectedErr:    errors.New("command does not matter failed with error err: %!s(<nil>) , stderr: this is an error"),
+			expectedResult: TestingJSON{},
+		},
+	}
+
+	for _, tc := range testCases {
+		result, err := getHWJsonOutput(&v1.Pod{
+			Spec: v1.PodSpec{
+				// Note: We don't actually care about the podname
+				// for this test, but the function uses it to build the
+				// context .
+				Containers: []v1.Container{
+					{
+						Name: "podname",
+					},
+				},
+			},
+		}, &clientsholder.CommandMock{
+			ExecCommandContainerFunc: func(context clientsholder.Context, s string) (string, string, error) {
+				return tc.execStdout, tc.execStderr, nil
+			},
+		}, "does not matter")
+
+		tj := TestingJSON{}
+		tjBytes, _ := json.Marshal(result)
+		_ = json.Unmarshal(tjBytes, &tj)
+
+		assert.Equal(t, tc.expectedErr, err)
+		assert.Equal(t, tc.expectedResult, tj)
+	}
+}
+
+//nolint:funlen
+func TestGetLspci(t *testing.T) {
+	testCases := []struct {
+		execStdout string
+		execStderr string
+		execErr    error
+
+		expectedErr    error
+		expectedResult []string
+	}{
+		{
+			execStdout: "hello\nworld",
+			execStderr: "",
+			execErr:    nil,
+
+			expectedErr:    nil,
+			expectedResult: []string{"hello", "world"},
+		},
+		{
+			execStdout: `{"testing":"hello world"}`,
+			execStderr: "this is an error",
+			execErr:    nil,
+
+			expectedErr:    errors.New("command lspci failed with error err: %!s(<nil>) , stderr: this is an error"),
+			expectedResult: nil,
+		},
+		{
+			execStdout: `{"testing":"hello world"}`,
+			execStderr: "this is an error",
+			execErr:    errors.New("this is an error2"),
+
+			expectedErr:    errors.New("command lspci failed with error err: %!s(<nil>) , stderr: this is an error"),
+			expectedResult: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		result, err := getLspci(&v1.Pod{
+			Spec: v1.PodSpec{
+				// Note: We don't actually care about the podname
+				// for this test, but the function uses it to build the
+				// context .
+				Containers: []v1.Container{
+					{
+						Name: "podname",
+					},
+				},
+			},
+		}, &clientsholder.CommandMock{
+			ExecCommandContainerFunc: func(context clientsholder.Context, s string) (string, string, error) {
+				return tc.execStdout, tc.execStderr, nil
+			},
+		})
+
+		assert.Equal(t, tc.expectedErr, err)
+		assert.Equal(t, tc.expectedResult, result)
+	}
+}

--- a/pkg/diagnostics/diagnostics_test.go
+++ b/pkg/diagnostics/diagnostics_test.go
@@ -101,7 +101,7 @@ func TestGetHWJsonOutput(t *testing.T) {
 }
 
 //nolint:funlen
-func TestGetLspci(t *testing.T) {
+func TestGetHWTextOutput(t *testing.T) {
 	testCases := []struct {
 		execStdout string
 		execStderr string
@@ -137,7 +137,7 @@ func TestGetLspci(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		result, err := getLspci(&v1.Pod{
+		result, err := getHWTextOutput(&v1.Pod{
 			Spec: v1.PodSpec{
 				// Note: We don't actually care about the podname
 				// for this test, but the function uses it to build the
@@ -152,7 +152,7 @@ func TestGetLspci(t *testing.T) {
 			ExecCommandContainerFunc: func(context clientsholder.Context, s string) (string, string, error) {
 				return tc.execStdout, tc.execStderr, nil
 			},
-		})
+		}, lspciCommand)
 
 		assert.Equal(t, tc.expectedErr, err)
 		assert.Equal(t, tc.expectedResult, result)

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -613,3 +613,75 @@ func TestCreateOperators(t *testing.T) {
 		}
 	}
 }
+
+//nolint:funlen
+func TestConvertArrayPods(t *testing.T) {
+	testCases := []struct {
+		testPods     []*v1.Pod
+		expectedPods []*Pod
+	}{
+		{ // Test Case 1 - No containers
+			testPods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testpod1",
+						Namespace: "testnamespace1",
+					},
+				},
+			},
+			expectedPods: []*Pod{
+				{
+					Data: &v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "testpod1",
+							Namespace: "testnamespace1",
+						},
+					},
+				},
+			},
+		},
+		{ // Test Case 2 - Containers
+			testPods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testpod1",
+						Namespace: "testnamespace1",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "testcontainer1",
+							},
+						},
+					},
+				},
+			},
+			expectedPods: []*Pod{
+				{
+					Data: &v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "testpod1",
+							Namespace: "testnamespace1",
+						},
+					},
+					Containers: []*Container{
+						{
+							Data: &v1.Container{
+								Name: "testcontainer1",
+							},
+							Namespace: "testnamespace1",
+							Podname:   "testpod1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		convertedArray := ConvertArrayPods(tc.testPods)
+		assert.Equal(t, tc.expectedPods[0].Containers, convertedArray[0].Containers)
+		assert.Equal(t, tc.expectedPods[0].Data.Name, convertedArray[0].Data.Name)
+		assert.Equal(t, tc.expectedPods[0].Data.Namespace, convertedArray[0].Data.Namespace)
+	}
+}


### PR DESCRIPTION
Added some more unit test coverage for the `diagnostics` package.  I skipped all of the functions that require a `GetTestEnvironment()` object because at this time I'm not sure how to spoof the singleton.

Notable changes:
- Removed `getLscpu`, `getIPConfig`, and `getLsblk` functions in favor of `getHWJsonOutput`.  These functions were essentially the same thing and needed a single parameter passed into them.
- Utilized changes from #109`clientsHolder.Command` interface for mocking out the `execCommandContainer` function.
- BONUS: Added a test in the `provider` package for `ConvertArrayPods` function.