### PR TITLE
wait for pod to be deleted to complete the drain

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -200,9 +200,9 @@ Best Practice Reference|
 Property|Description
 ---|---
 Version|v1.0.0
-Description|http://test-network-function.com/testcases/lifecycle/pod-high-availability ensures that CNF Pods replicas value is set to more than 1.
+Description|http://test-network-function.com/testcases/lifecycle/pod-high-availability ensures that CNF Pods specify podAntiAffinity rules and replica value is set to more than 1.
 Result Type|informative
-Suggested Remediation|In high availability cases, Pod replicas value should be set to more than 1 .
+Suggested Remediation|In high availability cases, Pod podAntiAffinity rule should be specified for pod scheduling and pod replica value is set to more than 1 .
 Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
 ### http://test-network-function.com/testcases/lifecycle/pod-owner-type
 

--- a/cnf-certification-test/lifecycle/podrecreation/podrecreation_test.go
+++ b/cnf-certification-test/lifecycle/podrecreation/podrecreation_test.go
@@ -83,7 +83,7 @@ func TestCountPodsWithDelete(t *testing.T) {
 		clientsholder.ClearTestClientsHolder()
 		_ = clientsholder.GetTestClientsHolder(testRuntimeObjects)
 
-		result, err := CountPodsWithDelete("node1", true)
+		result, err := CountPodsWithDelete("node1", true, false)
 		assert.Nil(t, err)
 		assert.Equal(t, tc.expectedCount, result)
 	}

--- a/cnf-certification-test/lifecycle/podrecreation/podrecreation_test.go
+++ b/cnf-certification-test/lifecycle/podrecreation/podrecreation_test.go
@@ -83,7 +83,7 @@ func TestCountPodsWithDelete(t *testing.T) {
 		clientsholder.ClearTestClientsHolder()
 		_ = clientsholder.GetTestClientsHolder(testRuntimeObjects)
 
-		result, err := CountPodsWithDelete("node1", true, false)
+		result, err := CountPodsWithDelete("node1", DeleteBackground)
 		assert.Nil(t, err)
 		assert.Equal(t, tc.expectedCount, result)
 	}

--- a/cnf-certification-test/lifecycle/podsets/podsets.go
+++ b/cnf-certification-test/lifecycle/podsets/podsets.go
@@ -117,7 +117,7 @@ func WaitForAllPodSetReady(env *provider.TestEnvironment, timeoutPodSetReady tim
 		}
 	}
 	for _, sut := range env.StatetfulSets {
-		isReady := WaitForDeploymentSetReady(sut.Namespace, sut.Name, timeoutPodSetReady)
+		isReady := WaitForStatefulSetReady(sut.Namespace, sut.Name, timeoutPodSetReady)
 		if isReady {
 			claimsLog = claimsLog.AddLogLine("%s Status: OK", provider.StatefulsetToString(sut))
 		} else {

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -335,13 +335,13 @@ func testPodsRecreation(env *provider.TestEnvironment) { //nolint:funlen
 		}
 		ginkgo.By(fmt.Sprintf("Draining and Cordoning node %s: ", n))
 		logrus.Debugf("node: %s cordoned", n)
-		count, err := podrecreation.CountPodsWithDelete(n, false, true)
+		count, err := podrecreation.CountPodsWithDelete(n, podrecreation.NoDelete)
 		if err != nil {
 			ginkgo.Fail(fmt.Sprintf("Getting pods list to drain in node %s failed with err: %s. Test inconclusive.", n, err))
 		}
 		nodeTimeout := timeoutPodSetReady + timeoutPodRecreationPerPod*time.Duration(count)
 		logrus.Debugf("draining node: %s with timeout: %s", n, nodeTimeout.String())
-		_, err = podrecreation.CountPodsWithDelete(n, true, true)
+		_, err = podrecreation.CountPodsWithDelete(n, podrecreation.DeleteForeground)
 		if err != nil {
 			ginkgo.Fail(fmt.Sprintf("Draining node %s failed with err: %s. Test inconclusive", n, err))
 		}

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -335,13 +335,13 @@ func testPodsRecreation(env *provider.TestEnvironment) { //nolint:funlen
 		}
 		ginkgo.By(fmt.Sprintf("Draining and Cordoning node %s: ", n))
 		logrus.Debugf("node: %s cordoned", n)
-		count, err := podrecreation.CountPodsWithDelete(n, false)
+		count, err := podrecreation.CountPodsWithDelete(n, false, true)
 		if err != nil {
 			ginkgo.Fail(fmt.Sprintf("Getting pods list to drain in node %s failed with err: %s. Test inconclusive.", n, err))
 		}
 		nodeTimeout := timeoutPodSetReady + timeoutPodRecreationPerPod*time.Duration(count)
 		logrus.Debugf("draining node: %s with timeout: %s", n, nodeTimeout.String())
-		_, err = podrecreation.CountPodsWithDelete(n, true)
+		_, err = podrecreation.CountPodsWithDelete(n, true, true)
 		if err != nil {
 			ginkgo.Fail(fmt.Sprintf("Draining node %s failed with err: %s. Test inconclusive", n, err))
 		}


### PR DESCRIPTION
Added code to wait for the pods to be completely deleted during the pod recreation node drain. Otherwise the deployment/statefulset api will not pickup the that the pods have been deleted.
Used mutithreaded approach to speed up deletion