### PR TITLE
Statefulsets autodiscovery changed to check inner pod's template labels.

### DIFF
--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -312,8 +312,8 @@ func testPodsRecreation(env *provider.TestEnvironment) { //nolint:funlen
 	ginkgo.By("Testing initial state for deployments")
 	defer env.SetNeedsRefresh()
 	claimsLog, atLeastOnePodsetNotReady := podsets.WaitForAllPodSetReady(env, timeoutPodSetReady)
-	tnf.ClaimFilePrintf("%s", claimsLog)
 	if atLeastOnePodsetNotReady {
+		tnf.ClaimFilePrintf("%s", claimsLog)
 		ginkgo.Fail("Some deployments or stateful sets are not in a good initial state. Cannot perform test.")
 	}
 	for n := range podsets.GetAllNodesForAllPodSets(env.Pods) {
@@ -335,8 +335,13 @@ func testPodsRecreation(env *provider.TestEnvironment) { //nolint:funlen
 		if err != nil {
 			ginkgo.Fail(fmt.Sprintf("Draining node %s failed with err: %s. Test inconclusive", n, err))
 		}
-		claimsLog, _ = podsets.WaitForAllPodSetReady(env, nodeTimeout)
-		tnf.ClaimFilePrintf("%s", claimsLog)
+
+		claimsLog, podsNotReady := podsets.WaitForAllPodSetReady(env, nodeTimeout)
+		if podsNotReady {
+			tnf.ClaimFilePrintf("%s", claimsLog)
+			ginkgo.Fail(fmt.Sprintf("Some pods are not ready after draining the node %s", n))
+		}
+
 		err = podrecreation.CordonHelper(n, podrecreation.Uncordon)
 		if err != nil {
 			logrus.Fatalf("error uncordoning the node: %s", n)

--- a/pkg/autodiscover/autodiscover_podset.go
+++ b/pkg/autodiscover/autodiscover_podset.go
@@ -58,7 +58,7 @@ func findDeploymentByLabel(
 	for _, ns := range namespaces {
 		dps, err := appClient.Deployments(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
-			logrus.Errorln("Failed to list deployments in ns=", ns, ", trying to proceed")
+			logrus.Errorf("Failed to list deployments in ns=%s, err: %v . Trying to proceed.", ns, err)
 			continue
 		}
 		if len(dps.Items) == 0 {
@@ -92,7 +92,7 @@ func findStatefulSetByLabel(
 	for _, ns := range namespaces {
 		ss, err := appClient.StatefulSets(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
-			logrus.Errorln("Failed to list statefulsets in ns=", ns, ", trying to proceed")
+			logrus.Errorf("Failed to list statefulsets in ns=%s, err: %v . Trying to proceed.", ns, err)
 			continue
 		}
 		if len(ss.Items) == 0 {

--- a/pkg/autodiscover/autodiscover_podset.go
+++ b/pkg/autodiscover/autodiscover_podset.go
@@ -48,6 +48,7 @@ func FindStatefulsetByNameByNamespace(appClient appv1client.AppsV1Interface, nam
 	return ss, nil
 }
 
+//nolint:dupl
 func findDeploymentByLabel(
 	appClient appv1client.AppsV1Interface,
 	labels []configuration.Label,
@@ -81,6 +82,7 @@ func findDeploymentByLabel(
 	return deployments
 }
 
+//nolint:dupl
 func findStatefulSetByLabel(
 	appClient appv1client.AppsV1Interface,
 	labels []configuration.Label,

--- a/pkg/autodiscover/autodiscover_podset.go
+++ b/pkg/autodiscover/autodiscover_podset.go
@@ -55,29 +55,28 @@ func findDeploymentByLabel(
 ) []v1.Deployment {
 	deployments := []v1.Deployment{}
 	for _, ns := range namespaces {
-		options := metav1.ListOptions{}
-		dpClient := appClient.Deployments(ns)
-		dps, err := dpClient.List(context.TODO(), options)
+		dps, err := appClient.Deployments(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
-			logrus.Errorln("error when listing Deployments in ns=", ns, " try to proceed")
+			logrus.Errorln("Failed to list deployments in ns=", ns, ", trying to proceed")
 			continue
 		}
 		if len(dps.Items) == 0 {
-			logrus.Trace("did not find any deployments in ns=", ns)
+			logrus.Warn("Did not find any deployments in ns=", ns)
 		}
+
 		for i := 0; i < len(dps.Items); i++ {
 			for _, l := range labels {
 				key, value := buildLabelKeyValue(l)
-				logrus.Trace("find deployment in ", ns, " using label ", key, "=", value)
+				logrus.Tracef("Searching pods in deployment %q found in ns %q using label %s=%s", dps.Items[i].Name, ns, key, value)
 				if dps.Items[i].Spec.Template.ObjectMeta.Labels[key] == value {
 					deployments = append(deployments, dps.Items[i])
-					logrus.Info("deployment ", dps.Items[i].Name, " found in ", dps.Items[i].Namespace)
+					logrus.Info("Deployment ", dps.Items[i].Name, " found in ns ", ns)
 				}
 			}
 		}
 	}
 	if len(deployments) == 0 {
-		logrus.Info("did not find any deployments in all namespaces")
+		logrus.Warnf("Did not find any deployment in the configured namespaces %v", namespaces)
 	}
 	return deployments
 }
@@ -87,26 +86,32 @@ func findStatefulSetByLabel(
 	labels []configuration.Label,
 	namespaces []string,
 ) []v1.StatefulSet {
-	statefulset := []v1.StatefulSet{}
+	statefulsets := []v1.StatefulSet{}
 	for _, ns := range namespaces {
-		for _, l := range labels {
-			label := buildLabelQuery(l)
-			logrus.Trace("find StatefulSet in ", ns, " using label ", label)
-			options := metav1.ListOptions{}
-			options.LabelSelector = label
-			statefulSetClient := appClient.StatefulSets(ns)
-			ss, err := statefulSetClient.List(context.TODO(), options)
-			if err != nil {
-				logrus.Errorln("error when listing StatefulSets in ns=", ns, " label=", label, " trying to proceed")
-				continue
+		ss, err := appClient.StatefulSets(ns).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			logrus.Errorln("Failed to list statefulsets in ns=", ns, ", trying to proceed")
+			continue
+		}
+		if len(ss.Items) == 0 {
+			logrus.Warn("Did not find any statefulSet in ns=", ns)
+		}
+
+		for i := 0; i < len(ss.Items); i++ {
+			for _, l := range labels {
+				key, value := buildLabelKeyValue(l)
+				logrus.Tracef("Searching pods in statefulset %q found in ns %q using label %s=%s", ss.Items[i].Name, ns, key, value)
+				if ss.Items[i].Spec.Template.ObjectMeta.Labels[key] == value {
+					statefulsets = append(statefulsets, ss.Items[i])
+					logrus.Info("StatefulSet ", ss.Items[i].Name, " found in ns ", ns)
+				}
 			}
-			statefulset = append(statefulset, ss.Items...)
 		}
 	}
-	if len(statefulset) == 0 {
-		logrus.Info("did not find any statefulset")
+	if len(statefulsets) == 0 {
+		logrus.Warnf("Did not find any statefulset in the configured namespaces %v", namespaces)
 	}
-	return statefulset
+	return statefulsets
 }
 
 func findHpaControllers(cs kubernetes.Interface, namespaces []string) map[string]*v1scaling.HorizontalPodAutoscaler {


### PR DESCRIPTION
This commit makes both deployments and statefulsets being discovered in
the same way: checking inner pod's labels to match the configured
targetPodLabels.

+ Traces improved. Show warning when no resources have been found in the
  configured namespaces.