### PR TITLE
Skipping test cases if resources they rely on are not detected

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -31,6 +31,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/internal/crclient"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
+	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
 )
 
@@ -56,82 +57,92 @@ var _ = ginkgo.Describe(common.AccessControlTestKey, func() {
 	// Security Context: non-compliant capabilities
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestSecConCapabilitiesIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
 		TestSecConCapabilities(&env)
 	})
 	// container security context: non-root user
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestSecConNonRootUserIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
 		TestSecConRootUser(&env)
 	})
 	// container security context: privileged escalation
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestSecConPrivilegeEscalation)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
 		TestSecConPrivilegeEscalation(&env)
 	})
 	// container security context: host port
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestContainerHostPort)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
 		TestContainerHostPort(&env)
 	})
 	// container security context: host network
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestPodHostNetwork)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
 		TestPodHostNetwork(&env)
 	})
 	// pod host path
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestPodHostPath)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
 		TestPodHostPath(&env)
 	})
 	// pod host ipc
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestPodHostIPC)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
 		TestPodHostIPC(&env)
 	})
 	// pod host pid
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestPodHostPID)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
 		TestPodHostPID(&env)
 	})
 	// Namespace
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestNamespaceBestPracticesIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Namespaces)
 		TestNamespace(&env)
 	})
 	// pod service account
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestPodServiceAccountBestPracticesIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
 		TestPodServiceAccount(&env)
 	})
 	// pod role bindings
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestPodRoleBindingsBestPracticesIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
 		TestPodRoleBindings(&env)
 	})
 	// pod cluster role bindings
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestPodClusterRoleBindingsBestPracticesIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
 		TestPodClusterRoleBindings(&env)
 	})
 	// automount service token
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestPodAutomountServiceAccountIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
 		TestAutomountServiceToken(&env)
 	})
 	// one process per container
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestOneProcessPerContainerIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
 		TestOneProcessPerContainer(&env)
 	})
-
 })
 
 // TestSecConCapabilities verifies that non compliant capabilities are not present
 func TestSecConCapabilities(env *provider.TestEnvironment) {
 	var badContainers []string
-	if len(env.Containers) == 0 {
-		ginkgo.Skip("No containers to perform test, skipping")
-	}
 	for _, cut := range env.Containers {
 		if cut.Data.SecurityContext != nil && cut.Data.SecurityContext.Capabilities != nil {
 			for _, ncc := range nonCompliantCapabilities {
@@ -149,9 +160,6 @@ func TestSecConCapabilities(env *provider.TestEnvironment) {
 // TestSecConRootUser verifies that the container is not running as root
 func TestSecConRootUser(env *provider.TestEnvironment) {
 	var badContainers, badPods []string
-	if len(env.Containers) == 0 {
-		ginkgo.Skip("No containers to perform test, skipping")
-	}
 	for _, put := range env.Pods {
 		if put.Data.Spec.SecurityContext != nil && put.Data.Spec.SecurityContext.RunAsUser != nil {
 			// Check the pod level RunAsUser parameter
@@ -180,9 +188,6 @@ func TestSecConRootUser(env *provider.TestEnvironment) {
 // TestSecConPrivilegeEscalation verifies that the container is not allowed privilege escalation
 func TestSecConPrivilegeEscalation(env *provider.TestEnvironment) {
 	var badContainers []string
-	if len(env.Containers) == 0 {
-		ginkgo.Skip("No containers to perform test, skipping")
-	}
 	for _, cut := range env.Containers {
 		if cut.Data.SecurityContext != nil && cut.Data.SecurityContext.AllowPrivilegeEscalation != nil {
 			if *(cut.Data.SecurityContext.AllowPrivilegeEscalation) {
@@ -198,9 +203,6 @@ func TestSecConPrivilegeEscalation(env *provider.TestEnvironment) {
 // TestContainerHostPort tests that containers are not configured with host port privileges
 func TestContainerHostPort(env *provider.TestEnvironment) {
 	var badContainers []string
-	if len(env.Containers) == 0 {
-		ginkgo.Skip("No containers to perform test, skipping")
-	}
 	for _, cut := range env.Containers {
 		for _, aPort := range cut.Data.Ports {
 			if aPort.HostPort != 0 {
@@ -214,11 +216,8 @@ func TestContainerHostPort(env *provider.TestEnvironment) {
 }
 
 // TestPodHostNetwork verifies that the pod hostNetwork parameter is not set to true
-func TestPodHostNetwork(env *provider.TestEnvironment) { //nolint:dupl
+func TestPodHostNetwork(env *provider.TestEnvironment) {
 	var badPods []string
-	if len(env.Pods) == 0 {
-		ginkgo.Skip("No Pods to run test, skipping")
-	}
 	for _, put := range env.Pods {
 		if put.Data.Spec.HostNetwork {
 			tnf.ClaimFilePrintf("Host network is set to true in pod %s.", put.Data.Namespace+"."+put.Data.Name)
@@ -232,9 +231,6 @@ func TestPodHostNetwork(env *provider.TestEnvironment) { //nolint:dupl
 // TestPodHostPath verifies that the pod hostpath parameter is not set to true
 func TestPodHostPath(env *provider.TestEnvironment) {
 	var badPods []string
-	if len(env.Pods) == 0 {
-		ginkgo.Skip("No Pods to run test, skipping")
-	}
 	for _, put := range env.Pods {
 		for idx := range put.Data.Spec.Volumes {
 			vol := &put.Data.Spec.Volumes[idx]
@@ -249,11 +245,8 @@ func TestPodHostPath(env *provider.TestEnvironment) {
 }
 
 // TestPodHostIPC verifies that the pod hostIpc parameter is not set to true
-func TestPodHostIPC(env *provider.TestEnvironment) { //nolint:dupl
+func TestPodHostIPC(env *provider.TestEnvironment) {
 	var badPods []string
-	if len(env.Pods) == 0 {
-		ginkgo.Skip("No Pods to run test, skipping")
-	}
 	for _, put := range env.Pods {
 		if put.Data.Spec.HostIPC {
 			tnf.ClaimFilePrintf("HostIpc is set in pod %s.", put.Data.Namespace+"."+put.Data.Name)
@@ -265,11 +258,8 @@ func TestPodHostIPC(env *provider.TestEnvironment) { //nolint:dupl
 }
 
 // TestPodHostPID verifies that the pod hostPid parameter is not set to true
-func TestPodHostPID(env *provider.TestEnvironment) { //nolint:dupl
+func TestPodHostPID(env *provider.TestEnvironment) {
 	var badPods []string
-	if len(env.Pods) == 0 {
-		ginkgo.Skip("No Pods to run test, skipping")
-	}
 	for _, put := range env.Pods {
 		if put.Data.Spec.HostPID {
 			tnf.ClaimFilePrintf("HostPid is set in pod %s.", put.Data.Namespace+"."+put.Data.Name)

--- a/cnf-certification-test/certification/suite.go
+++ b/cnf-certification-test/certification/suite.go
@@ -31,6 +31,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/results"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
+	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
 )
 
@@ -115,10 +116,7 @@ func testAllOperatorCertified(env *provider.TestEnvironment) {
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestOperatorIsCertifiedIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
 		operatorsToQuery := env.Subscriptions
-
-		if len(operatorsToQuery) == 0 {
-			ginkgo.Skip("No operators to check configured ")
-		}
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Operators)
 		certtool.CertAPIClient = api.NewHTTPClient()
 		ginkgo.By(fmt.Sprintf("Verify operator as certified. Number of operators to check: %d", len(operatorsToQuery)))
 		testFailed := false
@@ -150,9 +148,7 @@ func testHelmCertified(env *provider.TestEnvironment) {
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
 		certtool.CertAPIClient = api.NewHTTPClient()
 		helmchartsReleases := env.HelmChartReleases
-		if len(helmchartsReleases) == 0 {
-			ginkgo.Skip("No helm charts to check")
-		}
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, helmchartsReleases)
 		out, err := certtool.CertAPIClient.GetYamlFile()
 		if err != nil {
 			ginkgo.Fail(fmt.Sprintf("error while reading the helm yaml file from the api %s", err))

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -62,15 +62,18 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestPodNodeSelectorAndAffinityBestPractices)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
 		testPodNodeSelectorAndAffinityBestPractices(&env)
 	})
 
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestNonDefaultGracePeriodIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Deployments, env.StatetfulSets)
 		testGracePeriod(&env)
 	})
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestPodRecreationIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Deployments, env.StatetfulSets)
 		// Testing pod re-creation for deployments
 		testPodsRecreation(&env)
 	})
@@ -78,10 +81,12 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 	if env.IsIntrusive() {
 		testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestDeploymentScalingIdentifier)
 		ginkgo.It(testID, ginkgo.Label(testID), func() {
+			testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Deployments)
 			testDeploymentScaling(&env, timeout)
 		})
 		testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestStateFulSetScalingIdentifier)
 		ginkgo.It(testID, ginkgo.Label(testID), func() {
+			testhelper.SkipIfEmptyAny(ginkgo.Skip, env.StatetfulSets)
 			testStatefulSetScaling(&env, timeout)
 		})
 	}
@@ -109,6 +114,7 @@ func testContainersPreStop(env *provider.TestEnvironment) {
 func testContainersImagePolicy(env *provider.TestEnvironment) {
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestImagePullPolicyIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Containers)
 		badcontainers := []string{}
 		for _, cut := range env.Containers {
 			logrus.Debugln("check container ", cut.Namespace, " ", cut.Podname, " ", cut.Data.Name, " pull policy, should be ", v1.PullIfNotPresent)
@@ -129,6 +135,7 @@ func testContainersImagePolicy(env *provider.TestEnvironment) {
 func testContainersReadinessProbe(env *provider.TestEnvironment) {
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestReadinessProbeIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Containers)
 		badcontainers := []string{}
 		for _, cut := range env.Containers {
 			logrus.Debugln("check container ", cut.Namespace, " ", cut.Podname, " ", cut.Data.Name, " readiness probe ")
@@ -149,6 +156,7 @@ func testContainersReadinessProbe(env *provider.TestEnvironment) {
 func testContainersLivenessProbe(env *provider.TestEnvironment) {
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestLivenessProbeIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Containers)
 		badcontainers := []string{}
 		for _, cut := range env.Containers {
 			logrus.Debugln("check container ", cut.Namespace, " ", cut.Podname, " ", cut.Data.Name, " liveness probe ")
@@ -168,6 +176,7 @@ func testContainersLivenessProbe(env *provider.TestEnvironment) {
 func testPodsOwnerReference(env *provider.TestEnvironment) {
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestPodDeploymentBestPracticesIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Pods)
 		ginkgo.By("Testing owners of CNF pod, should be replicas Set")
 		badPods := []string{}
 		for _, put := range env.Pods {
@@ -237,10 +246,6 @@ func testGracePeriod(env *provider.TestEnvironment) {
 func testDeploymentScaling(env *provider.TestEnvironment, timeout time.Duration) {
 	ginkgo.By("Testing deployment scaling")
 	defer env.SetNeedsRefresh()
-
-	if len(env.Deployments) == 0 {
-		ginkgo.Skip("No test deployments found.")
-	}
 	failedDeployments := []string{}
 	for i := range env.Deployments {
 		// TestDeploymentScaling test scaling of deployment
@@ -274,10 +279,6 @@ func testDeploymentScaling(env *provider.TestEnvironment, timeout time.Duration)
 func testStatefulSetScaling(env *provider.TestEnvironment, timeout time.Duration) {
 	ginkgo.By("Testing statefulset scaling")
 	defer env.SetNeedsRefresh()
-
-	if len(env.Deployments) == 0 {
-		ginkgo.Skip("No test statefulset found.")
-	}
 	failedSatetfulSets := []string{}
 	for i := range env.StatetfulSets {
 		// TeststatefulsetScaling test scaling of statefulset
@@ -312,9 +313,7 @@ func testHighAvailability(env *provider.TestEnvironment) {
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestPodHighAvailabilityBestPractices)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
 		ginkgo.By("Should set pod replica number greater than 1")
-		if len(env.Deployments) == 0 && len(env.StatetfulSets) == 0 {
-			ginkgo.Skip("No test deployments/statefulset found.")
-		}
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Deployments, env.StatetfulSets)
 
 		badDeployments := []string{}
 		badStatefulSet := []string{}

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -31,6 +31,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/internal/crclient"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
+	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -61,30 +62,36 @@ var _ = ginkgo.Describe(common.NetworkingTestKey, func() {
 	// Default interface ICMP IPv4 test case
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestICMPv4ConnectivityIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers, env.Pods)
 		testDefaultNetworkConnectivity(&env, defaultNumPings, netcommons.IPv4)
 	})
 	// Multus interfaces ICMP IPv4 test case
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestICMPv4ConnectivityMultusIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers, env.Pods)
 		testMultusNetworkConnectivity(&env, defaultNumPings, netcommons.IPv4)
 	})
 	// Default interface ICMP IPv6 test case
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestICMPv6ConnectivityIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers, env.Pods)
 		testDefaultNetworkConnectivity(&env, defaultNumPings, netcommons.IPv6)
 	})
 	// Multus interfaces ICMP IPv6 test case
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestICMPv6ConnectivityMultusIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers, env.Pods)
 		testMultusNetworkConnectivity(&env, defaultNumPings, netcommons.IPv6)
 	})
 	// Default interface ICMP IPv6 test case
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestUndeclaredContainerPortsUsage)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers, env.Pods)
 		testListenAndDeclared(&env)
 	})
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestServicesDoNotUseNodeportsIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers, env.Pods)
 		testNodePort(&env)
 	})
 })

--- a/cnf-certification-test/observability/suite.go
+++ b/cnf-certification-test/observability/suite.go
@@ -29,6 +29,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/results"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
+	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
 
 	v1 "k8s.io/api/core/v1"
@@ -46,16 +47,19 @@ var _ = ginkgo.Describe(common.ObservabilityTestKey, func() {
 
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestLoggingIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
 		testContainersLogging(&env)
 	})
 
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestCrdsStatusSubresourceIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Crds)
 		testCrds(&env)
 	})
 
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestTerminationMessagePolicyIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
 		testTerminationMessagePolicy(&env)
 	})
 })
@@ -86,10 +90,6 @@ func containerHasLoggingOutput(cut *provider.Container) (bool, error) {
 }
 
 func testContainersLogging(env *provider.TestEnvironment) {
-	if len(env.Containers) == 0 {
-		ginkgo.Skip("No containers to run test, skipping")
-	}
-
 	// Iterate through all the CUTs to get their log output. The TC checks that at least
 	// one log line is found.
 	badContainers := []string{}

--- a/cnf-certification-test/operator/suite.go
+++ b/cnf-certification-test/operator/suite.go
@@ -29,6 +29,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/results"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
+	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,26 +47,25 @@ var _ = ginkgo.Describe(common.OperatorTestKey, func() {
 
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestOperatorInstallStatusSucceededIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Operators)
 		testOperatorInstallationPhaseSucceeded(&env)
 	})
 
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestOperatorNoPrivileges)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Operators)
 		testOperatorInstallationWithoutPrivileges(&env)
 	})
 
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestOperatorIsInstalledViaOLMIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Operators)
 		testOperatorOlmSubscription(&env)
 	})
 })
 
 func testOperatorInstallationPhaseSucceeded(env *provider.TestEnvironment) {
 	badOperators := []string{}
-	if len(env.Operators) == 0 {
-		ginkgo.Skip("No operators found to perform test, skipping.")
-	}
-
 	for i := range env.Operators {
 		csv := env.Operators[i].Csv
 		phase := phasecheck.WaitOperatorReady(csv)
@@ -83,10 +83,6 @@ func testOperatorInstallationPhaseSucceeded(env *provider.TestEnvironment) {
 
 func testOperatorInstallationWithoutPrivileges(env *provider.TestEnvironment) {
 	badOperators := []string{}
-	if len(env.Operators) == 0 {
-		ginkgo.Skip("No operators found to perform test, skipping.")
-	}
-
 	for i := range env.Operators {
 		csv := env.Operators[i].Csv
 		clusterPermissions := csv.Spec.InstallStrategy.StrategySpec.ClusterPermissions
@@ -121,10 +117,6 @@ func testOperatorInstallationWithoutPrivileges(env *provider.TestEnvironment) {
 
 func testOperatorOlmSubscription(env *provider.TestEnvironment) {
 	badCsvs := []string{}
-	if len(env.Operators) == 0 {
-		ginkgo.Skip("No CSVs to perform test, skipping.")
-	}
-
 	ocpClient := clientsholder.GetClientsHolder()
 	for i := range env.Operators {
 		csv := env.Operators[i].Csv

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -52,6 +52,7 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestUnalteredBaseImageIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
 		if provider.IsOCPCluster() {
+			testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
 			testContainersFsDiff(&env, cnffsdiff.NewFsDiffTester(clientsholder.GetClientsHolder()))
 		} else {
 			ginkgo.Skip(" non ocp cluster ")
@@ -60,17 +61,20 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestNonTaintedNodeKernelsIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.DebugPods)
 		testTainted(&env, nodetainted.NewNodeTaintedTester(clientsholder.GetClientsHolder())) // minikube tainted kernels are allowed via config
 	})
 
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestIsRedHatReleaseIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
 		testIsRedHatRelease(&env)
 	})
 
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestIsSELinuxEnforcingIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
 		if provider.IsOCPCluster() {
+			testhelper.SkipIfEmptyAny(ginkgo.Skip, env.DebugPods)
 			testIsSELinuxEnforcing(&env)
 		} else {
 			ginkgo.Skip(" non ocp cluster ")

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -42,7 +42,7 @@ func ResultToString(result int) (str string) {
 func SkipIfEmptyAny(skip func(string, ...int), object ...interface{}) {
 	for _, o := range object {
 		s := reflect.ValueOf(o)
-		if s.Kind() != reflect.Slice {
+		if s.Kind() != reflect.Slice && s.Kind() != reflect.Map {
 			panic("SkipIfEmpty given a non-slice type")
 		}
 
@@ -57,7 +57,7 @@ func SkipIfEmptyAll(skip func(string, ...int), object ...interface{}) {
 	allTypes := ""
 	for _, o := range object {
 		s := reflect.ValueOf(o)
-		if s.Kind() != reflect.Slice {
+		if s.Kind() != reflect.Slice && s.Kind() != reflect.Map {
 			panic("SkipIfEmpty given a non-slice type")
 		}
 

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -47,7 +47,7 @@ func SkipIfEmptyAny(skip func(string, ...int), object ...interface{}) {
 		}
 
 		if s.Len() == 0 {
-			skip(fmt.Sprintf("Test failed because there are no %s to test, please check under test labels", reflect.TypeOf(o)))
+			skip(fmt.Sprintf("Test skipped because there are no %s to test, please check under test labels", reflect.TypeOf(o)))
 		}
 	}
 }
@@ -68,6 +68,6 @@ func SkipIfEmptyAll(skip func(string, ...int), object ...interface{}) {
 	}
 	// all objects have len() of 0
 	if countLenZero == len(object) {
-		skip(fmt.Sprintf("Test failed because there are no %s to test, please check under test labels", allTypes))
+		skip(fmt.Sprintf("Test skipped because there are no %s to test, please check under test labels", allTypes))
 	}
 }

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -16,6 +16,11 @@
 
 package testhelper
 
+import (
+	"fmt"
+	"reflect"
+)
+
 const (
 	SUCCESS = iota
 	FAILURE
@@ -32,4 +37,37 @@ func ResultToString(result int) (str string) {
 		return "ERROR" //nolint:goconst
 	}
 	return ""
+}
+
+func SkipIfEmptyAny(skip func(string, ...int), object ...interface{}) {
+	for _, o := range object {
+		s := reflect.ValueOf(o)
+		if s.Kind() != reflect.Slice {
+			panic("SkipIfEmpty given a non-slice type")
+		}
+
+		if s.Len() == 0 {
+			skip(fmt.Sprintf("Test failed because there are no %s to test, please check under test labels", reflect.TypeOf(o)))
+		}
+	}
+}
+
+func SkipIfEmptyAll(skip func(string, ...int), object ...interface{}) {
+	countLenZero := 0
+	allTypes := ""
+	for _, o := range object {
+		s := reflect.ValueOf(o)
+		if s.Kind() != reflect.Slice {
+			panic("SkipIfEmpty given a non-slice type")
+		}
+
+		if s.Len() == 0 {
+			countLenZero++
+			allTypes = allTypes + reflect.TypeOf(o).String() + ", "
+		}
+	}
+	// all objects have len() of 0
+	if countLenZero == len(object) {
+		skip(fmt.Sprintf("Test failed because there are no %s to test, please check under test labels", allTypes))
+	}
 }

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -43,7 +43,7 @@ func SkipIfEmptyAny(skip func(string, ...int), object ...interface{}) {
 	for _, o := range object {
 		s := reflect.ValueOf(o)
 		if s.Kind() != reflect.Slice && s.Kind() != reflect.Map {
-			panic("SkipIfEmpty given a non-slice type")
+			panic("SkipIfEmpty was given a non slice/map type")
 		}
 
 		if s.Len() == 0 {
@@ -58,7 +58,7 @@ func SkipIfEmptyAll(skip func(string, ...int), object ...interface{}) {
 	for _, o := range object {
 		s := reflect.ValueOf(o)
 		if s.Kind() != reflect.Slice && s.Kind() != reflect.Map {
-			panic("SkipIfEmpty given a non-slice type")
+			panic("SkipIfEmpty was given a non slice/map type")
 		}
 
 		if s.Len() == 0 {


### PR DESCRIPTION
Verified each test to make sure that they would skip if not finding a required resources (pods, containers, operators, etc)
Added 2 generic function:
- SkipIfEmptyAny: takes a list of resources to check for and skip the test if any of them are empty
- SkipIfEmptyAll: takes a list of resources to check for and skip the test if all of them are empty
