### PR TITLE
In-line the ListOptions

### DIFF
--- a/cnf-certification-test/operator/suite.go
+++ b/cnf-certification-test/operator/suite.go
@@ -121,8 +121,7 @@ func testOperatorOlmSubscription(env *provider.TestEnvironment) {
 	for i := range env.Operators {
 		csv := env.Operators[i].Csv
 		ginkgo.By(fmt.Sprintf("Checking OLM subscription for %s", provider.CsvToString(csv)))
-		options := metav1.ListOptions{}
-		subscriptions, err := ocpClient.OlmClient.OperatorsV1alpha1().Subscriptions(csv.Namespace).List(context.TODO(), options)
+		subscriptions, err := ocpClient.OlmClient.OperatorsV1alpha1().Subscriptions(csv.Namespace).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			ginkgo.Fail(fmt.Sprintf("Failed to get subscription for %s: %s", provider.CsvToString(csv), err))
 		}

--- a/pkg/autodiscover/autodiscover_crds.go
+++ b/pkg/autodiscover/autodiscover_crds.go
@@ -33,8 +33,7 @@ import (
 // getClusterCrdNames returns a list of crd names found in the cluster.
 func getClusterCrdNames() (crdList []*apiextv1.CustomResourceDefinition, err error) {
 	oc := clientsholder.GetClientsHolder()
-	options := metav1.ListOptions{}
-	crds, err := oc.APIExtClient.CustomResourceDefinitions().List(context.TODO(), options)
+	crds, err := oc.APIExtClient.CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		logrus.Errorln("error when listing crds")
 		return crdList, err

--- a/pkg/autodiscover/autodiscover_operators.go
+++ b/pkg/autodiscover/autodiscover_operators.go
@@ -35,10 +35,10 @@ func findOperatorsByLabel(olmClient clientOlm.Interface, labels []configuration.
 		logrus.Debugf("Searching CSVs in namespace %s", ns)
 		for _, label := range labels {
 			logrus.Debugf("Searching CSVs with label %+v", label)
-			options := metav1.ListOptions{}
 			label := buildLabelQuery(label)
-			options.LabelSelector = label
-			csvList, err := olmClient.OperatorsV1alpha1().ClusterServiceVersions(ns.Name).List(context.TODO(), options)
+			csvList, err := olmClient.OperatorsV1alpha1().ClusterServiceVersions(ns.Name).List(context.TODO(), metav1.ListOptions{
+				LabelSelector: label,
+			})
 			if err != nil {
 				logrus.Errorln("error when listing csvs in ns=", ns, " label=", label)
 				continue
@@ -60,10 +60,10 @@ func findSubscriptions(olmClient clientOlm.Interface, labels []configuration.Lab
 		logrus.Debugf("Searching subscriptions in namespace %s", ns)
 		for _, label := range labels {
 			logrus.Debugf("Searching subscriptions with label %+v", label)
-			options := metav1.ListOptions{}
 			label := buildLabelQuery(label)
-			options.LabelSelector = label
-			subscription, err := olmClient.OperatorsV1alpha1().Subscriptions(ns).List(context.TODO(), metav1.ListOptions{})
+			subscription, err := olmClient.OperatorsV1alpha1().Subscriptions(ns).List(context.TODO(), metav1.ListOptions{
+				LabelSelector: label,
+			})
 			if err != nil {
 				logrus.Errorln("error when listing subscriptions in ns=", ns, " label=", label)
 				continue

--- a/pkg/autodiscover/autodiscover_podset.go
+++ b/pkg/autodiscover/autodiscover_podset.go
@@ -55,9 +55,8 @@ func findDeploymentByLabel(
 ) []v1.Deployment {
 	deployments := []v1.Deployment{}
 	for _, ns := range namespaces {
-		options := metav1.ListOptions{}
 		dpClient := appClient.Deployments(ns)
-		dps, err := dpClient.List(context.TODO(), options)
+		dps, err := dpClient.List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			logrus.Errorln("error when listing Deployments in ns=", ns, " try to proceed")
 			continue
@@ -92,10 +91,10 @@ func findStatefulSetByLabel(
 		for _, l := range labels {
 			label := buildLabelQuery(l)
 			logrus.Trace("find StatefulSet in ", ns, " using label ", label)
-			options := metav1.ListOptions{}
-			options.LabelSelector = label
 			statefulSetClient := appClient.StatefulSets(ns)
-			ss, err := statefulSetClient.List(context.TODO(), options)
+			ss, err := statefulSetClient.List(context.TODO(), metav1.ListOptions{
+				LabelSelector: label,
+			})
 			if err != nil {
 				logrus.Errorln("error when listing StatefulSets in ns=", ns, " label=", label, " trying to proceed")
 				continue


### PR DESCRIPTION
Found a bug in the `findSubscriptions` function where it was creating the `options` var but then not using it.

This should make everything more uniform.

Might have merge conflicts with #145.