### PR TITLE
Add repo access token to the update certified db job.

### DIFF
--- a/.github/workflows/update-certification.yml
+++ b/.github/workflows/update-certification.yml
@@ -34,6 +34,8 @@ jobs:
         run: ./tnf fetch --operator --container --helm
       - name: create PR
         uses: peter-evans/create-pull-request@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.UPDATE_CERTIFIED_DB_TOKEN }}
         with:
           commit-message: Update certification files
           title: Update certification files


### PR DESCRIPTION
The jobs seems to work, but it's not triggering the PR check actions as
a repo token is needed for this. See:
https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs