### PR TITLE
Surface more information about tainted kernel failures

### DIFF
--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -199,9 +199,11 @@ func testTainted(env *provider.TestEnvironment, testerFuncs nodetainted.TaintedF
 			nodeTaintsAccepted = false
 
 			// Surface more information about tainted kernel failures that have nothing to do with modules.
-			tnf.ClaimFilePrintf("Please note that taints other than 'module was loaded' were found.")
+			tnf.ClaimFilePrintf("Please note that taints other than 'module was loaded' were found on node %s.", dp.Spec.NodeName)
+			logrus.Debugf("Please note that taints other than 'module was loaded' were found on node %s.", dp.Spec.NodeName)
 			for _, ot := range otherTaints {
-				tnf.ClaimFilePrintf("Taint causing failure: %s", ot)
+				tnf.ClaimFilePrintf("Taint causing failure: %s on node: %s", ot, dp.Spec.NodeName)
+				logrus.Debugf("Taint causing failure: %s on node: %s", ot, dp.Spec.NodeName)
 			}
 		} else if moduleTaintsFound {
 			// Retrieve the modules from the node (via the debug pod)

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -185,16 +185,24 @@ func testTainted(env *provider.TestEnvironment, testerFuncs nodetainted.TaintedF
 		moduleTaintsFound := false
 		otherTaintsFound := false
 
+		otherTaints := []string{}
 		for _, it := range individualTaints {
 			if strings.Contains(it, `module was loaded`) {
 				moduleTaintsFound = true
 			} else {
 				otherTaintsFound = true
+				otherTaints = append(otherTaints, it)
 			}
 		}
 
 		if otherTaintsFound {
 			nodeTaintsAccepted = false
+
+			// Surface more information about tainted kernel failures that have nothing to do with modules.
+			tnf.ClaimFilePrintf("Please note that taints other than 'module was loaded' were found.")
+			for _, ot := range otherTaints {
+				tnf.ClaimFilePrintf("Taint causing failure: %s", ot)
+			}
 		} else if moduleTaintsFound {
 			// Retrieve the modules from the node (via the debug pod)
 			modules := testerFuncs.GetModulesFromNode(ocpContext)


### PR DESCRIPTION
If there are "other" tainted kernel failures than the `module was loaded` failures, report them as part of the claim file printout.