### PR TITLE
Manually update Ginkgo to 2.1.4

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -143,7 +143,7 @@ jobs:
         run: go install github.com/golang/mock/mockgen@v1.6.0 && make mocks
 
       - name: Install ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.3
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.4
 
       - name: Execute `make build`
         run: make build

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ update-deps:
 
 # Install build tools and other required software.
 install-tools:
-	go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.3
+	go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.4
 	go install github.com/onsi/gomega
 	go install github.com/golang/mock/mockgen@v1.6.0
 


### PR DESCRIPTION
Dependabot [updated](https://github.com/test-network-function/cnf-certification-test/pull/154) the go.mod but we need to also do this manual step.