### PR TITLE
Fix High Availability Test

### DIFF
--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -575,9 +575,9 @@ instantiation on any underlying Node.`),
 	TestPodHighAvailabilityBestPractices: {
 		Identifier:  TestPodHighAvailabilityBestPractices,
 		Type:        informativeResult,
-		Remediation: `In high availability cases, Pod replicas value should be set to more than 1 .`,
+		Remediation: `In high availability cases, Pod podAntiAffinity rule should be specified for pod scheduling and pod replica value is set to more than 1 .`,
 		Description: formDescription(TestPodHighAvailabilityBestPractices,
-			`ensures that CNF Pods replicas value is set to more than 1.`),
+			`ensures that CNF Pods specify podAntiAffinity rules and replica value is set to more than 1.`),
 		BestPracticeReference: bestPracticeDocV1dot2URL + " Section 6.2",
 	},
 

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -283,13 +283,23 @@ func testHighAvailability(env *provider.TestEnvironment) {
 		badDeployments := []string{}
 		badStatefulSet := []string{}
 		for _, dp := range env.Deployments {
-			if dp.Spec.Replicas == nil || *(dp.Spec.Replicas) == 1 {
+			if dp.Spec.Replicas == nil || *(dp.Spec.Replicas) <= 1 {
+				badDeployments = append(badDeployments, provider.DeploymentToString(dp))
+				continue
+			}
+			if dp.Spec.Template.Spec.Affinity == nil ||
+				dp.Spec.Template.Spec.Affinity.PodAntiAffinity == nil {
 				badDeployments = append(badDeployments, provider.DeploymentToString(dp))
 			}
 		}
 		for _, st := range env.StatetfulSets {
-			if st.Spec.Replicas == nil || *(st.Spec.Replicas) == 1 {
+			if st.Spec.Replicas == nil || *(st.Spec.Replicas) <= 1 {
 				badStatefulSet = append(badStatefulSet, provider.StatefulsetToString(st))
+				continue
+			}
+			if st.Spec.Template.Spec.Affinity == nil ||
+				st.Spec.Template.Spec.Affinity.PodAntiAffinity == nil {
+				badDeployments = append(badDeployments, provider.StatefulsetToString(st))
 			}
 		}
 


### PR DESCRIPTION
In 3.3.0, to pass the high availability check, the CNF should define pod anti affinity to avoid deploying Pods in the same node.
The number of replica should be higher than 1 as well.
In the current code, we check for replicas number only, this PT fixes that.