### PR TITLE
Upgrade to Go 1.18.1

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.9
+          go-version: 1.18.1
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.9
+          go-version: 1.18.1
 
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"
@@ -80,10 +80,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.9
+          go-version: 1.18.1
 
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"
@@ -125,10 +125,10 @@ jobs:
       KUBECONFIG: '/home/runner/.kube/config'
 
     steps:
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18.1
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.9
+          go-version: 1.18.1
 
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN yum install -y gcc git jq make wget
 
 # Install Go binary
 ENV GO_DL_URL="https://golang.org/dl"
-ENV GO_BIN_TAR="go1.17.4.linux-amd64.tar.gz"
+ENV GO_BIN_TAR="go1.18.1.linux-amd64.tar.gz"
 ENV GO_BIN_URL_x86_64=${GO_DL_URL}/${GO_BIN_TAR}
 ENV GOPATH="/root/go"
 RUN if [[ "$(uname -m)" -eq "x86_64" ]] ; then \

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ At a minimum, the following dependencies must be installed *prior* to running `m
 
 Dependency|Minimum Version
 ---|---
-[GoLang](https://golang.org/dl/)|1.17
+[GoLang](https://golang.org/dl/)|1.18
 [golangci-lint](https://golangci-lint.run/usage/install/)|1.45.2
 [jq](https://stedolan.github.io/jq/)|1.6
 [OpenShift Client](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/)|4.7

--- a/cnf-certification-test/networking/icmp/icmp_test.go
+++ b/cnf-certification-test/networking/icmp/icmp_test.go
@@ -273,7 +273,7 @@ func TestProcessContainerIpsPerNet(t *testing.T) { //nolint:funlen
 	}
 }
 
-func loadEnvFromFile(claimFileName string) (env *provider.TestEnvironment, err error) { //nolint:deadcode,unused
+func loadEnvFromFile(claimFileName string) (env *provider.TestEnvironment, err error) { //nolint:deadcode
 	return claimhelper.GetConfigurationFromClaimFile(claimFileName)
 }
 

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -164,7 +164,7 @@ func testNodePort(env *provider.TestEnvironment) {
 }
 
 // testDefaultNetworkConnectivity test the connectivity between the default interfaces of containers under test
-func testNetworkConnectivity(env *provider.TestEnvironment, count int, aIPVersion netcommons.IPVersion, aType netcommons.IFType) { //nolint:unparam
+func testNetworkConnectivity(env *provider.TestEnvironment, count int, aIPVersion netcommons.IPVersion, aType netcommons.IFType) {
 	netsUnderTest, claimsLog := icmp.BuildNetTestContext(env.Pods, aIPVersion, aType)
 	// Saving  curated logs to claims file
 	tnf.ClaimFilePrintf("%s", claimsLog)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/cnf-certification-test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -260,7 +260,7 @@ func (api CertAPIClient) GetOperatorBundleIDByPackageName(org, name, version str
 
 // getRequest a http call to rest api, returns byte array or error
 func (api CertAPIClient) getRequest(url string) (response []byte, err error) {
-	req, err := http.NewRequest(http.MethodGet, url, http.NoBody) //nolint:noctx
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -115,7 +115,7 @@ func getDoFunc(data string, status int) func(req *http.Request) (*http.Response,
 }
 func TestApiClient_IsContainerCertified(t *testing.T) {
 	for _, c := range containerTestCases {
-		GetDoFunc = getDoFunc(c.responseData, c.responseStatus) //nolint:bodyclose
+		GetDoFunc = getDoFunc(c.responseData, c.responseStatus)
 		result := client.IsContainerCertified(c.repository, c.name)
 		assert.Equal(t, c.expectedResult, result)
 	}
@@ -123,7 +123,7 @@ func TestApiClient_IsContainerCertified(t *testing.T) {
 
 func TestApiClient_IsOperatorCertified(t *testing.T) {
 	for _, c := range operatorTestCases {
-		GetDoFunc = getDoFunc(c.responseData, c.responseStatus) //nolint:bodyclose
+		GetDoFunc = getDoFunc(c.responseData, c.responseStatus)
 		result, err := client.IsOperatorCertified(c.org, c.packageName, c.version)
 		assert.Equal(t, c.expectedResult, result, err)
 	}
@@ -132,7 +132,7 @@ func TestApiClient_IsOperatorCertified(t *testing.T) {
 func TestApiClient_GetImageById(t *testing.T) {
 	containerTestCases[0].id = id
 	for _, c := range containerTestCases {
-		GetDoFunc = getDoFunc(c.responseData, c.responseStatus) //nolint:bodyclose
+		GetDoFunc = getDoFunc(c.responseData, c.responseStatus)
 		result, err := client.GetImageByID(c.id)
 		assert.Equal(t, c.expectedError, err)
 		if err == nil {


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/CNFCERT-262

Our repo seems to be healthy enough running locally on Go 1.18.1.  I'll see if the CI likes it.

The GolangCI linter seems to be tracking some individual tests that don't quite work with 1.18 here: https://github.com/golangci/golangci-lint/issues/2649