### PR TITLE
Add scaling unit tests

### DIFF
--- a/cnf-certification-test/lifecycle/podsets/podsets.go
+++ b/cnf-certification-test/lifecycle/podsets/podsets.go
@@ -31,7 +31,7 @@ const (
 	StatefulsetString = "StatefulSet"
 )
 
-func WaitForDeploymentSetReady(ns, name string, timeout time.Duration) bool {
+var WaitForDeploymentSetReady = func(ns, name string, timeout time.Duration) bool {
 	logrus.Trace("check if deployment ", ns, ":", name, " is ready ")
 	clients := clientsholder.GetClientsHolder()
 	start := time.Now()
@@ -48,6 +48,7 @@ func WaitForDeploymentSetReady(ns, name string, timeout time.Duration) bool {
 	logrus.Error("deployment ", ns, ":", name, " is not ready ")
 	return false
 }
+
 func IsDeploymentReady(deployment *v1app.Deployment) bool {
 	notReady := true
 	for _, condition := range deployment.Status.Conditions {

--- a/cnf-certification-test/lifecycle/scaling/deployment_scaling_test.go
+++ b/cnf-certification-test/lifecycle/scaling/deployment_scaling_test.go
@@ -15,3 +15,72 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package scaling
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/lifecycle/podsets"
+	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
+	v1app "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+//nolint:funlen
+func TestScaleDeploymentFunc(t *testing.T) {
+	generateDeployment := func(name string, replicas *int32) *v1app.Deployment {
+		return &v1app.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "namespace1",
+			},
+			Spec: v1app.DeploymentSpec{
+				Replicas: replicas,
+			},
+		}
+	}
+
+	testCases := []struct {
+		deploymentName string
+		replicaCount   int
+	}{
+		{
+			deploymentName: "dp1",
+			replicaCount:   3,
+		},
+		{
+			deploymentName: "dp2",
+			replicaCount:   0,
+		},
+	}
+
+	// Always return that the Deployment is Ready
+	origFunc := podsets.WaitForDeploymentSetReady
+	defer func() {
+		podsets.WaitForDeploymentSetReady = origFunc
+	}()
+	podsets.WaitForDeploymentSetReady = func(ns, name string, timeout time.Duration) bool {
+		return true
+	}
+
+	for _, tc := range testCases {
+		var runtimeObjects []runtime.Object
+		var intVar *int32
+		intVar = new(int32)
+		*intVar = int32(tc.replicaCount)
+		tempDP := generateDeployment(tc.deploymentName, intVar)
+		runtimeObjects = append(runtimeObjects, tempDP)
+		c := clientsholder.GetTestClientsHolder(runtimeObjects)
+
+		// Run the function
+		TestScaleDeployment(tempDP, 10*time.Second)
+
+		// Get the deployment from the fake API
+		dp, err := c.K8sClient.AppsV1().Deployments("namespace1").Get(context.TODO(), tc.deploymentName, metav1.GetOptions{})
+		assert.Nil(t, err)
+		assert.Equal(t, int32(tc.replicaCount), *dp.Spec.Replicas)
+	}
+}

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	ocpMachine "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextv1fake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
@@ -63,6 +64,7 @@ func SetupFakeOlmClient(olmMockObjects []runtime.Object) {
 // Only pure k8s interfaces will be available. The runtime objects must be pure k8s ones.
 // For other (OLM, )
 // runtime mocking objects loading, use the proper clientset mocking function.
+//nolint:funlen
 func GetTestClientsHolder(k8sMockObjects []runtime.Object, filenames ...string) *ClientsHolder {
 	// Build slices of different objects depending on what client
 	// is supposed to expect them.
@@ -88,6 +90,8 @@ func GetTestClientsHolder(k8sMockObjects []runtime.Object, filenames ...string) 
 		case *corev1.Pod:
 			k8sClientObjects = append(k8sClientObjects, v)
 		case *corev1.Node:
+			k8sClientObjects = append(k8sClientObjects, v)
+		case *appsv1.Deployment:
 			k8sClientObjects = append(k8sClientObjects, v)
 
 		// K8s Extension Client Objects


### PR DESCRIPTION
`coverage: 14.1% of statements` 

I will add more tests for the HPA Scaler (very similar) in another PR.

- Changed `WaitForDeploymentSetReady` to be a func var to be able to override the check for AvailableReplicas.
- Removed `v1.DeploymentInterface` from the call to `scaleDeploymentHelper` as it was not necessary.