### PR TITLE
Do not use labels to discover subscriptions.

### DIFF
--- a/cnf-certification-test/certification/suite.go
+++ b/cnf-certification-test/certification/suite.go
@@ -100,9 +100,9 @@ func testContainerCertificationStatus(env *provider.TestEnvironment) {
 func testAllOperatorCertified(env *provider.TestEnvironment) {
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestOperatorIsCertifiedIdentifier)
 	ginkgo.It(testID, ginkgo.Label(Online, testID), func() {
-		operatorsToQuery := env.Subscriptions
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, operatorsToQuery)
-		ginkgo.By(fmt.Sprintf("Verify operator as certified. Number of operators to check: %d", len(operatorsToQuery)))
+		operatorsUnderTest := env.Operators
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, operatorsUnderTest)
+		ginkgo.By(fmt.Sprintf("Verify operator as certified. Number of operators to check: %d", len(operatorsUnderTest)))
 		testFailed := false
 		ocpMinorVersion := ""
 		if env.OpenshiftVersion != "" {
@@ -111,15 +111,15 @@ func testAllOperatorCertified(env *provider.TestEnvironment) {
 			splitVersion := strings.SplitN(env.OpenshiftVersion, ".", majorMinorPatchCount)
 			ocpMinorVersion = splitVersion[0] + "." + splitVersion[1]
 		}
-		for _, op := range operatorsToQuery {
-			pack := op.Status.InstalledCSV
-			isCertified := registry.IsOperatorCertified(pack, ocpMinorVersion)
+		for i := range operatorsUnderTest {
+			name := operatorsUnderTest[i].Name
+			isCertified := registry.IsOperatorCertified(name, ocpMinorVersion)
 			if !isCertified {
 				testFailed = true
-				logrus.Info(fmt.Sprintf("Operator %s not certified for OpenShift %s .", pack, ocpMinorVersion))
-				tnf.ClaimFilePrintf("Operator %s  failed to be certified for OpenShift %s", pack, ocpMinorVersion)
+				logrus.Info(fmt.Sprintf("Operator %s not certified for OpenShift %s .", name, ocpMinorVersion))
+				tnf.ClaimFilePrintf("Operator %s  failed to be certified for OpenShift %s", name, ocpMinorVersion)
 			} else {
-				logrus.Info(fmt.Sprintf("Operator %s certified OK.", pack))
+				logrus.Info(fmt.Sprintf("Operator %s certified OK.", name))
 			}
 		}
 		if testFailed {

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -105,7 +105,7 @@ func DoAutoDiscover() DiscoveredTestData {
 	data.DebugPods = findPodsByLabel(oc.K8sClient.CoreV1(), debugLabels, debugNS)
 	data.Crds = FindTestCrdNames(data.TestData.CrdFilters)
 	data.Csvs = findOperatorsByLabel(oc.OlmClient, []configuration.Label{{Name: tnfCsvTargetLabelName, Prefix: tnfLabelPrefix, Value: tnfCsvTargetLabelValue}}, data.TestData.TargetNameSpaces)
-	data.Subscriptions = findSubscriptions(oc.OlmClient, []configuration.Label{{Name: tnfCsvTargetLabelName, Prefix: tnfLabelPrefix, Value: tnfCsvTargetLabelValue}}, data.Namespaces)
+	data.Subscriptions = findSubscriptions(oc.OlmClient, data.Namespaces)
 	data.HelmChartReleases = getHelmList(oc.RestConfig, data.Namespaces)
 	openshiftVersion, _ := getOpenshiftVersion(oc.OcpClient)
 	data.OpenshiftVersion = openshiftVersion

--- a/pkg/autodiscover/autodiscover_operators.go
+++ b/pkg/autodiscover/autodiscover_operators.go
@@ -54,25 +54,19 @@ func findOperatorsByLabel(olmClient clientOlm.Interface, labels []configuration.
 
 	return csvs
 }
-func findSubscriptions(olmClient clientOlm.Interface, labels []configuration.Label, namespaces []string) []olmv1Alpha.Subscription {
+func findSubscriptions(olmClient clientOlm.Interface, namespaces []string) []olmv1Alpha.Subscription {
 	subscriptions := []olmv1Alpha.Subscription{}
 	for _, ns := range namespaces {
 		logrus.Debugf("Searching subscriptions in namespace %s", ns)
-		for _, label := range labels {
-			logrus.Debugf("Searching subscriptions with label %+v", label)
-			label := buildLabelQuery(label)
-			subscription, err := olmClient.OperatorsV1alpha1().Subscriptions(ns).List(context.TODO(), metav1.ListOptions{
-				LabelSelector: label,
-			})
-			if err != nil {
-				logrus.Errorln("error when listing subscriptions in ns=", ns, " label=", label)
-				continue
-			}
-			subscriptions = append(subscriptions, subscription.Items...)
+		subscription, err := olmClient.OperatorsV1alpha1().Subscriptions(ns).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			logrus.Errorln("error when listing subscriptions in ns=", ns)
+			continue
 		}
+		subscriptions = append(subscriptions, subscription.Items...)
 	}
 
-	logrus.Infof("Found %d Subscriptions:", len(subscriptions))
+	logrus.Infof("Found %d subscriptions in the target namespaces:", len(subscriptions))
 	for i := range subscriptions {
 		logrus.Infof(" Subscriptions name: %s (ns: %s)", subscriptions[i].Name, subscriptions[i].Namespace)
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -106,7 +106,6 @@ type TestEnvironment struct { // rename this with testTarget
 	StatetfulSets     []*appsv1.StatefulSet                         `json:"testStatetfulSets"`
 	HorizontalScaler  map[string]*scalingv1.HorizontalPodAutoscaler `json:"testHorizontalScaler"`
 	Nodes             map[string]Node                               `json:"-"`
-	Subscriptions     []*olmv1Alpha.Subscription                    `json:"testSubscriptions"`
 	K8sVersion        string                                        `json:"-"`
 	OpenshiftVersion  string                                        `json:"-"`
 	HelmChartReleases []*release.Release                            `json:"testHelmChartReleases"`
@@ -232,14 +231,7 @@ func buildTestEnvironment() { //nolint:funlen
 		nodeName := data.DebugPods[i].Spec.NodeName
 		env.DebugPods[nodeName] = &data.DebugPods[i]
 	}
-	csvs := data.Csvs
-	subscriptions := data.Subscriptions
-	for i := range csvs {
-		isCsv, sub := IsinstalledCsv(&csvs[i], subscriptions)
-		if isCsv {
-			env.Subscriptions = append(env.Subscriptions, &sub)
-		}
-	}
+
 	env.OpenshiftVersion = data.OpenshiftVersion
 	env.K8sVersion = data.K8sVersion
 	for _, nsHelmChartReleases := range data.HelmChartReleases {
@@ -262,6 +254,7 @@ func buildTestEnvironment() { //nolint:funlen
 		logrus.Errorf("Failed to get cluster operators: %s", err)
 	}
 	env.Operators = operators
+	logrus.Infof("Operators found: %d", len(env.Operators))
 }
 
 func getPodContainers(aPod *corev1.Pod) (containerList []*Container) {


### PR DESCRIPTION
The subscriptions discovery was wrong as it was using labels to find
them. I've changed that and also removed the subscriptions slice as it's
never used.

+ Includes PR #186 changes plus some naming refactors.