### PR TITLE
Adjust CuratedLogLines

### DIFF
--- a/cnf-certification-test/accesscontrol/namespace/namespace.go
+++ b/cnf-certification-test/accesscontrol/namespace/namespace.go
@@ -96,7 +96,7 @@ func GetInvalidCRsNum(invalidCrs map[string]map[string][]string) (invalidCrsNum 
 	for crdName, namespaces := range invalidCrs {
 		for namespace, crNames := range namespaces {
 			for _, crName := range crNames {
-				claimsLog = claimsLog.AddLogLine("crName=%s namespace=%s is invalid (crd=%s)", crName, namespace, crdName)
+				claimsLog.AddLogLine("crName=%s namespace=%s is invalid (crd=%s)", crName, namespace, crdName)
 				invalidCrsNum++
 			}
 		}

--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -296,7 +296,7 @@ func TestNamespace(env *provider.TestEnvironment) {
 	invalidCrsNum, claimsLog := namespace.GetInvalidCRsNum(invalidCrs)
 	if invalidCrsNum > 0 {
 		ginkgo.Fail(fmt.Sprintf("Found %d CRs belonging to invalid namespaces.", invalidCrsNum))
-		tnf.ClaimFilePrintf("%s", claimsLog)
+		tnf.ClaimFilePrintf("%s", claimsLog.GetLogLines())
 	}
 }
 

--- a/cnf-certification-test/lifecycle/podsets/podsets.go
+++ b/cnf-certification-test/lifecycle/podsets/podsets.go
@@ -111,18 +111,18 @@ func WaitForAllPodSetReady(env *provider.TestEnvironment, timeoutPodSetReady tim
 	for _, dut := range env.Deployments {
 		isReady := WaitForDeploymentSetReady(dut.Namespace, dut.Name, timeoutPodSetReady)
 		if isReady {
-			claimsLog = claimsLog.AddLogLine("%s Status: OK", provider.DeploymentToString(dut))
+			claimsLog.AddLogLine("%s Status: OK", provider.DeploymentToString(dut))
 		} else {
-			claimsLog = claimsLog.AddLogLine("%s Status: NOK", provider.DeploymentToString(dut))
+			claimsLog.AddLogLine("%s Status: NOK", provider.DeploymentToString(dut))
 			atLeastOnePodsetNotReady = true
 		}
 	}
 	for _, sut := range env.StatetfulSets {
 		isReady := WaitForStatefulSetReady(sut.Namespace, sut.Name, timeoutPodSetReady)
 		if isReady {
-			claimsLog = claimsLog.AddLogLine("%s Status: OK", provider.StatefulsetToString(sut))
+			claimsLog.AddLogLine("%s Status: OK", provider.StatefulsetToString(sut))
 		} else {
-			claimsLog = claimsLog.AddLogLine("%s Status: NOK", provider.StatefulsetToString(sut))
+			claimsLog.AddLogLine("%s Status: NOK", provider.StatefulsetToString(sut))
 			atLeastOnePodsetNotReady = true
 		}
 	}

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -324,7 +324,7 @@ func testPodsRecreation(env *provider.TestEnvironment) { //nolint:funlen
 	defer env.SetNeedsRefresh()
 	claimsLog, atLeastOnePodsetNotReady := podsets.WaitForAllPodSetReady(env, timeoutPodSetReady)
 	if atLeastOnePodsetNotReady {
-		tnf.ClaimFilePrintf("%s", claimsLog)
+		tnf.ClaimFilePrintf("%s", claimsLog.GetLogLines())
 		ginkgo.Fail("Some deployments or stateful sets are not in a good initial state. Cannot perform test.")
 	}
 	for n := range podsets.GetAllNodesForAllPodSets(env.Pods) {
@@ -349,7 +349,7 @@ func testPodsRecreation(env *provider.TestEnvironment) { //nolint:funlen
 
 		claimsLog, podsNotReady := podsets.WaitForAllPodSetReady(env, nodeTimeout)
 		if podsNotReady {
-			tnf.ClaimFilePrintf("%s", claimsLog)
+			tnf.ClaimFilePrintf("%s", claimsLog.GetLogLines())
 			ginkgo.Fail(fmt.Sprintf("Some pods are not ready after draining the node %s", n))
 		}
 

--- a/cnf-certification-test/networking/icmp/icmp.go
+++ b/cnf-certification-test/networking/icmp/icmp.go
@@ -52,13 +52,13 @@ func BuildNetTestContext(pods []*provider.Pod, aIPVersion netcommons.IPVersion, 
 	netsUnderTest = make(map[string]netcommons.NetTestContext)
 	for _, put := range pods {
 		if put.SkipNetTests {
-			claimsLog = claimsLog.AddLogLine("Skipping %s because it is excluded from all connectivity tests", put)
+			claimsLog.AddLogLine("Skipping %s because it is excluded from all connectivity tests", put)
 			continue
 		}
 
 		if aType == netcommons.MULTUS {
 			if put.SkipMultusNetTests {
-				claimsLog = claimsLog.AddLogLine("Skipping pod %s because it is excluded from %s connectivity tests only", put.Data.Name, aType)
+				claimsLog.AddLogLine("Skipping pod %s because it is excluded from %s connectivity tests only", put.Data.Name, aType)
 				continue
 			}
 			for netKey, multusIPAddress := range put.MultusIPs {
@@ -149,7 +149,7 @@ func RunNetworkingTests( //nolint:funlen
 				aDestIP.ContainerIdentifier, aDestIP.IP)
 			result, err := TestPing(netUnderTest.TesterSource.ContainerIdentifier, aDestIP, count)
 			logrus.Debugf("Ping results: %s", result.String())
-			claimsLog = claimsLog.AddLogLine("%s ping test on network %s from ( %s  srcip: %s ) to ( %s dstip: %s ) result: %s",
+			claimsLog.AddLogLine("%s ping test on network %s from ( %s  srcip: %s ) to ( %s dstip: %s ) result: %s",
 				aIPVersion, netName,
 				netUnderTest.TesterSource.ContainerIdentifier, netUnderTest.TesterSource.IP,
 				aDestIP.ContainerIdentifier, aDestIP.IP, result.String())

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -167,10 +167,10 @@ func testNodePort(env *provider.TestEnvironment) {
 func testNetworkConnectivity(env *provider.TestEnvironment, count int, aIPVersion netcommons.IPVersion, aType netcommons.IFType) {
 	netsUnderTest, claimsLog := icmp.BuildNetTestContext(env.Pods, aIPVersion, aType)
 	// Saving  curated logs to claims file
-	tnf.ClaimFilePrintf("%s", claimsLog)
+	tnf.ClaimFilePrintf("%s", claimsLog.GetLogLines())
 	badNets, claimsLog, skip := icmp.RunNetworkingTests(netsUnderTest, count, aIPVersion)
 	// Saving curated logs to claims file
-	tnf.ClaimFilePrintf("%s", claimsLog)
+	tnf.ClaimFilePrintf("%s", claimsLog.GetLogLines())
 	if skip {
 		ginkgo.Skip(fmt.Sprintf("There are no %s networks to test, skipping test", aIPVersion))
 	}

--- a/cnf-certification-test/platform/bootparams/bootparams.go
+++ b/cnf-certification-test/platform/bootparams/bootparams.go
@@ -53,7 +53,7 @@ func TestBootParamsHelper(env *provider.TestEnvironment, cut *provider.Container
 	for key, mcVal := range mcKernelArgumentsMap {
 		if currentVal, ok := currentKernelArgsMap[key]; ok {
 			if currentVal != mcVal {
-				claimsLog = claimsLog.AddLogLine("%s KernelCmdLineArg %q does not match MachineConfig value: %q!=%q",
+				claimsLog.AddLogLine("%s KernelCmdLineArg %q does not match MachineConfig value: %q!=%q",
 					cut.NodeName, key, currentVal, mcVal)
 			} else {
 				logrus.Tracef("%s KernelCmdLineArg==mcVal %q: %q==%q", cut.NodeName, key, currentVal, mcVal)
@@ -61,7 +61,7 @@ func TestBootParamsHelper(env *provider.TestEnvironment, cut *provider.Container
 		}
 		if grubVal, ok := grubKernelConfigMap[key]; ok {
 			if grubVal != mcVal {
-				claimsLog = claimsLog.AddLogLine("%s NodeGrubKernelArgs %q does not match MachineConfig value: %q!=%q",
+				claimsLog.AddLogLine("%s NodeGrubKernelArgs %q does not match MachineConfig value: %q!=%q",
 					cut.NodeName, key, mcVal, grubVal)
 			} else {
 				logrus.Tracef("%s NodeGrubKernelArg==mcVal %q: %q==%q", cut.NodeName, key, grubVal, mcVal)

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -330,7 +330,7 @@ func testUnalteredBootParams(env *provider.TestEnvironment) {
 
 		if err != nil || len(claimsLog.GetLogLines()) != 0 {
 			failedNodes = append(failedNodes, fmt.Sprintf("node %s (%s)", cut.NodeName, cut.String()))
-			tnf.ClaimFilePrintf("%s", claimsLog)
+			tnf.ClaimFilePrintf("%s", claimsLog.GetLogLines())
 		}
 	}
 	gomega.Expect(failedNodes).To(gomega.BeEmpty())

--- a/pkg/loghelper/loghelper.go
+++ b/pkg/loghelper/loghelper.go
@@ -32,20 +32,19 @@ type CuratedLogLines struct {
 }
 
 // AddLogLine checks a slice for a given string.
-func (list CuratedLogLines) AddLogLine(format string, args ...interface{}) CuratedLogLines {
+//nolint:goprintffuncname
+func (list *CuratedLogLines) AddLogLine(format string, args ...interface{}) {
 	message := fmt.Sprintf(format+"\n", args...)
 	list.lines = append(list.lines, message)
 	logrus.Debug(message)
-	return list
 }
 
 // Init checks a slice for a given string.
-func (list CuratedLogLines) Init(lines ...string) CuratedLogLines {
+func (list *CuratedLogLines) Init(lines ...string) {
 	list.lines = append(list.lines, lines...)
-	return list
 }
 
-func (list CuratedLogLines) GetLogLines() []string {
+func (list *CuratedLogLines) GetLogLines() []string {
 	return list.lines
 }
 

--- a/pkg/loghelper/loghelper_test.go
+++ b/pkg/loghelper/loghelper_test.go
@@ -25,8 +25,8 @@ import (
 func TestLogLines(t *testing.T) {
 	SetLogFormat()
 	ll := CuratedLogLines{}
-	ll = ll.Init("one", "two", "three")
+	ll.Init("one", "two", "three")
 	assert.Equal(t, []string{"one", "two", "three"}, ll.GetLogLines())
-	ll = ll.AddLogLine("four") // adds a newline
+	ll.AddLogLine("four") // adds a newline
 	assert.Equal(t, []string{"one", "two", "three", "four\n"}, ll.GetLogLines())
 }


### PR DESCRIPTION
Changed `CuratedLogLines` struct funcs to be implemented via pointers and instead of passing around copies just use the same object wherever it's used.