### PR TITLE
Be consistent in import naming convention

### DIFF
--- a/cnf-certification-test/accesscontrol/namespace/namespace.go
+++ b/cnf-certification-test/accesscontrol/namespace/namespace.go
@@ -25,7 +25,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/pkg/loghelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/stringhelper"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -65,7 +65,7 @@ func getCrsPerNamespaces(aCrd *apiextv1.CustomResourceDefinition) (crdNamespaces
 			Resource: aCrd.Spec.Names.Plural,
 		}
 		logrus.Debugf("Looking for CRs from CRD: %s api version:%s group:%s plural:%s", aCrd.Name, version.Name, aCrd.Spec.Group, aCrd.Spec.Names.Plural)
-		crs, err := oc.DynamicClient.Resource(gvr).List(context.Background(), v1.ListOptions{})
+		crs, err := oc.DynamicClient.Resource(gvr).List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			logrus.Errorf("error getting %s: %v\n", aCrd.Name, err)
 			return crdNamespaces, err

--- a/cnf-certification-test/accesscontrol/rbac/automount.go
+++ b/cnf-certification-test/accesscontrol/rbac/automount.go
@@ -22,13 +22,13 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
-	v1core "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func AutomountServiceAccountSetOnSA(serviceAccountName, podNamespace string) (*bool, error) {
 	clientsHolder := clientsholder.GetClientsHolder()
-	sa, err := clientsHolder.K8sClient.CoreV1().ServiceAccounts(podNamespace).Get(context.TODO(), serviceAccountName, v1.GetOptions{})
+	sa, err := clientsHolder.K8sClient.CoreV1().ServiceAccounts(podNamespace).Get(context.TODO(), serviceAccountName, metav1.GetOptions{})
 	if err != nil {
 		logrus.Errorf("executing serviceaccount command failed with error: %s", err)
 		return nil, err
@@ -37,7 +37,7 @@ func AutomountServiceAccountSetOnSA(serviceAccountName, podNamespace string) (*b
 }
 
 //nolint:gocritic
-func EvaluateAutomountTokens(put *v1core.Pod) (bool, string) {
+func EvaluateAutomountTokens(put *corev1.Pod) (bool, string) {
 	// The token can be specified in the pod directly
 	// or it can be specified in the service account of the pod
 	// if no service account is configured, then the pod will use the configuration

--- a/cnf-certification-test/accesscontrol/rbac/automount_test.go
+++ b/cnf-certification-test/accesscontrol/rbac/automount_test.go
@@ -21,31 +21,31 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
-	v1core "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func buildServiceAccountTokenTestObjects() []runtime.Object {
 	falseVar := false
 	trueVar := true
-	testSAwithSATokenTrue := v1core.ServiceAccount{
+	testSAwithSATokenTrue := corev1.ServiceAccount{
 		AutomountServiceAccountToken: &trueVar,
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "SAAutomountTrue",
 			Namespace: "testNamespace",
 		},
 	}
-	testSAwithSATokenFalse := v1core.ServiceAccount{
+	testSAwithSATokenFalse := corev1.ServiceAccount{
 		AutomountServiceAccountToken: &falseVar,
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "SAAutomountFalse",
 			Namespace: "testNamespace",
 		},
 	}
-	testSAwithSATokenNil := v1core.ServiceAccount{
+	testSAwithSATokenNil := corev1.ServiceAccount{
 		AutomountServiceAccountToken: nil,
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "SAAutomountNil",
 			Namespace: "testNamespace",
 		},
@@ -69,8 +69,8 @@ func TestAutomountServiceAccountSetOnSA(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		testSA := v1core.ServiceAccount{
-			ObjectMeta: v1.ObjectMeta{
+		testSA := corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "podNS",
 				Name:      "testSA",
 			},
@@ -92,14 +92,14 @@ func TestEvaluateAutomountTokens(t *testing.T) {
 	falseVar := false
 	trueVar := true
 
-	generatePod := func(tokenStatus *bool, saName string) *v1core.Pod {
-		return &v1core.Pod{
-			Spec: v1core.PodSpec{
+	generatePod := func(tokenStatus *bool, saName string) *corev1.Pod {
+		return &corev1.Pod{
+			Spec: corev1.PodSpec{
 				NodeName:                     "worker01",
 				AutomountServiceAccountToken: tokenStatus,
 				ServiceAccountName:           saName,
 			},
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testPod",
 				Namespace: "testNamespace",
 			},
@@ -107,7 +107,7 @@ func TestEvaluateAutomountTokens(t *testing.T) {
 	}
 
 	testCases := []struct {
-		testPod        *v1core.Pod
+		testPod        *corev1.Pod
 		expectedMsg    string
 		expectedResult bool
 	}{

--- a/cnf-certification-test/accesscontrol/rbac/clusterrolebinding.go
+++ b/cnf-certification-test/accesscontrol/rbac/clusterrolebinding.go
@@ -21,13 +21,13 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func GetClusterRoleBindings(serviceAccountName, podNamespace string) ([]string, error) {
 	// Get all of the clusterrolebindings from all namespaces.
 	clientsHolder := clientsholder.GetClientsHolder()
-	crbList, crbErr := clientsHolder.K8sClient.RbacV1().ClusterRoles().List(context.TODO(), v1.ListOptions{})
+	crbList, crbErr := clientsHolder.K8sClient.RbacV1().ClusterRoles().List(context.TODO(), metav1.ListOptions{})
 	if crbErr != nil {
 		logrus.Errorf("executing clusterrolebinding command failed with error: %s", crbErr)
 		return nil, crbErr

--- a/cnf-certification-test/accesscontrol/rbac/common_test.go
+++ b/cnf-certification-test/accesscontrol/rbac/common_test.go
@@ -4,48 +4,48 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	v1core "k8s.io/api/core/v1"
-	v1rbac "k8s.io/api/rbac/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func buildTestObjects() []runtime.Object {
 	// ClusterRoleBinding Objects
-	testCRB1 := v1rbac.ClusterRoleBinding{
-		ObjectMeta: v1.ObjectMeta{
+	testCRB1 := rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "testNS",
 			Name:      "testCRB",
 		},
 	}
-	testSA1 := v1core.ServiceAccount{
-		ObjectMeta: v1.ObjectMeta{
+	testSA1 := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "testNS",
 			Name:      "testCR1",
 		},
 	}
-	testCR1 := v1rbac.ClusterRole{
-		ObjectMeta: v1.ObjectMeta{
+	testCR1 := rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "testNS",
 			Name:      "testCR",
 		},
 	}
 
 	// RoleBinding Objects
-	testRB2 := v1rbac.RoleBinding{
-		ObjectMeta: v1.ObjectMeta{
+	testRB2 := rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testRB",
 			Namespace: "testNS",
 		},
 	}
-	testSA2 := v1core.ServiceAccount{
-		ObjectMeta: v1.ObjectMeta{
+	testSA2 := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "testNS",
 			Name:      "testCR2",
 		},
 	}
-	testCR2 := v1rbac.Role{
-		ObjectMeta: v1.ObjectMeta{
+	testCR2 := rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "testNS",
 			Name:      "testRole",
 		},

--- a/cnf-certification-test/accesscontrol/rbac/rolebinding.go
+++ b/cnf-certification-test/accesscontrol/rbac/rolebinding.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // GetRoleBindings returns any role bindings extracted from the desired pod.
 func GetRoleBindings(podNamespace, serviceAccountName string) ([]string, error) {
 	// Get all of the rolebindings from all namespaces.
 	clientsHolder := clientsholder.GetClientsHolder()
-	roleList, roleErr := clientsHolder.K8sClient.RbacV1().Roles("").List(context.TODO(), v1.ListOptions{})
+	roleList, roleErr := clientsHolder.K8sClient.RbacV1().Roles("").List(context.TODO(), metav1.ListOptions{})
 	if roleErr != nil {
 		logrus.Errorf("executing rolebinding command failed with error: %s", roleErr)
 		return nil, roleErr

--- a/cnf-certification-test/lifecycle/ownerreference/ownerreference.go
+++ b/cnf-certification-test/lifecycle/ownerreference/ownerreference.go
@@ -19,7 +19,7 @@ package ownerreference
 import (
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -30,11 +30,11 @@ const (
 )
 
 type OwnerReference struct {
-	put    *v1.Pod
+	put    *corev1.Pod
 	result int
 }
 
-func NewOwnerReference(put *v1.Pod) *OwnerReference {
+func NewOwnerReference(put *corev1.Pod) *OwnerReference {
 	o := OwnerReference{
 		put:    put,
 		result: testhelper.ERROR,

--- a/cnf-certification-test/lifecycle/podrecreation/podrecreation.go
+++ b/cnf-certification-test/lifecycle/podrecreation/podrecreation.go
@@ -25,7 +25,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	retry "k8s.io/client-go/util/retry"
@@ -99,7 +99,7 @@ func CountPodsWithDelete(nodeName, mode string) (count int, err error) {
 	wg.Wait()
 	return count, nil
 }
-func skipDaemonPod(pod *v1.Pod) bool {
+func skipDaemonPod(pod *corev1.Pod) bool {
 	for _, or := range pod.OwnerReferences {
 		if or.Kind == DaemonSetString {
 			return true
@@ -108,7 +108,7 @@ func skipDaemonPod(pod *v1.Pod) bool {
 	return false
 }
 
-func deletePod(pod *v1.Pod, mode string, wg *sync.WaitGroup) error {
+func deletePod(pod *corev1.Pod, mode string, wg *sync.WaitGroup) error {
 	clients := clientsholder.GetClientsHolder()
 	logrus.Debugf("deleting ns=%s pod=%s with %s mode", pod.Namespace, pod.Name, mode)
 	gracePeriodSeconds := *pod.Spec.TerminationGracePeriodSeconds

--- a/cnf-certification-test/lifecycle/podsets/podsets_test.go
+++ b/cnf-certification-test/lifecycle/podsets/podsets_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
 	v1app "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -92,7 +92,7 @@ func TestIsStatefulSetReady(t *testing.T) {
 
 func TestGetPodSetNodes(t *testing.T) { //nolint:funlen
 	type args struct {
-		pods    []*v1.Pod
+		pods    []*corev1.Pod
 		ssName  string
 		nodesIn map[string]bool
 	}
@@ -103,7 +103,7 @@ func TestGetPodSetNodes(t *testing.T) { //nolint:funlen
 	}{
 		{
 			name: "ok",
-			args: args{pods: []*v1.Pod{{
+			args: args{pods: []*corev1.Pod{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod1",
 					Namespace: "tnf",
@@ -112,7 +112,7 @@ func TestGetPodSetNodes(t *testing.T) { //nolint:funlen
 						Name: "stateful1",
 					}},
 				},
-				Spec: v1.PodSpec{
+				Spec: corev1.PodSpec{
 					NodeName: "node1",
 				},
 			}, {
@@ -124,14 +124,14 @@ func TestGetPodSetNodes(t *testing.T) { //nolint:funlen
 						Name: "stateful1",
 					}},
 				},
-				Spec: v1.PodSpec{
+				Spec: corev1.PodSpec{
 					NodeName: "node2",
 				},
 			}}, ssName: "stateful1", nodesIn: map[string]bool{}}, want: map[string]bool{"node1": true, "node2": true},
 		},
 		{
 			name: "nok",
-			args: args{pods: []*v1.Pod{{
+			args: args{pods: []*corev1.Pod{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod1",
 					Namespace: "tnf",
@@ -140,7 +140,7 @@ func TestGetPodSetNodes(t *testing.T) { //nolint:funlen
 						Name: "stateful1",
 					}},
 				},
-				Spec: v1.PodSpec{
+				Spec: corev1.PodSpec{
 					NodeName: "node1",
 				},
 			}, {
@@ -152,7 +152,7 @@ func TestGetPodSetNodes(t *testing.T) { //nolint:funlen
 						Name: "stateful1",
 					}},
 				},
-				Spec: v1.PodSpec{
+				Spec: corev1.PodSpec{
 					NodeName: "node2",
 				},
 			}}, ssName: "stateful1", nodesIn: map[string]bool{}}, want: map[string]bool{"node1": true},

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -33,8 +33,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
 	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
-
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -111,8 +110,8 @@ func testContainersImagePolicy(env *provider.TestEnvironment) {
 		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Containers)
 		badcontainers := []string{}
 		for _, cut := range env.Containers {
-			logrus.Debugln("check container ", cut.String(), " pull policy, should be ", v1.PullIfNotPresent)
-			if cut.Data.ImagePullPolicy != v1.PullIfNotPresent {
+			logrus.Debugln("check container ", cut.String(), " pull policy, should be ", corev1.PullIfNotPresent)
+			if cut.Data.ImagePullPolicy != corev1.PullIfNotPresent {
 				badcontainers = append(badcontainers, cut.String())
 				logrus.Errorln("container ", cut.Data.Name, " is using ", cut.Data.ImagePullPolicy, " as image policy")
 			}
@@ -186,7 +185,7 @@ func testPodsOwnerReference(env *provider.TestEnvironment) {
 }
 
 func testPodNodeSelectorAndAffinityBestPractices(env *provider.TestEnvironment) {
-	var badPods []*v1.Pod
+	var badPods []*corev1.Pod
 	for _, put := range env.Pods {
 		if len(put.Data.Spec.NodeSelector) != 0 {
 			tnf.ClaimFilePrintf("ERROR: %s has a node selector clause. Node selector: %v", put, &put.Data.Spec.NodeSelector)

--- a/cnf-certification-test/networking/icmp/icmp_test.go
+++ b/cnf-certification-test/networking/icmp/icmp_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/test-network-function/cnf-certification-test/pkg/loghelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
 	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
-	v1 "k8s.io/api/core/v1"
-	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_parsePingResult(t *testing.T) { //nolint:funlen
@@ -206,8 +206,8 @@ func TestProcessContainerIpsPerNet(t *testing.T) { //nolint:funlen
 			name: "ok",
 			args: args{
 				containerID: &provider.Container{
-					Data:      &v1.Container{},
-					Status:    v1.ContainerStatus{},
+					Data:      &corev1.Container{},
+					Status:    corev1.ContainerStatus{},
 					Namespace: "namespace1",
 					Podname:   "pod1",
 					NodeName:  "node1",
@@ -224,8 +224,8 @@ func TestProcessContainerIpsPerNet(t *testing.T) { //nolint:funlen
 						TesterSource: netcommons.ContainerIP{
 							IP: "1.1.1.1",
 							ContainerIdentifier: &provider.Container{
-								Data:      &v1.Container{},
-								Status:    v1.ContainerStatus{},
+								Data:      &corev1.Container{},
+								Status:    corev1.ContainerStatus{},
 								Namespace: "namespace1",
 								Podname:   "pod1",
 								NodeName:  "node1",
@@ -236,8 +236,8 @@ func TestProcessContainerIpsPerNet(t *testing.T) { //nolint:funlen
 						DestTargets: []netcommons.ContainerIP{{
 							IP: "2.2.2.2",
 							ContainerIdentifier: &provider.Container{
-								Data:      &v1.Container{},
-								Status:    v1.ContainerStatus{},
+								Data:      &corev1.Container{},
+								Status:    corev1.ContainerStatus{},
 								Namespace: "namespace1",
 								Podname:   "pod1",
 								NodeName:  "node1",
@@ -247,8 +247,8 @@ func TestProcessContainerIpsPerNet(t *testing.T) { //nolint:funlen
 						}, {
 							IP: "3.3.3.3",
 							ContainerIdentifier: &provider.Container{
-								Data:      &v1.Container{},
-								Status:    v1.ContainerStatus{},
+								Data:      &corev1.Container{},
+								Status:    corev1.ContainerStatus{},
 								Namespace: "namespace1",
 								Podname:   "pod1",
 								NodeName:  "node1",
@@ -296,7 +296,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 					TesterSource: netcommons.ContainerIP{
 						IP: "10.244.195.231",
 						ContainerIdentifier: &provider.Container{
-							Data: &v1.Container{
+							Data: &corev1.Container{
 								Name: "test1",
 							},
 							Namespace: "tnf",
@@ -309,7 +309,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 					DestTargets: []netcommons.ContainerIP{{
 						IP: "10.244.195.232",
 						ContainerIdentifier: &provider.Container{
-							Data: &v1.Container{
+							Data: &corev1.Container{
 								Name: "test2",
 							},
 							Namespace: "tnf",
@@ -337,7 +337,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 					TesterSource: netcommons.ContainerIP{
 						IP: "10.244.195.231",
 						ContainerIdentifier: &provider.Container{
-							Data: &v1.Container{
+							Data: &corev1.Container{
 								Name: "test1",
 							},
 							Namespace: "tnf",
@@ -365,7 +365,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 					TesterSource: netcommons.ContainerIP{
 						IP: "192.168.0.3",
 						ContainerIdentifier: &provider.Container{
-							Data: &v1.Container{
+							Data: &corev1.Container{
 								Name: "test1",
 							},
 							Namespace: "tnf",
@@ -379,7 +379,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 						{
 							IP: "192.168.0.4",
 							ContainerIdentifier: &provider.Container{
-								Data: &v1.Container{
+								Data: &corev1.Container{
 									Name: "test2",
 								},
 								Namespace: "tnf",
@@ -396,7 +396,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 					TesterSource: netcommons.ContainerIP{
 						IP: "192.168.1.3",
 						ContainerIdentifier: &provider.Container{
-							Data: &v1.Container{
+							Data: &corev1.Container{
 								Name: "test1",
 							},
 							Namespace: "tnf",
@@ -410,7 +410,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 						{
 							IP: "192.168.1.4",
 							ContainerIdentifier: &provider.Container{
-								Data: &v1.Container{
+								Data: &corev1.Container{
 									Name: "test2",
 								},
 								Namespace: "tnf",
@@ -437,7 +437,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 					TesterSource: netcommons.ContainerIP{
 						IP: "192.168.0.3",
 						ContainerIdentifier: &provider.Container{
-							Data: &v1.Container{
+							Data: &corev1.Container{
 								Name: "test1",
 							},
 							Namespace: "tnf",
@@ -454,7 +454,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 					TesterSource: netcommons.ContainerIP{
 						IP: "192.168.1.3",
 						ContainerIdentifier: &provider.Container{
-							Data: &v1.Container{
+							Data: &corev1.Container{
 								Name: "test1",
 							},
 							Namespace: "tnf",
@@ -498,16 +498,16 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 
 var (
 	pod1 = provider.Pod{ //nolint:dupl
-		Data: &v1.Pod{
-			ObjectMeta: v1meta.ObjectMeta{
+		Data: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod1",
 				Namespace: "ns1",
 				Annotations: map[string]string{
 					"k8s.v1.cni.cncf.io/networks-status": "[{\n    \"name\": \"k8s-pod-network\",\n    \"ips\": [\n        \"10.244.195.231\",\n        \"fd00:10:244:88:58fd:b191:5c13:9ce6\"\n    ],\n    \"default\": true,\n    \"dns\": {}\n},{\n    \"name\": \"tnf/mynet-ipv4-0\",\n    \"interface\": \"net1\",\n    \"ips\": [\n        \"192.168.0.3\"\n    ],\n    \"mac\": \"96:e8:f5:33:9c:66\",\n    \"dns\": {}\n},{\n    \"name\": \"tnf/mynet-ipv4-1\",\n    \"interface\": \"net2\",\n    \"ips\": [\n        \"192.168.1.3\"\n    ],\n    \"mac\": \"4e:c5:60:c2:1c:55\",\n    \"dns\": {}\n},{\n    \"name\": \"tnf/mynet-ipv6-0\",\n    \"interface\": \"net3\",\n    \"ips\": [\n        \"3ffe:ffff::3\"\n    ],\n    \"mac\": \"ca:f5:77:b4:2f:49\",\n    \"dns\": {}\n},{\n    \"name\": \"tnf/mynet-ipv6-1\",\n    \"interface\": \"net4\",\n    \"ips\": [\n        \"3ffe:ffff:0:1::3\"\n    ],\n    \"mac\": \"26:7b:69:1b:b0:5c\",\n    \"dns\": {}\n}]", //nolint:lll
 				},
 			},
-			Status: v1.PodStatus{
-				PodIPs: []v1.PodIP{
+			Status: corev1.PodStatus{
+				PodIPs: []corev1.PodIP{
 					{
 						IP: "10.244.195.231",
 					},
@@ -524,7 +524,7 @@ var (
 		SkipMultusNetTests: false,
 		Containers: []*provider.Container{
 			{
-				Data: &v1.Container{
+				Data: &corev1.Container{
 					Name: "test1",
 				},
 				Namespace: "tnf",
@@ -536,16 +536,16 @@ var (
 		},
 	}
 	pod2 = provider.Pod{ //nolint:dupl
-		Data: &v1.Pod{
-			ObjectMeta: v1meta.ObjectMeta{
+		Data: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod2",
 				Namespace: "ns1",
 				Annotations: map[string]string{
 					"k8s.v1.cni.cncf.io/networks-status": "[{\n    \"name\": \"k8s-pod-network\",\n    \"ips\": [\n        \"10.244.195.232\",\n        \"fd00:10:244:88:58fd:b191:5c13:9ce7\"\n    ],\n    \"default\": true,\n    \"dns\": {}\n},{\n    \"name\": \"tnf/mynet-ipv4-0\",\n    \"interface\": \"net1\",\n    \"ips\": [\n        \"192.168.0.4\"\n    ],\n    \"mac\": \"96:e8:f5:33:9c:67\",\n    \"dns\": {}\n},{\n    \"name\": \"tnf/mynet-ipv4-1\",\n    \"interface\": \"net2\",\n    \"ips\": [\n        \"192.168.1.4\"\n    ],\n    \"mac\": \"4e:c5:60:c2:1c:56\",\n    \"dns\": {}\n},{\n    \"name\": \"tnf/mynet-ipv6-0\",\n    \"interface\": \"net3\",\n    \"ips\": [\n        \"3ffe:ffff::4\"\n    ],\n    \"mac\": \"ca:f5:77:b4:2f:50\",\n    \"dns\": {}\n},{\n    \"name\": \"tnf/mynet-ipv6-1\",\n    \"interface\": \"net4\",\n    \"ips\": [\n        \"3ffe:ffff:0:1::4\"\n    ],\n    \"mac\": \"26:7b:69:1b:b0:5d\",\n    \"dns\": {}\n}]", //nolint:lll
 				},
 			},
-			Status: v1.PodStatus{
-				PodIPs: []v1.PodIP{
+			Status: corev1.PodStatus{
+				PodIPs: []corev1.PodIP{
 					{
 						IP: "10.244.195.232",
 					},
@@ -562,7 +562,7 @@ var (
 		SkipMultusNetTests: false,
 		Containers: []*provider.Container{
 			{
-				Data: &v1.Container{
+				Data: &corev1.Container{
 					Name: "test2",
 				},
 				Namespace: "tnf",
@@ -574,16 +574,16 @@ var (
 		},
 	}
 	pod3 = provider.Pod{ //nolint:dupl
-		Data: &v1.Pod{
-			ObjectMeta: v1meta.ObjectMeta{
+		Data: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod2",
 				Namespace: "ns1",
 				Annotations: map[string]string{
 					"k8s.v1.cni.cncf.io/networks-status": "[{\n    \"name\": \"k8s-pod-network\",\n    \"ips\": [\n        \"10.244.195.232\",\n        \"fd00:10:244:88:58fd:b191:5c13:9ce7\"\n    ],\n    \"default\": true,\n    \"dns\": {}\n},{\n    \"name\": \"tnf/mynet-ipv4-0\",\n    \"interface\": \"net1\",\n    \"ips\": [\n        \"192.168.0.4\"\n    ],\n    \"mac\": \"96:e8:f5:33:9c:67\",\n    \"dns\": {}\n},{\n    \"name\": \"tnf/mynet-ipv4-1\",\n    \"interface\": \"net2\",\n    \"ips\": [\n        \"192.168.1.4\"\n    ],\n    \"mac\": \"4e:c5:60:c2:1c:56\",\n    \"dns\": {}\n},{\n    \"name\": \"tnf/mynet-ipv6-0\",\n    \"interface\": \"net3\",\n    \"ips\": [\n        \"3ffe:ffff::4\"\n    ],\n    \"mac\": \"ca:f5:77:b4:2f:50\",\n    \"dns\": {}\n},{\n    \"name\": \"tnf/mynet-ipv6-1\",\n    \"interface\": \"net4\",\n    \"ips\": [\n        \"3ffe:ffff:0:1::4\"\n    ],\n    \"mac\": \"26:7b:69:1b:b0:5d\",\n    \"dns\": {}\n}]", //nolint:lll
 				},
 			},
-			Status: v1.PodStatus{
-				PodIPs: []v1.PodIP{
+			Status: corev1.PodStatus{
+				PodIPs: []corev1.PodIP{
 					{
 						IP: "10.244.195.232",
 					},
@@ -600,7 +600,7 @@ var (
 		SkipMultusNetTests: false,
 		Containers: []*provider.Container{
 			{
-				Data: &v1.Container{
+				Data: &corev1.Container{
 					Name: "test2",
 				},
 				Namespace: "tnf",
@@ -612,16 +612,16 @@ var (
 		},
 	}
 	pod4 = provider.Pod{ //nolint:dupl
-		Data: &v1.Pod{
-			ObjectMeta: v1meta.ObjectMeta{
+		Data: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod2",
 				Namespace: "ns1",
 				Annotations: map[string]string{
 					"k8s.v1.cni.cncf.io/networks-status": "[{\n    \"name\": \"k8s-pod-network\",\n    \"ips\": [\n        \"10.244.195.232\",\n        \"fd00:10:244:88:58fd:b191:5c13:9ce7\"\n    ],\n    \"default\": true,\n    \"dns\": {}\n},{\n    \"name\": \"tnf/mynet-ipv4-0\",\n    \"interface\": \"net1\",\n    \"ips\": [\n        \"192.168.0.4\"\n    ],\n    \"mac\": \"96:e8:f5:33:9c:67\",\n    \"dns\": {}\n},{\n    \"name\": \"tnf/mynet-ipv4-1\",\n    \"interface\": \"net2\",\n    \"ips\": [\n        \"192.168.1.4\"\n    ],\n    \"mac\": \"4e:c5:60:c2:1c:56\",\n    \"dns\": {}\n},{\n    \"name\": \"tnf/mynet-ipv6-0\",\n    \"interface\": \"net3\",\n    \"ips\": [\n        \"3ffe:ffff::4\"\n    ],\n    \"mac\": \"ca:f5:77:b4:2f:50\",\n    \"dns\": {}\n},{\n    \"name\": \"tnf/mynet-ipv6-1\",\n    \"interface\": \"net4\",\n    \"ips\": [\n        \"3ffe:ffff:0:1::4\"\n    ],\n    \"mac\": \"26:7b:69:1b:b0:5d\",\n    \"dns\": {}\n}]", //nolint:lll
 				},
 			},
-			Status: v1.PodStatus{
-				PodIPs: []v1.PodIP{
+			Status: corev1.PodStatus{
+				PodIPs: []corev1.PodIP{
 					{
 						IP: "10.244.195.232",
 					},
@@ -638,7 +638,7 @@ var (
 		SkipMultusNetTests: true,
 		Containers: []*provider.Container{
 			{
-				Data: &v1.Container{
+				Data: &corev1.Container{
 					Name: "test2",
 				},
 				Namespace: "tnf",
@@ -670,7 +670,7 @@ func TestRunNetworkingTests(t *testing.T) { //nolint:funlen
 				TesterSource: netcommons.ContainerIP{
 					IP: "10.244.195.231",
 					ContainerIdentifier: &provider.Container{
-						Data: &v1.Container{
+						Data: &corev1.Container{
 							Name: "test1",
 						},
 						Namespace: "tnf",
@@ -683,7 +683,7 @@ func TestRunNetworkingTests(t *testing.T) { //nolint:funlen
 				DestTargets: []netcommons.ContainerIP{{
 					IP: "10.244.195.232",
 					ContainerIdentifier: &provider.Container{
-						Data: &v1.Container{
+						Data: &corev1.Container{
 							Name: "test2",
 						},
 						Namespace: "tnf",
@@ -715,7 +715,7 @@ func TestRunNetworkingTests(t *testing.T) { //nolint:funlen
 				TesterSource: netcommons.ContainerIP{
 					IP: "10.244.195.231",
 					ContainerIdentifier: &provider.Container{
-						Data: &v1.Container{
+						Data: &corev1.Container{
 							Name: "test1",
 						},
 						Namespace: "tnf",
@@ -739,7 +739,7 @@ func TestRunNetworkingTests(t *testing.T) { //nolint:funlen
 				TesterSource: netcommons.ContainerIP{
 					IP: "10.244.195.231",
 					ContainerIdentifier: &provider.Container{
-						Data: &v1.Container{
+						Data: &corev1.Container{
 							Name: "test1",
 						},
 						Namespace: "tnf",
@@ -752,7 +752,7 @@ func TestRunNetworkingTests(t *testing.T) { //nolint:funlen
 				DestTargets: []netcommons.ContainerIP{{
 					IP: "10.244.195.232",
 					ContainerIdentifier: &provider.Container{
-						Data: &v1.Container{
+						Data: &corev1.Container{
 							Name: "test2",
 						},
 						Namespace: "tnf",
@@ -765,7 +765,7 @@ func TestRunNetworkingTests(t *testing.T) { //nolint:funlen
 					{
 						IP: "10.244.195.233",
 						ContainerIdentifier: &provider.Container{
-							Data: &v1.Container{
+							Data: &corev1.Container{
 								Name: "test3",
 							},
 							Namespace: "tnf",

--- a/cnf-certification-test/networking/netcommons/netcommons.go
+++ b/cnf-certification-test/networking/netcommons/netcommons.go
@@ -21,7 +21,7 @@ import (
 	"net"
 
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type IPVersion string
@@ -87,8 +87,8 @@ func PrintNetTestContextMap(netsUnderTest map[string]NetTestContext) string {
 	return output
 }
 
-// PodIPsToStringList converts a list of v1.PodIP objects into a list of strings
-func PodIPsToStringList(ips []v1.PodIP) (ipList []string) {
+// PodIPsToStringList converts a list of corev1.PodIP objects into a list of strings
+func PodIPsToStringList(ips []corev1.PodIP) (ipList []string) {
 	for _, ip := range ips {
 		ipList = append(ipList, ip.IP)
 	}

--- a/cnf-certification-test/observability/suite.go
+++ b/cnf-certification-test/observability/suite.go
@@ -31,8 +31,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
 	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
-
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 //
@@ -70,7 +69,7 @@ func containerHasLoggingOutput(cut *provider.Container) (bool, error) {
 	ocpClient := clientsholder.GetClientsHolder()
 
 	numLogLines := int64(1)
-	podLogOptions := v1.PodLogOptions{TailLines: &numLogLines, Container: cut.Data.Name}
+	podLogOptions := corev1.PodLogOptions{TailLines: &numLogLines, Container: cut.Data.Name}
 	req := ocpClient.K8sClient.CoreV1().Pods(cut.Namespace).GetLogs(cut.Podname, &podLogOptions)
 
 	podLogsReaderCloser, err := req.Stream(context.TODO())
@@ -138,7 +137,7 @@ func testTerminationMessagePolicy(env *provider.TestEnvironment) {
 	failedContainers := []string{}
 	for _, cut := range env.Containers {
 		ginkgo.By("Testing for terminationMessagePolicy: " + cut.String())
-		if cut.Data.TerminationMessagePolicy != v1.TerminationMessageFallbackToLogsOnError {
+		if cut.Data.TerminationMessagePolicy != corev1.TerminationMessageFallbackToLogsOnError {
 			tnf.ClaimFilePrintf("FAILURE: %s does not have a TerminationMessagePolicy: FallbackToLogsOnError", cut)
 			failedContainers = append(failedContainers, cut.Data.Name)
 		}

--- a/cnf-certification-test/operator/phasecheck/phasecheck_test.go
+++ b/cnf-certification-test/operator/phasecheck/phasecheck_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_isOperatorSucceeded(t *testing.T) { //nolint:funlen
@@ -34,7 +34,7 @@ func Test_isOperatorSucceeded(t *testing.T) { //nolint:funlen
 	}{
 		{name: "ok",
 			args: args{csv: &v1alpha1.ClusterServiceVersion{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "aCSV",
 					Namespace: "aNamespace",
 				},
@@ -46,7 +46,7 @@ func Test_isOperatorSucceeded(t *testing.T) { //nolint:funlen
 		},
 		{name: "nok",
 			args: args{csv: &v1alpha1.ClusterServiceVersion{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "aCSV",
 					Namespace: "aNamespace",
 				},
@@ -58,7 +58,7 @@ func Test_isOperatorSucceeded(t *testing.T) { //nolint:funlen
 		},
 		{name: "nok",
 			args: args{csv: &v1alpha1.ClusterServiceVersion{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "aCSV",
 					Namespace: "aNamespace",
 				},
@@ -70,7 +70,7 @@ func Test_isOperatorSucceeded(t *testing.T) { //nolint:funlen
 		},
 		{name: "nok",
 			args: args{csv: &v1alpha1.ClusterServiceVersion{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "aCSV",
 					Namespace: "aNamespace",
 				},
@@ -81,7 +81,7 @@ func Test_isOperatorSucceeded(t *testing.T) { //nolint:funlen
 		},
 		{name: "nok",
 			args: args{csv: &v1alpha1.ClusterServiceVersion{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "aCSV",
 					Namespace: "aNamespace",
 				},
@@ -93,7 +93,7 @@ func Test_isOperatorSucceeded(t *testing.T) { //nolint:funlen
 		},
 		{name: "nok",
 			args: args{csv: &v1alpha1.ClusterServiceVersion{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "aCSV",
 					Namespace: "aNamespace",
 				},
@@ -105,7 +105,7 @@ func Test_isOperatorSucceeded(t *testing.T) { //nolint:funlen
 		},
 		{name: "nok",
 			args: args{csv: &v1alpha1.ClusterServiceVersion{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "aCSV",
 					Namespace: "aNamespace",
 				},
@@ -117,7 +117,7 @@ func Test_isOperatorSucceeded(t *testing.T) { //nolint:funlen
 		},
 		{name: "nok",
 			args: args{csv: &v1alpha1.ClusterServiceVersion{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "aCSV",
 					Namespace: "aNamespace",
 				},
@@ -129,7 +129,7 @@ func Test_isOperatorSucceeded(t *testing.T) { //nolint:funlen
 		},
 		{name: "nok",
 			args: args{csv: &v1alpha1.ClusterServiceVersion{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "aCSV",
 					Namespace: "aNamespace",
 				},
@@ -142,7 +142,7 @@ func Test_isOperatorSucceeded(t *testing.T) { //nolint:funlen
 		},
 		{name: "nok",
 			args: args{csv: &v1alpha1.ClusterServiceVersion{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "aCSV",
 					Namespace: "aNamespace",
 				},

--- a/cnf-certification-test/platform/hugepages/hugepages.go
+++ b/cnf-certification-test/platform/hugepages/hugepages.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -76,7 +76,7 @@ func hugepageSizeToInt(s string) int {
 	return num
 }
 
-func NewTester(node *provider.Node, debugPod *v1.Pod) (*Tester, error) {
+func NewTester(node *provider.Node, debugPod *corev1.Pod) (*Tester, error) {
 	tester := &Tester{
 		node: node,
 		context: clientsholder.Context{

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -32,8 +32,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	ocpMachine "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
-	v1core "k8s.io/api/core/v1"
-	v1rbac "k8s.io/api/rbac/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiextv1fake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	k8sFakeClient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
@@ -75,19 +75,19 @@ func GetTestClientsHolder(k8sMockObjects []runtime.Object, filenames ...string) 
 		// Add more items below if/when needed.
 		switch v.(type) {
 		// K8s Client Objects
-		case *v1core.ServiceAccount:
+		case *corev1.ServiceAccount:
 			k8sClientObjects = append(k8sClientObjects, v)
-		case *v1rbac.ClusterRole:
+		case *rbacv1.ClusterRole:
 			k8sClientObjects = append(k8sClientObjects, v)
-		case *v1rbac.ClusterRoleBinding:
+		case *rbacv1.ClusterRoleBinding:
 			k8sClientObjects = append(k8sClientObjects, v)
-		case *v1rbac.Role:
+		case *rbacv1.Role:
 			k8sClientObjects = append(k8sClientObjects, v)
-		case *v1rbac.RoleBinding:
+		case *rbacv1.RoleBinding:
 			k8sClientObjects = append(k8sClientObjects, v)
-		case *v1core.Pod:
+		case *corev1.Pod:
 			k8sClientObjects = append(k8sClientObjects, v)
-		case *v1core.Node:
+		case *corev1.Node:
 			k8sClientObjects = append(k8sClientObjects, v)
 
 		// K8s Extension Client Objects

--- a/internal/clientsholder/command.go
+++ b/internal/clientsholder/command.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
 )
@@ -51,7 +51,7 @@ func (clientsholder *ClientsHolder) ExecCommandContainer(
 		Resource("pods").
 		Name(ctx.Podname).
 		SubResource("exec").
-		VersionedParams(&v1.PodExecOptions{
+		VersionedParams(&corev1.PodExecOptions{
 			Container: ctx.Containername,
 			Command:   commandStr,
 			Stdin:     false,

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -28,9 +28,9 @@ import (
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 	"helm.sh/helm/v3/pkg/release"
-	v1apps "k8s.io/api/apps/v1"
-	v1scaling "k8s.io/api/autoscaling/v1"
-	v1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	scalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,19 +48,19 @@ const (
 type DiscoveredTestData struct {
 	Env               configuration.TestParameters
 	TestData          configuration.TestConfiguration
-	Pods              []v1.Pod
-	DebugPods         []v1.Pod
+	Pods              []corev1.Pod
+	DebugPods         []corev1.Pod
 	Crds              []*apiextv1.CustomResourceDefinition
 	Namespaces        []string
 	Csvs              []olmv1Alpha.ClusterServiceVersion
-	Deployments       []v1apps.Deployment
-	StatefulSet       []v1apps.StatefulSet
-	Hpas              map[string]*v1scaling.HorizontalPodAutoscaler
+	Deployments       []appsv1.Deployment
+	StatefulSet       []appsv1.StatefulSet
+	Hpas              map[string]*scalingv1.HorizontalPodAutoscaler
 	Subscriptions     []olmv1Alpha.Subscription
 	HelmChartReleases map[string][]*release.Release
 	K8sVersion        string
 	OpenshiftVersion  string
-	Nodes             *v1.NodeList
+	Nodes             *corev1.NodeList
 }
 
 var data = DiscoveredTestData{}

--- a/pkg/autodiscover/autodiscover_crds_test.go
+++ b/pkg/autodiscover/autodiscover_crds_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -31,7 +31,7 @@ func TestFindTestCrdNames(t *testing.T) {
 	// Function to generate some runtime objects for the k8s mock client
 	generateObjects := func() []runtime.Object {
 		testCRD := apiextv1.CustomResourceDefinition{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: "testCRD_testsuffix",
 			},
 		}
@@ -53,7 +53,7 @@ func TestFindTestCrdNames(t *testing.T) {
 			},
 			expectedTargetCRDs: []*apiextv1.CustomResourceDefinition{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name: "testCRD_testsuffix",
 					},
 				},

--- a/pkg/autodiscover/autodiscover_pods.go
+++ b/pkg/autodiscover/autodiscover_pods.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
@@ -29,8 +29,8 @@ import (
 // Filter out any pod that is not in a running state
 const filterStatusRunning = "status.phase=Running"
 
-func findPodsByLabel(oc corev1client.CoreV1Interface, labels []configuration.Label, namespaces []string) []v1.Pod {
-	Pods := []v1.Pod{}
+func findPodsByLabel(oc corev1client.CoreV1Interface, labels []configuration.Label, namespaces []string) []corev1.Pod {
+	Pods := []corev1.Pod{}
 	for _, ns := range namespaces {
 		for _, l := range labels {
 			label := buildLabelQuery(l)

--- a/pkg/autodiscover/autodiscover_pods_test.go
+++ b/pkg/autodiscover/autodiscover_pods_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
@@ -32,7 +32,7 @@ import (
 func TestFindPodsByLabel(t *testing.T) {
 	generatePod := func(podname, namespace, label string) *corev1.Pod {
 		return &corev1.Pod{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      podname,
 				Namespace: namespace,
 				Labels: map[string]string{
@@ -58,7 +58,7 @@ func TestFindPodsByLabel(t *testing.T) {
 
 			expectedResults: []corev1.Pod{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testPod",
 						Namespace: "testNamespace",
 						Labels: map[string]string{

--- a/pkg/autodiscover/autodiscover_podset.go
+++ b/pkg/autodiscover/autodiscover_podset.go
@@ -20,15 +20,15 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
-	v1 "k8s.io/api/apps/v1"
-	v1scaling "k8s.io/api/autoscaling/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	scalingv1 "k8s.io/api/autoscaling/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	appv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 )
 
-func FindDeploymentByNameByNamespace(appClient appv1client.AppsV1Interface, namespace, name string) (*v1.Deployment, error) {
+func FindDeploymentByNameByNamespace(appClient appv1client.AppsV1Interface, namespace, name string) (*appsv1.Deployment, error) {
 	dp, err := appClient.Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		logrus.Error("Can't retrieve deployment in ns=", namespace, " name=", name)
@@ -36,7 +36,7 @@ func FindDeploymentByNameByNamespace(appClient appv1client.AppsV1Interface, name
 	}
 	return dp, nil
 }
-func FindStatefulsetByNameByNamespace(appClient appv1client.AppsV1Interface, namespace, name string) (*v1.StatefulSet, error) {
+func FindStatefulsetByNameByNamespace(appClient appv1client.AppsV1Interface, namespace, name string) (*appsv1.StatefulSet, error) {
 	ss, err := appClient.StatefulSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		logrus.Error("Can't retrieve deployment in ns=", namespace, " name=", name)
@@ -50,8 +50,8 @@ func findDeploymentByLabel(
 	appClient appv1client.AppsV1Interface,
 	labels []configuration.Label,
 	namespaces []string,
-) []v1.Deployment {
-	deployments := []v1.Deployment{}
+) []appsv1.Deployment {
+	deployments := []appsv1.Deployment{}
 	for _, ns := range namespaces {
 		dps, err := appClient.Deployments(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
@@ -84,8 +84,8 @@ func findStatefulSetByLabel(
 	appClient appv1client.AppsV1Interface,
 	labels []configuration.Label,
 	namespaces []string,
-) []v1.StatefulSet {
-	statefulsets := []v1.StatefulSet{}
+) []appsv1.StatefulSet {
+	statefulsets := []appsv1.StatefulSet{}
 	for _, ns := range namespaces {
 		ss, err := appClient.StatefulSets(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
@@ -113,8 +113,8 @@ func findStatefulSetByLabel(
 	return statefulsets
 }
 
-func findHpaControllers(cs kubernetes.Interface, namespaces []string) map[string]*v1scaling.HorizontalPodAutoscaler {
-	m := make(map[string]*v1scaling.HorizontalPodAutoscaler)
+func findHpaControllers(cs kubernetes.Interface, namespaces []string) map[string]*scalingv1.HorizontalPodAutoscaler {
+	m := make(map[string]*scalingv1.HorizontalPodAutoscaler)
 	for _, ns := range namespaces {
 		hpas, err := cs.AutoscalingV1().HorizontalPodAutoscalers(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -27,7 +27,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apimachineryv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -106,7 +106,7 @@ func GetHwInfoAllNodes() (out map[string]NodeHwInfo) {
 }
 
 // getHWJsonOutput performs a query via debug pod and returns the JSON blob
-func getHWJsonOutput(debugPod *v1.Pod, o clientsholder.Command, cmd string) (out interface{}, err error) {
+func getHWJsonOutput(debugPod *corev1.Pod, o clientsholder.Command, cmd string) (out interface{}, err error) {
 	ctx := clientsholder.Context{Namespace: debugPod.Namespace, Podname: debugPod.Name, Containername: debugPod.Spec.Containers[0].Name}
 	outStr, errStr, err := o.ExecCommandContainer(ctx, cmd)
 	if err != nil || errStr != "" {
@@ -120,7 +120,7 @@ func getHWJsonOutput(debugPod *v1.Pod, o clientsholder.Command, cmd string) (out
 }
 
 // getHWTextOutput performs a query via debug and returns plaintext lines
-func getHWTextOutput(debugPod *v1.Pod, o clientsholder.Command, cmd string) (out []string, err error) {
+func getHWTextOutput(debugPod *corev1.Pod, o clientsholder.Command, cmd string) (out []string, err error) {
 	ctx := clientsholder.Context{Namespace: debugPod.Namespace, Podname: debugPod.Name, Containername: debugPod.Spec.Containers[0].Name}
 	outStr, errStr, err := o.ExecCommandContainer(ctx, cmd)
 	if err != nil || errStr != "" {

--- a/pkg/diagnostics/diagnostics_test.go
+++ b/pkg/diagnostics/diagnostics_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestGetVersionOcClient(t *testing.T) {
@@ -74,12 +74,12 @@ func TestGetHWJsonOutput(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		result, err := getHWJsonOutput(&v1.Pod{
-			Spec: v1.PodSpec{
+		result, err := getHWJsonOutput(&corev1.Pod{
+			Spec: corev1.PodSpec{
 				// Note: We don't actually care about the podname
 				// for this test, but the function uses it to build the
 				// context .
-				Containers: []v1.Container{
+				Containers: []corev1.Container{
 					{
 						Name: "podname",
 					},
@@ -137,12 +137,12 @@ func TestGetHWTextOutput(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		result, err := getHWTextOutput(&v1.Pod{
-			Spec: v1.PodSpec{
+		result, err := getHWTextOutput(&corev1.Pod{
+			Spec: corev1.PodSpec{
 				// Note: We don't actually care about the podname
 				// for this test, but the function uses it to build the
 				// context .
-				Containers: []v1.Container{
+				Containers: []corev1.Container{
 					{
 						Name: "podname",
 					},

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -34,9 +34,9 @@ import (
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 	"github.com/test-network-function/cnf-certification-test/pkg/stringhelper"
 	"helm.sh/helm/v3/pkg/release"
-	v1apps "k8s.io/api/apps/v1"
-	v1scaling "k8s.io/api/autoscaling/v1"
-	v1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	scalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	appv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
@@ -59,14 +59,14 @@ var (
 )
 
 type Pod struct {
-	Data               *v1.Pod
+	Data               *corev1.Pod
 	Containers         []*Container
 	MultusIPs          map[string][]string
 	SkipNetTests       bool
 	SkipMultusNetTests bool
 }
 
-func NewPod(aPod *v1.Pod) (out Pod) {
+func NewPod(aPod *corev1.Pod) (out Pod) {
 	var err error
 	out.Data = aPod
 	out.MultusIPs = make(map[string][]string)
@@ -85,7 +85,7 @@ func NewPod(aPod *v1.Pod) (out Pod) {
 	return out
 }
 
-func ConvertArrayPods(pods []*v1.Pod) (out []*Pod) {
+func ConvertArrayPods(pods []*corev1.Pod) (out []*Pod) {
 	for i := range pods {
 		aPodWrapper := NewPod(pods[i])
 		out = append(out, &aPodWrapper)
@@ -94,17 +94,17 @@ func ConvertArrayPods(pods []*v1.Pod) (out []*Pod) {
 }
 
 type TestEnvironment struct { // rename this with testTarget
-	Namespaces        []string           `json:"testNamespaces"`
-	Pods              []*Pod             `json:"testPods"`
-	Containers        []*Container       `json:"testContainers"`
-	Operators         []Operator         `json:"testOperators"`
-	DebugPods         map[string]*v1.Pod // map from nodename to debugPod
+	Namespaces        []string               `json:"testNamespaces"`
+	Pods              []*Pod                 `json:"testPods"`
+	Containers        []*Container           `json:"testContainers"`
+	Operators         []Operator             `json:"testOperators"`
+	DebugPods         map[string]*corev1.Pod // map from nodename to debugPod
 	Config            configuration.TestConfiguration
 	variables         configuration.TestParameters
 	Crds              []*apiextv1.CustomResourceDefinition          `json:"testCrds"`
-	Deployments       []*v1apps.Deployment                          `json:"testDeployments"`
-	StatetfulSets     []*v1apps.StatefulSet                         `json:"testStatetfulSets"`
-	HorizontalScaler  map[string]*v1scaling.HorizontalPodAutoscaler `json:"testHorizontalScaler"`
+	Deployments       []*appsv1.Deployment                          `json:"testDeployments"`
+	StatetfulSets     []*appsv1.StatefulSet                         `json:"testStatetfulSets"`
+	HorizontalScaler  map[string]*scalingv1.HorizontalPodAutoscaler `json:"testHorizontalScaler"`
 	Nodes             map[string]Node                               `json:"-"`
 	Subscriptions     []*olmv1Alpha.Subscription                    `json:"testSubscriptions"`
 	K8sVersion        string                                        `json:"-"`
@@ -132,8 +132,8 @@ type Operator struct {
 	Version          string                            `yaml:"Version" json:"Version"`
 }
 type Container struct {
-	Data                     *v1.Container
-	Status                   v1.ContainerStatus
+	Data                     *corev1.Container
+	Status                   corev1.ContainerStatus
 	Namespace                string
 	Podname                  string
 	NodeName                 string
@@ -155,7 +155,7 @@ type MachineConfig struct {
 }
 
 type Node struct {
-	Data *v1.Node
+	Data *corev1.Node
 	Mc   MachineConfig `json:"-"`
 }
 
@@ -198,10 +198,10 @@ func GetContainer() *Container {
 	return &Container{}
 }
 
-func GetUpdatedDeployment(ac appv1client.AppsV1Interface, namespace, podName string) (*v1apps.Deployment, error) {
+func GetUpdatedDeployment(ac appv1client.AppsV1Interface, namespace, podName string) (*appsv1.Deployment, error) {
 	return autodiscover.FindDeploymentByNameByNamespace(ac, namespace, podName)
 }
-func GetUpdatedStatefulset(ac appv1client.AppsV1Interface, namespace, podName string) (*v1apps.StatefulSet, error) {
+func GetUpdatedStatefulset(ac appv1client.AppsV1Interface, namespace, podName string) (*appsv1.StatefulSet, error) {
 	return autodiscover.FindStatefulsetByNameByNamespace(ac, namespace, podName)
 }
 
@@ -227,7 +227,7 @@ func buildTestEnvironment() { //nolint:funlen
 		env.Pods = append(env.Pods, &aNewPod)
 		env.Containers = append(env.Containers, getPodContainers(&pods[i])...)
 	}
-	env.DebugPods = make(map[string]*v1.Pod)
+	env.DebugPods = make(map[string]*corev1.Pod)
 	for i := 0; i < len(data.DebugPods); i++ {
 		nodeName := data.DebugPods[i].Spec.NodeName
 		env.DebugPods[nodeName] = &data.DebugPods[i]
@@ -264,10 +264,10 @@ func buildTestEnvironment() { //nolint:funlen
 	env.Operators = operators
 }
 
-func getPodContainers(aPod *v1.Pod) (containerList []*Container) {
+func getPodContainers(aPod *corev1.Pod) (containerList []*Container) {
 	for j := 0; j < len(aPod.Spec.Containers); j++ {
 		cut := &(aPod.Spec.Containers[j])
-		var state v1.ContainerStatus
+		var state corev1.ContainerStatus
 		if len(aPod.Status.ContainerStatuses) > 0 {
 			state = aPod.Status.ContainerStatuses[j]
 		} else {
@@ -353,7 +353,7 @@ func WaitDebugPodsReady() error {
 	return nil
 }
 
-func isDaemonSetReady(status *v1apps.DaemonSetStatus) bool {
+func isDaemonSetReady(status *appsv1.DaemonSetStatus) bool {
 	//nolint:gocritic
 	return status.DesiredNumberScheduled == status.CurrentNumberScheduled &&
 		status.DesiredNumberScheduled == status.NumberAvailable &&
@@ -397,7 +397,7 @@ func buildContainerImageSource(url string) configuration.ContainerImageIdentifie
 	}
 	return source
 }
-func GetRuntimeUID(cs *v1.ContainerStatus) (runtime, uid string) {
+func GetRuntimeUID(cs *corev1.ContainerStatus) (runtime, uid string) {
 	split := strings.Split(cs.ContainerID, "://")
 	if len(split) > 0 {
 		uid = split[len(split)-1]
@@ -431,14 +431,14 @@ func (p *Pod) String() string {
 	)
 }
 
-func DeploymentToString(d *v1apps.Deployment) string {
+func DeploymentToString(d *appsv1.Deployment) string {
 	return fmt.Sprintf("deployment: %s ns: %s",
 		d.Name,
 		d.Namespace,
 	)
 }
 
-func StatefulsetToString(s *v1apps.StatefulSet) string {
+func StatefulsetToString(s *appsv1.StatefulSet) string {
 	return fmt.Sprintf("statefulset: %s ns: %s",
 		s.Name,
 		s.Namespace,
@@ -628,7 +628,7 @@ func getMachineConfig(mcName string, machineConfigs map[string]MachineConfig) (M
 	return mc, nil
 }
 
-func createNodes(nodes []v1.Node) map[string]Node {
+func createNodes(nodes []corev1.Node) map[string]Node {
 	wrapperNodes := map[string]Node{}
 
 	// machineConfigs is a helper map to avoid download & process the same mc twice.

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -23,7 +23,7 @@ import (
 	"errors"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	olmv1Alpha "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	olmFakeClient "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
@@ -68,7 +68,7 @@ var (
 		Spec: olmv1Alpha.InstallPlanSpec{CatalogSource: "catalogSource1", CatalogSourceNamespace: "ns1",
 			ClusterServiceVersionNames: []string{"op1.v1.0.1"}, Approval: olmv1Alpha.ApprovalAutomatic, Approved: true},
 		Status: olmv1Alpha.InstallPlanStatus{BundleLookups: []olmv1Alpha.BundleLookup{{Path: "lookuppath1",
-			CatalogSourceRef: &v1.ObjectReference{Name: "catalogSource1", Namespace: "ns1"}}}},
+			CatalogSourceRef: &corev1.ObjectReference{Name: "catalogSource1", Namespace: "ns1"}}}},
 	}
 
 	ns2InstallPlan1 = olmv1Alpha.InstallPlan{
@@ -76,7 +76,7 @@ var (
 		Spec: olmv1Alpha.InstallPlanSpec{CatalogSource: "catalogSource2", CatalogSourceNamespace: "ns2",
 			ClusterServiceVersionNames: []string{"op1.v1.0.1"}, Approval: olmv1Alpha.ApprovalAutomatic, Approved: true},
 		Status: olmv1Alpha.InstallPlanStatus{BundleLookups: []olmv1Alpha.BundleLookup{{Path: "lookuppath2",
-			CatalogSourceRef: &v1.ObjectReference{Name: "catalogSource2", Namespace: "ns2"}}}},
+			CatalogSourceRef: &corev1.ObjectReference{Name: "catalogSource2", Namespace: "ns2"}}}},
 	}
 
 	ns2InstallPlan2 = olmv1Alpha.InstallPlan{
@@ -84,7 +84,7 @@ var (
 		Spec: olmv1Alpha.InstallPlanSpec{CatalogSource: "catalogSource3", CatalogSourceNamespace: "ns2",
 			ClusterServiceVersionNames: []string{"op2.v2.0.2"}, Approval: olmv1Alpha.ApprovalAutomatic, Approved: true},
 		Status: olmv1Alpha.InstallPlanStatus{BundleLookups: []olmv1Alpha.BundleLookup{{Path: "lookuppath3",
-			CatalogSourceRef: &v1.ObjectReference{Name: "catalogSource3", Namespace: "ns2"}}}},
+			CatalogSourceRef: &corev1.ObjectReference{Name: "catalogSource3", Namespace: "ns2"}}}},
 	}
 )
 
@@ -159,7 +159,7 @@ func TestGetUID(t *testing.T) {
 
 	for _, tc := range testCases {
 		c := GetContainer()
-		c.Data = &v1.Container{}
+		c.Data = &corev1.Container{}
 		c.Status.ContainerID = tc.testCID
 		uid, err := c.GetUID()
 		assert.Equal(t, tc.expectedErr, err)
@@ -248,7 +248,7 @@ func TestGetCsvInstallPlans(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "installPlan1", Namespace: "ns4"},
 		Spec:       olmv1Alpha.InstallPlanSpec{ClusterServiceVersionNames: []string{"op4.v4.0.4"}},
 		Status: olmv1Alpha.InstallPlanStatus{BundleLookups: []olmv1Alpha.BundleLookup{{Path: "lookuppath1",
-			CatalogSourceRef: &v1.ObjectReference{Name: "catalogSource1", Namespace: "ns4"}}}},
+			CatalogSourceRef: &corev1.ObjectReference{Name: "catalogSource1", Namespace: "ns4"}}}},
 	}
 	op4InstallPlan2 := op4InstallPlan1
 	op4InstallPlan2.ObjectMeta.Name = "installPlan2"
@@ -350,7 +350,7 @@ func TestGetCatalogSourceImageIndexFromInstallPlan(t *testing.T) {
 			installPlan: &olmv1Alpha.InstallPlan{
 				Status: olmv1Alpha.InstallPlanStatus{
 					BundleLookups: []olmv1Alpha.BundleLookup{
-						{Path: "path", CatalogSourceRef: &v1.ObjectReference{Name: "catalogName", Namespace: "notExistingNamespace"}}}},
+						{Path: "path", CatalogSourceRef: &corev1.ObjectReference{Name: "catalogName", Namespace: "notExistingNamespace"}}}},
 			},
 			expectedImageIndex: "",
 			expectedErrorStr:   "failed to get catalogsource: catalogsources.operators.coreos.com \"catalogName\" not found",
@@ -618,11 +618,11 @@ func TestCreateOperators(t *testing.T) {
 //nolint:funlen
 func TestConvertArrayPods(t *testing.T) {
 	testCases := []struct {
-		testPods     []*v1.Pod
+		testPods     []*corev1.Pod
 		expectedPods []*Pod
 	}{
 		{ // Test Case 1 - No containers
-			testPods: []*v1.Pod{
+			testPods: []*corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testpod1",
@@ -632,7 +632,7 @@ func TestConvertArrayPods(t *testing.T) {
 			},
 			expectedPods: []*Pod{
 				{
-					Data: &v1.Pod{
+					Data: &corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "testpod1",
 							Namespace: "testnamespace1",
@@ -642,14 +642,14 @@ func TestConvertArrayPods(t *testing.T) {
 			},
 		},
 		{ // Test Case 2 - Containers
-			testPods: []*v1.Pod{
+			testPods: []*corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testpod1",
 						Namespace: "testnamespace1",
 					},
-					Spec: v1.PodSpec{
-						Containers: []v1.Container{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
 							{
 								Name: "testcontainer1",
 							},
@@ -659,7 +659,7 @@ func TestConvertArrayPods(t *testing.T) {
 			},
 			expectedPods: []*Pod{
 				{
-					Data: &v1.Pod{
+					Data: &corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "testpod1",
 							Namespace: "testnamespace1",
@@ -667,7 +667,7 @@ func TestConvertArrayPods(t *testing.T) {
 					},
 					Containers: []*Container{
 						{
-							Data: &v1.Container{
+							Data: &corev1.Container{
 								Name: "testcontainer1",
 							},
 							Namespace: "testnamespace1",
@@ -776,10 +776,10 @@ func TestContainerStringFuncs(t *testing.T) {
 			NodeName:  tc.nodename,
 			Namespace: tc.namespace,
 			Podname:   tc.podname,
-			Data: &v1.Container{
+			Data: &corev1.Container{
 				Name: tc.name,
 			},
-			Status: v1.ContainerStatus{
+			Status: corev1.ContainerStatus{
 				ContainerID: tc.containerID,
 			},
 			Runtime: tc.runtime,
@@ -818,7 +818,7 @@ func TestCsvToString(t *testing.T) {
 
 func TestPodString(t *testing.T) {
 	p := Pod{
-		Data: &v1.Pod{
+		Data: &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test1",
 				Namespace: "testNS",
@@ -840,47 +840,47 @@ func TestOperatorString(t *testing.T) {
 //nolint:funlen
 func TestIsWorkerNode(t *testing.T) {
 	testCases := []struct {
-		node           *v1.Node
+		node           *corev1.Node
 		expectedResult bool
 	}{
 		{
-			node: &v1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
 			},
 			expectedResult: false,
 		},
 		{
-			node: &v1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"label1": "fakeValue1"}},
 			},
 			expectedResult: false,
 		},
 		{
-			node: &v1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"node-role.kubernetes.io/master": ""}},
 			},
 			expectedResult: false,
 		},
 		{
-			node: &v1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"node-role.kubernetes.io/worker": ""}},
 			},
 			expectedResult: true,
 		},
 		{
-			node: &v1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"node-role.kubernetes.io/worker": "blahblah"}},
 			},
 			expectedResult: true,
 		},
 		{
-			node: &v1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"label1": "fakeValue1", "node-role.kubernetes.io/worker": ""}},
 			},
 			expectedResult: true,
 		},
 		{
-			node: &v1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"label1": "fakeValue1", "node-role.kubernetes.io/worker": ""}},
 			},
 			expectedResult: true,
@@ -896,65 +896,65 @@ func TestIsWorkerNode(t *testing.T) {
 //nolint:funlen
 func TestIsMasterNode(t *testing.T) {
 	testCases := []struct {
-		node           *v1.Node
+		node           *corev1.Node
 		expectedResult bool
 	}{
 		{
-			node: &v1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
 			},
 			expectedResult: false,
 		},
 		{
-			node: &v1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"label1": "fakeValue1"}},
 			},
 			expectedResult: false,
 		},
 		{
-			node: &v1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"node-role.kubernetes.io/worker": ""}},
 			},
 			expectedResult: false,
 		},
 		{
-			node: &v1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"node-role.kubernetes.io/master": ""}},
 			},
 			expectedResult: true,
 		},
 		{
-			node: &v1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"node-role.kubernetes.io/master": "blahblah"}},
 			},
 			expectedResult: true,
 		},
 		{
-			node: &v1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""}},
 			},
 			expectedResult: true,
 		},
 		{
-			node: &v1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"node-role.kubernetes.io/control-plane": "blablah"}},
 			},
 			expectedResult: true,
 		},
 		{
-			node: &v1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"label1": "fakeValue1", "node-role.kubernetes.io/master": ""}},
 			},
 			expectedResult: true,
 		},
 		{
-			node: &v1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"label1": "fakeValue1", "node-role.kubernetes.io/control-plane": ""}},
 			},
 			expectedResult: true,
 		},
 		{
-			node: &v1.Node{
+			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"label1": "fakeValue1", "node-role.kubernetes.io/master": "", "node-role.kubernetes.io/control-plane": ""}},
 			},
 			expectedResult: true,


### PR DESCRIPTION
We import a lot of libraries, and it getting difficult to figure out which one we were referencing and in places where we did use unique import names, they weren't consistent. 

Changes:
- `v1` ambiguity in naming convention replaced by the module+v1
- Module naming changed (if applicable) from example `v1rbac` to `rbacv1` to match repo-wide.