### PR TITLE
More breakdown and testing of certification status

### DIFF
--- a/cnf-certification-test/certification/certtool/certtool.go
+++ b/cnf-certification-test/certification/certtool/certtool.go
@@ -23,6 +23,7 @@ import (
 	version "github.com/hashicorp/go-version"
 	"github.com/test-network-function/cnf-certification-test/internal/api"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
+	"github.com/test-network-function/cnf-certification-test/pkg/provider"
 	"helm.sh/helm/v3/pkg/release"
 )
 
@@ -104,4 +105,17 @@ func IsReleaseCertified(helm *release.Release, ourKubeVersion string, out api.Ch
 		}
 	}
 	return false
+}
+
+func GetContainersToQuery(env *provider.TestEnvironment) map[configuration.ContainerImageIdentifier]bool {
+	containersToQuery := make(map[configuration.ContainerImageIdentifier]bool)
+	for _, c := range env.Config.CertifiedContainerInfo {
+		containersToQuery[c] = true
+	}
+	if env.Config.CheckDiscoveredContainerCertificationStatus {
+		for _, cut := range env.Containers {
+			containersToQuery[cut.ContainerImageIdentifier] = true
+		}
+	}
+	return containersToQuery
 }

--- a/cnf-certification-test/certification/certtool/certtool_test.go
+++ b/cnf-certification-test/certification/certtool/certtool_test.go
@@ -246,7 +246,7 @@ func TestIsReleaseCertified(t *testing.T) {
 
 //nolint:funlen
 func TestGetContainersToQuery(t *testing.T) {
-	generateEnv := func(certName string, checkDiscovered bool, CIDs []configuration.ContainerImageIdentifier, CIIs []*provider.Container) *provider.TestEnvironment {
+	generateEnv := func(checkDiscovered bool, CIDs []configuration.ContainerImageIdentifier, CIIs []*provider.Container) *provider.TestEnvironment {
 		return &provider.TestEnvironment{
 			Config: configuration.TestConfiguration{
 				CertifiedContainerInfo:                      CIDs,
@@ -261,7 +261,7 @@ func TestGetContainersToQuery(t *testing.T) {
 		expectedMap map[configuration.ContainerImageIdentifier]bool
 	}{
 		{ // Test Case #1 - Different images in the map
-			testEnv: generateEnv("certified1", true, []configuration.ContainerImageIdentifier{
+			testEnv: generateEnv(true, []configuration.ContainerImageIdentifier{
 				{
 					Name: "image1",
 				},
@@ -278,7 +278,7 @@ func TestGetContainersToQuery(t *testing.T) {
 			},
 		},
 		{ // Test Case 2 - Map is overwritten with image1
-			testEnv: generateEnv("certified2", true, []configuration.ContainerImageIdentifier{
+			testEnv: generateEnv(true, []configuration.ContainerImageIdentifier{
 				{
 					Name: "image1",
 				},
@@ -294,11 +294,11 @@ func TestGetContainersToQuery(t *testing.T) {
 			},
 		},
 		{ // Test Case 3 - Empty map
-			testEnv:     generateEnv("certified3", true, []configuration.ContainerImageIdentifier{}, []*provider.Container{}),
+			testEnv:     generateEnv(true, []configuration.ContainerImageIdentifier{}, []*provider.Container{}),
 			expectedMap: map[configuration.ContainerImageIdentifier]bool{},
 		},
 		{ // Test Case 4 - CheckDiscoveredContainerCertificationStatus is false
-			testEnv: generateEnv("certified4", false, []configuration.ContainerImageIdentifier{
+			testEnv: generateEnv(false, []configuration.ContainerImageIdentifier{
 				{
 					Name: "image1",
 				},

--- a/cnf-certification-test/certification/certtool/certtool_test.go
+++ b/cnf-certification-test/certification/certtool/certtool_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/cnf-certification-test/internal/api"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
+	"github.com/test-network-function/cnf-certification-test/pkg/provider"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/release"
 )
@@ -240,5 +241,78 @@ func TestIsReleaseCertified(t *testing.T) {
 
 	for _, tc := range testCases {
 		assert.Equal(t, tc.expectedCertified, IsReleaseCertified(tc.testRelease, tc.testKubeVersion, tc.testChartStruct))
+	}
+}
+
+//nolint:funlen
+func TestGetContainersToQuery(t *testing.T) {
+	generateEnv := func(certName string, checkDiscovered bool, CIDs []configuration.ContainerImageIdentifier, CIIs []*provider.Container) *provider.TestEnvironment {
+		return &provider.TestEnvironment{
+			Config: configuration.TestConfiguration{
+				CertifiedContainerInfo:                      CIDs,
+				CheckDiscoveredContainerCertificationStatus: checkDiscovered,
+			},
+			Containers: CIIs,
+		}
+	}
+
+	testCases := []struct {
+		testEnv     *provider.TestEnvironment
+		expectedMap map[configuration.ContainerImageIdentifier]bool
+	}{
+		{ // Test Case #1 - Different images in the map
+			testEnv: generateEnv("certified1", true, []configuration.ContainerImageIdentifier{
+				{
+					Name: "image1",
+				},
+			}, []*provider.Container{
+				{
+					ContainerImageIdentifier: configuration.ContainerImageIdentifier{
+						Name: "image2",
+					},
+				},
+			}),
+			expectedMap: map[configuration.ContainerImageIdentifier]bool{
+				{Name: "image1"}: true,
+				{Name: "image2"}: true,
+			},
+		},
+		{ // Test Case 2 - Map is overwritten with image1
+			testEnv: generateEnv("certified2", true, []configuration.ContainerImageIdentifier{
+				{
+					Name: "image1",
+				},
+			}, []*provider.Container{
+				{
+					ContainerImageIdentifier: configuration.ContainerImageIdentifier{
+						Name: "image1",
+					},
+				},
+			}),
+			expectedMap: map[configuration.ContainerImageIdentifier]bool{
+				{Name: "image1"}: true,
+			},
+		},
+		{ // Test Case 3 - Empty map
+			testEnv:     generateEnv("certified3", true, []configuration.ContainerImageIdentifier{}, []*provider.Container{}),
+			expectedMap: map[configuration.ContainerImageIdentifier]bool{},
+		},
+		{ // Test Case 4 - CheckDiscoveredContainerCertificationStatus is false
+			testEnv: generateEnv("certified4", false, []configuration.ContainerImageIdentifier{
+				{
+					Name: "image1",
+				},
+			}, []*provider.Container{
+				{ContainerImageIdentifier: configuration.ContainerImageIdentifier{Name: "image2"}},
+				{ContainerImageIdentifier: configuration.ContainerImageIdentifier{Name: "image3"}},
+			}),
+			expectedMap: map[configuration.ContainerImageIdentifier]bool{
+				{Name: "image1"}: true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedMap, GetContainersToQuery(tc.testEnv))
 	}
 }

--- a/cnf-certification-test/certification/suite.go
+++ b/cnf-certification-test/certification/suite.go
@@ -66,16 +66,7 @@ func testContainerCertificationStatus(env *provider.TestEnvironment) {
 	// Query API for certification status of listed containers
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestContainerIsCertifiedIdentifier)
 	ginkgo.It(testID, ginkgo.Label(Online, testID), func() {
-		containersToQuery := make(map[configuration.ContainerImageIdentifier]bool)
-
-		for _, c := range env.Config.CertifiedContainerInfo {
-			containersToQuery[c] = true
-		}
-		if env.Config.CheckDiscoveredContainerCertificationStatus {
-			for _, cut := range env.Containers {
-				containersToQuery[cut.ContainerImageIdentifier] = true
-			}
-		}
+		containersToQuery := certtool.GetContainersToQuery(env)
 		if len(containersToQuery) == 0 {
 			ginkgo.Skip("No containers to check configured in tnf_config.yml")
 		}


### PR DESCRIPTION
Broke out some more of the looping complexity to be able to better test it.  Created `GetContainersToQuery` which will look through the env for containers to query.

The `certtool` package is now at: `coverage: 93.0% of statements`.