### PR TITLE
Update partner release tag to v4.0.0

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "partner_tag": "v3.1.0"
+  "partner_tag": "v4.0.0"
 }


### PR DESCRIPTION
In preparation for the v4.0.0 release we are setting the partner repo version to tag 4.0.0 which can be found here: https://github.com/test-network-function/cnf-certification-test-partner/releases/tag/v4.0.0