### PR TITLE
Add working directory in tnf_image.yaml

### DIFF
--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -133,6 +133,8 @@ jobs:
           
       - name: Start the minikube cluster for `local-test-infra`
         uses: ./cnf-certification-test-partner/.github/actions/start-k8s-cluster
+        with:
+          working_directory: cnf-certification-test-partner
           
       - name: Create `local-test-infra` OpenShift resources
         uses: ./cnf-certification-test-partner/.github/actions/create-local-test-infra-resources


### PR DESCRIPTION
This was causing the v4.0.0 image publish run to fail.