### PR TITLE
Missed shellcheck ubuntu version

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -59,7 +59,7 @@ jobs:
         run: make vet
   shellcheck:
     name: Shellcheck
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Run ShellCheck


### PR DESCRIPTION
#185 added this shellcheck linter but #196 missed the version bump.