### PR TITLE
Check for pods using UID 1337

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -33,6 +33,15 @@ Description|http://test-network-function.com/testcases/access-control/namespace 
 Result Type|normative
 Suggested Remediation|Ensure that your CNF utilizes namespaces declared in the yaml config file. Additionally, the namespaces should not start with "default, openshift-, istio- or aspenmesh-", except in rare cases.
 Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2, 16.3.8 & 16.3.9
+### http://test-network-function.com/testcases/access-control/no-1337-uid
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/access-control/no-1337-uid check that all pods do not use securityContext UID 1337
+Result Type|informative
+Suggested Remediation|specify another user ID in the security context
+Best Practice Reference|
 ### http://test-network-function.com/testcases/access-control/one-process-per-container
 
 Property|Description

--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -138,6 +138,12 @@ var _ = ginkgo.Describe(common.AccessControlTestKey, func() {
 		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
 		TestOneProcessPerContainer(&env)
 	})
+	// no 1337 UID's being used by pods
+	testID = identifiers.XformToGinkgoItIdentifier(identifiers.Test1337UIDIdentifier)
+	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		Test1337UIDs(&env)
+	})
 })
 
 // TestSecConCapabilities verifies that non compliant capabilities are not present
@@ -440,6 +446,24 @@ func TestOneProcessPerContainer(env *provider.TestEnvironment) {
 
 	if n := len(badContainers); n > 0 {
 		errMsg := fmt.Sprintf("Number of faulty containers found: %d", n)
+		tnf.ClaimFilePrintf(errMsg)
+		ginkgo.Fail(errMsg)
+	}
+}
+
+func Test1337UIDs(env *provider.TestEnvironment) {
+	const leetNum = 1337
+	var badPods []string
+	for _, put := range env.Pods {
+		ginkgo.By(fmt.Sprintf("checking if pod %s has a securityContext RunAsUser 1337 (ns= %s)", put.Data.Name, put.Data.Namespace))
+		if put.Data.Spec.SecurityContext.RunAsUser != nil && *put.Data.Spec.SecurityContext.RunAsUser == int64(leetNum) {
+			tnf.ClaimFilePrintf("Pod: %s/%s is found to use securityContext RunAsUser 1337", put.Data.Namespace, put.Data.Name)
+			badPods = append(badPods, put.Data.Name)
+		}
+	}
+
+	if n := len(badPods); n > 0 {
+		errMsg := fmt.Sprintf("Number of pods found using UID 1337: %d", n)
 		tnf.ClaimFilePrintf(errMsg)
 		ginkgo.Fail(errMsg)
 	}

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -299,6 +299,11 @@ var (
 		Url:     formTestURL(common.AccessControlTestKey, "one-process-per-container"),
 		Version: versionOne,
 	}
+	// Test1337UIDIdentifier ensures that no pods are configured to use UID 1337
+	Test1337UIDIdentifier = claim.Identifier{
+		Url:     formTestURL(common.AccessControlTestKey, "no-1337-uid"),
+		Version: versionOne,
+	}
 )
 
 func formDescription(identifier claim.Identifier, description string) string {
@@ -823,5 +828,12 @@ the changes for you.`,
 		have only one process running`),
 		Remediation:           `launch only one process per container`,
 		BestPracticeReference: bestPracticeDocV1dot2URL + " Section 11.8.3",
+	},
+	Test1337UIDIdentifier: {
+		Identifier:  Test1337UIDIdentifier,
+		Type:        informativeResult,
+		Description: formDescription(Test1337UIDIdentifier, `check that all pods do not use securityContext UID 1337`),
+		Remediation: `specify another user ID in the security context`,
+		// BestPracticeReference: bestPracticeDocV1dot2URL + " Section 11.8.3",
 	},
 }


### PR DESCRIPTION
Relates to issue CNFCERT-278.

Makes sure that none of the pods are using `securityContext.RunAsUser` == 1337.

TODO: Still need to find the section in the document for the `BestPracticeReference`.