### PR TITLE
Fix claim file log

### DIFF
--- a/cnf-certification-test/accesscontrol/namespace/namespace.go
+++ b/cnf-certification-test/accesscontrol/namespace/namespace.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
+	"github.com/test-network-function/cnf-certification-test/pkg/loghelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/stringhelper"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -91,15 +92,14 @@ func getCrsPerNamespaces(aCrd *apiextv1.CustomResourceDefinition) (crdNamespaces
 }
 
 // GetInvalidCRDsNum returns the number of invalid CRs in the map
-func GetInvalidCRsNum(invalidCrs map[string]map[string][]string) int {
-	invalidCrsNum := 0
+func GetInvalidCRsNum(invalidCrs map[string]map[string][]string) (invalidCrsNum int, claimsLog loghelper.CuratedLogLines) {
 	for crdName, namespaces := range invalidCrs {
 		for namespace, crNames := range namespaces {
 			for _, crName := range crNames {
-				logrus.Debugf("crName=%s namespace=%s is invalid (crd=%s)", crName, namespace, crdName)
+				claimsLog = claimsLog.AddLogLine("crName=%s namespace=%s is invalid (crd=%s)", crName, namespace, crdName)
 				invalidCrsNum++
 			}
 		}
 	}
-	return invalidCrsNum
+	return invalidCrsNum, claimsLog
 }

--- a/cnf-certification-test/accesscontrol/namespace/namespace_test.go
+++ b/cnf-certification-test/accesscontrol/namespace/namespace_test.go
@@ -44,6 +44,7 @@ func TestGetInvalidCRsNum(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		assert.Equal(t, tc.expectedInvalidCRs, GetInvalidCRsNum(tc.invalidCrs))
+		result, _ := GetInvalidCRsNum(tc.invalidCrs)
+		assert.Equal(t, tc.expectedInvalidCRs, result)
 	}
 }

--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -294,9 +294,9 @@ func TestNamespace(env *provider.TestEnvironment) {
 	}
 
 	invalidCrsNum, claimsLog := namespace.GetInvalidCRsNum(invalidCrs)
-	tnf.ClaimFilePrintf("%s", claimsLog)
 	if invalidCrsNum > 0 {
 		ginkgo.Fail(fmt.Sprintf("Found %d CRs belonging to invalid namespaces.", invalidCrsNum))
+		tnf.ClaimFilePrintf("%s", claimsLog)
 	}
 }
 

--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -293,7 +293,8 @@ func TestNamespace(env *provider.TestEnvironment) {
 		ginkgo.Fail("error retrieving CRs")
 	}
 
-	invalidCrsNum := namespace.GetInvalidCRsNum(invalidCrs)
+	invalidCrsNum, claimsLog := namespace.GetInvalidCRsNum(invalidCrs)
+	tnf.ClaimFilePrintf("%s", claimsLog)
 	if invalidCrsNum > 0 {
 		ginkgo.Fail(fmt.Sprintf("Found %d CRs belonging to invalid namespaces.", invalidCrsNum))
 	}


### PR DESCRIPTION
#80 accidentally broke the way the CI was checking if this test failed.  Using the `loghelper.CuratedLogLines` this will restore this functionality.