### PR TITLE
Fix platform-alteration-base-image TC

### DIFF
--- a/cnf-certification-test/platform/cnffsdiff/fsdiff.go
+++ b/cnf-certification-test/platform/cnffsdiff/fsdiff.go
@@ -17,6 +17,7 @@
 package cnffsdiff
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/sirupsen/logrus"
@@ -41,7 +42,7 @@ type FsDiff struct {
 }
 
 type FsDiffFuncs interface {
-	RunTest(ctx clientsholder.Context)
+	RunTest(ctx clientsholder.Context, containerUID string)
 	GetResults() int
 }
 
@@ -52,9 +53,9 @@ func NewFsDiffTester(client clientsholder.Command) *FsDiff {
 	}
 }
 
-func (f *FsDiff) RunTest(ctx clientsholder.Context) {
+func (f *FsDiff) RunTest(ctx clientsholder.Context, containerUID string) {
 	expected := []string{varlibrpm, varlibdpkg, bin, sbin, lib, usrbin, usrsbin, usrlib}
-	output, outerr, err := f.ClientHolder.ExecCommandContainer(ctx, `chroot /host podman diff --format json`)
+	output, outerr, err := f.ClientHolder.ExecCommandContainer(ctx, fmt.Sprintf("chroot /host podman diff --format json %s", containerUID))
 	if err != nil {
 		logrus.Errorln("can't execute command on container ", err)
 		f.result = testhelper.ERROR

--- a/cnf-certification-test/platform/cnffsdiff/fsdiff_test.go
+++ b/cnf-certification-test/platform/cnffsdiff/fsdiff_test.go
@@ -82,7 +82,7 @@ func TestRunTest(t *testing.T) {
 		}
 
 		fsdiff := NewFsDiffTester(chm)
-		fsdiff.RunTest(clientsholder.Context{})
+		fsdiff.RunTest(clientsholder.Context{}, "fakeUID")
 		assert.Equal(t, tc.expectedResult, fsdiff.GetResults())
 	}
 }

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -93,7 +93,7 @@ func testContainersFsDiff(env *provider.TestEnvironment, testerFuncs cnffsdiff.F
 			Namespace:     debugPod.Namespace,
 			Podname:       debugPod.Name,
 			Containername: debugPod.Spec.Containers[0].Name,
-		})
+		}, cut.UID)
 		switch testerFuncs.GetResults() {
 		case testhelper.SUCCESS:
 			continue


### PR DESCRIPTION
The TC was failing in real OCP clusters.
The fsDiff function was not using the target container UID, so the
command was just showing this error when executed:

ERROR  [Apr 25 13:11:31.770][command.go: 76] command: chroot /host
podman diff --format json
ERROR  [Apr 25 13:11:31.770][command.go: 77] stderr: Error: "podman
diff" requires a name, id, or the "--latest" flag
ERROR  [Apr 25 13:11:31.770][command.go: 78] stdout: