### PR TITLE
Add tests for SkipIfEmpty funcs

### DIFF
--- a/pkg/testhelper/testhelper_test.go
+++ b/pkg/testhelper/testhelper_test.go
@@ -56,6 +56,10 @@ func TestSkipIfEmptyFuncs(t *testing.T) {
 			objects: []string{"test"},
 			skipped: false,
 		},
+		{ // Test Case #4 - Multiple objects
+			objects: []string{"test1", "test2"},
+			skipped: false,
+		},
 		// Note: Cannot test calls to panic
 	}
 

--- a/pkg/testhelper/testhelper_test.go
+++ b/pkg/testhelper/testhelper_test.go
@@ -17,6 +17,7 @@
 package testhelper
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,5 +36,49 @@ func TestResultToString(t *testing.T) {
 
 	for _, tc := range testCases {
 		assert.Equal(t, tc.expectedResult, ResultToString(tc.input))
+	}
+}
+
+func TestSkipIfEmptyFuncs(t *testing.T) {
+	testCases := []struct {
+		objects interface{}
+		skipped bool
+	}{
+		{ // Test Case #1 - Skip because objects is empty, no panic because []string type
+			objects: []string{},
+			skipped: true,
+		},
+		{ // Test Case #2 - Skip because objects is empty, no panic because map type
+			objects: make(map[string]string),
+			skipped: true,
+		},
+		{ // Test Case #3 - No skip because objects is populated, no panic because []string type
+			objects: []string{"test"},
+			skipped: false,
+		},
+		// Note: Cannot test calls to panic
+	}
+
+	for _, tc := range testCases {
+		result := false
+
+		SkipIfEmptyAll(func(s string, i ...int) {
+			if strings.Contains(s, "Test skipped") {
+				result = true
+			} else {
+				result = false
+			}
+		}, tc.objects)
+		assert.Equal(t, tc.skipped, result)
+
+		SkipIfEmptyAny(func(s string, i ...int) {
+			if strings.Contains(s, "Test skipped") {
+				result = true
+			} else {
+				result = false
+			}
+		}, tc.objects)
+
+		assert.Equal(t, tc.skipped, result)
 	}
 }

--- a/pkg/testhelper/testhelper_test.go
+++ b/pkg/testhelper/testhelper_test.go
@@ -39,26 +39,35 @@ func TestResultToString(t *testing.T) {
 	}
 }
 
+//nolint:funlen
 func TestSkipIfEmptyFuncs(t *testing.T) {
 	testCases := []struct {
-		objects interface{}
-		skipped bool
+		map1, slice1           interface{}
+		skippedAny, skippedAll bool
 	}{
 		{ // Test Case #1 - Skip because objects is empty, no panic because []string type
-			objects: []string{},
-			skipped: true,
+			slice1:     []string{},
+			map1:       make(map[string]string),
+			skippedAny: true,
+			skippedAll: true,
 		},
 		{ // Test Case #2 - Skip because objects is empty, no panic because map type
-			objects: make(map[string]string),
-			skipped: true,
+			slice1:     make(map[string]string),
+			map1:       make(map[string]string),
+			skippedAny: true,
+			skippedAll: true,
 		},
 		{ // Test Case #3 - No skip because objects is populated, no panic because []string type
-			objects: []string{"test"},
-			skipped: false,
+			slice1:     []string{"test"},
+			map1:       make(map[string]string),
+			skippedAny: true,
+			skippedAll: false,
 		},
 		{ // Test Case #4 - Multiple objects
-			objects: []string{"test1", "test2"},
-			skipped: false,
+			slice1:     []string{"test1", "test2"},
+			map1:       make(map[string]string),
+			skippedAny: true,
+			skippedAll: false,
 		},
 		// Note: Cannot test calls to panic
 	}
@@ -72,8 +81,8 @@ func TestSkipIfEmptyFuncs(t *testing.T) {
 			} else {
 				result = false
 			}
-		}, tc.objects)
-		assert.Equal(t, tc.skipped, result)
+		}, tc.slice1, tc.map1)
+		assert.Equal(t, tc.skippedAll, result)
 
 		SkipIfEmptyAny(func(s string, i ...int) {
 			if strings.Contains(s, "Test skipped") {
@@ -81,8 +90,8 @@ func TestSkipIfEmptyFuncs(t *testing.T) {
 			} else {
 				result = false
 			}
-		}, tc.objects)
+		}, tc.slice1, tc.map1)
 
-		assert.Equal(t, tc.skipped, result)
+		assert.Equal(t, tc.skippedAny, result)
 	}
 }


### PR DESCRIPTION
New coverage level: `coverage: 90.9% of statements`.

To be honest these two functions seem very similar and there might be room to merge the two in a subsequent PR.