### PR TITLE
Set pre-main to install correct ginkgo v2 version

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -142,7 +142,7 @@ jobs:
         run: go install github.com/golang/mock/mockgen@v1.6.0 && make mocks
 
       - name: Install ginkgo
-        run: go install github.com/onsi/ginkgo/ginkgo@v1.16.5
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.3
 
       - name: Execute `make build`
         run: make build


### PR DESCRIPTION
Looks like this line was missed in the old repo as well.

Fix applied in the old repo here: https://github.com/test-network-function/test-network-function/pull/670