### PR TITLE
Upgrade to v3 setup-go action

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
       - name: Set up Go 1.18
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.1
 

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Set up Go 1.18
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.1
 
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Set up Go 1.18
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.1
 
@@ -128,7 +128,7 @@ jobs:
 
     steps:
       - name: Set up Go 1.18.1
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.1
 

--- a/.github/workflows/update-certification.yml
+++ b/.github/workflows/update-certification.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Set up Go 1.18.1
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.1
 


### PR DESCRIPTION
https://github.com/actions/setup-go/releases/tag/v3.0.0

v3 is the latest available release of `setup-go`.

Semi-related to #204 