### PR TITLE
Consolidate release logic

### DIFF
--- a/cnf-certification-test/certification/certtool/certtool.go
+++ b/cnf-certification-test/certification/certtool/certtool.go
@@ -17,14 +17,11 @@
 package certtool
 
 import (
-	"strings"
 	"time"
 
-	version "github.com/hashicorp/go-version"
 	"github.com/test-network-function/cnf-certification-test/internal/api"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
-	"helm.sh/helm/v3/pkg/release"
 )
 
 const (
@@ -67,44 +64,6 @@ func WaitForCertificationRequestToSuccess(certificationRequestFunc func() (inter
 		elapsed += pollingPeriod
 	}
 	return result
-}
-
-// CompareVersion compare between versions
-func CompareVersion(ver1, ver2 string) bool {
-	ourKubeVersion, _ := version.NewVersion(ver1)
-	kubeVersion := strings.ReplaceAll(ver2, " ", "")[2:]
-	if strings.Contains(kubeVersion, "<") {
-		kubever := strings.Split(kubeVersion, "<")
-		minVersion, _ := version.NewVersion(kubever[0])
-		maxVersion, _ := version.NewVersion(kubever[1])
-		if ourKubeVersion.GreaterThanOrEqual(minVersion) && ourKubeVersion.LessThan(maxVersion) {
-			return true
-		}
-	} else {
-		kubever := strings.Split(kubeVersion, "-")
-		minVersion, _ := version.NewVersion(kubever[0])
-		if ourKubeVersion.GreaterThanOrEqual(minVersion) {
-			return true
-		}
-	}
-	return false
-}
-
-func IsReleaseCertified(helm *release.Release, ourKubeVersion string, out api.ChartStruct) bool {
-	for _, entryList := range out.Entries {
-		for _, entry := range entryList {
-			if entry.Name == helm.Chart.Metadata.Name && entry.Version == helm.Chart.Metadata.Version {
-				if entry.KubeVersion != "" {
-					if CompareVersion(ourKubeVersion, entry.KubeVersion) {
-						return true
-					}
-				} else {
-					return true
-				}
-			}
-		}
-	}
-	return false
 }
 
 func GetContainersToQuery(env *provider.TestEnvironment) map[configuration.ContainerImageIdentifier]bool {

--- a/cnf-certification-test/certification/certtool/certtool_test.go
+++ b/cnf-certification-test/certification/certtool/certtool_test.go
@@ -25,8 +25,6 @@ import (
 	"github.com/test-network-function/cnf-certification-test/internal/api"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
-	"helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/release"
 )
 
 func TestGetContainerCertificationRequestFunction(t *testing.T) {
@@ -105,36 +103,6 @@ func TestGetOperatorCertificationRequestFunction(t *testing.T) {
 	}
 }
 
-func TestCompareVersion(t *testing.T) {
-	// Note: These values pertain to 'kubeVersion' fields found:
-	// https://charts.openshift.io/index.yaml
-	testCases := []struct {
-		ver1           string
-		ver2           string
-		expectedOutput bool
-	}{
-		{
-			ver1:           "1.18.1",
-			ver2:           ">= 1.19",
-			expectedOutput: false,
-		},
-		{
-			ver1:           "1.19.1",
-			ver2:           ">= 1.19",
-			expectedOutput: true,
-		},
-		{
-			ver1:           "1.19",
-			ver2:           ">= 1.16.0 < 1.22.0",
-			expectedOutput: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		assert.Equal(t, tc.expectedOutput, CompareVersion(tc.ver1, tc.ver2))
-	}
-}
-
 func TestWaitForCertificationRequestToSuccess(t *testing.T) {
 	testCases := []struct {
 		testFunc   func() (interface{}, error)
@@ -178,69 +146,6 @@ func TestWaitForCertificationRequestToSuccess(t *testing.T) {
 			// Note: Cannot cast the result here because the interface returned is nil.
 			assert.Nil(t, result)
 		}
-	}
-}
-
-//nolint:funlen
-func TestIsReleaseCertified(t *testing.T) {
-	// Create a helm object
-	generateHelm := func(name, version string) *release.Release {
-		return &release.Release{
-			Chart: &chart.Chart{
-				Metadata: &chart.Metadata{
-					Name:    name,
-					Version: version,
-				},
-			},
-		}
-	}
-	// Create a chart struct
-	generateChartStruct := func(name, version, kubeVersion string) api.ChartStruct {
-		return api.ChartStruct{
-			Entries: map[string][]struct {
-				Name        string "yaml:\"name\""
-				Version     string "yaml:\"version\""
-				KubeVersion string "yaml:\"kubeVersion\""
-			}{
-				"entry1": {
-					{
-						Name:        name,
-						Version:     version,
-						KubeVersion: kubeVersion,
-					},
-				},
-			},
-		}
-	}
-
-	testCases := []struct {
-		testKubeVersion   string
-		testRelease       *release.Release
-		testChartStruct   api.ChartStruct
-		expectedCertified bool
-	}{
-		{ // Test Case #1 - FAIL the entries mismatched helm1 vs. helm2
-			testRelease:       generateHelm("helm1", "0.0.1"),
-			testKubeVersion:   "1.18.1",
-			testChartStruct:   generateChartStruct("helm2", "0.0.1", ">= 1.19"),
-			expectedCertified: false,
-		},
-		{ // Test Case #2 - PASS the entries matched
-			testRelease:       generateHelm("helm1", "0.0.1"),
-			testKubeVersion:   "1.20.1",
-			testChartStruct:   generateChartStruct("helm1", "0.0.1", ">= 1.19"),
-			expectedCertified: true,
-		},
-		{ // Test Case #3 - FAIL the versions mismatch 0.0.1 vs 0.0.2
-			testRelease:       generateHelm("helm1", "0.0.1"),
-			testKubeVersion:   "1.18.1",
-			testChartStruct:   generateChartStruct("helm1", "0.0.2", ">= 1.19"),
-			expectedCertified: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		assert.Equal(t, tc.expectedCertified, IsReleaseCertified(tc.testRelease, tc.testKubeVersion, tc.testChartStruct))
 	}
 }
 

--- a/cnf-certification-test/certification/suite.go
+++ b/cnf-certification-test/certification/suite.go
@@ -150,7 +150,7 @@ func testHelmCertified(env *provider.TestEnvironment) {
 	// Collect all of the failed helm charts
 	failedHelmCharts := [][]string{}
 	for _, helm := range helmchartsReleases {
-		if !releasehelper.IsReleaseCertified(helm, env.K8sVersion, out, chartsdb) {
+		if !releasehelper.IsReleaseCertified(helm, env.K8sVersion, out.Entries) {
 			failedHelmCharts = append(failedHelmCharts, []string{helm.Chart.Metadata.Version, helm.Name})
 		} else {
 			logrus.Info(fmt.Sprintf("Helm %s with version %s is certified", helm.Name, helm.Chart.Metadata.Version))

--- a/cnf-certification-test/certification/suite.go
+++ b/cnf-certification-test/certification/suite.go
@@ -31,6 +31,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/results"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
+	"github.com/test-network-function/cnf-certification-test/pkg/releasehelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
 )
@@ -149,7 +150,7 @@ func testHelmCertified(env *provider.TestEnvironment) {
 	// Collect all of the failed helm charts
 	failedHelmCharts := [][]string{}
 	for _, helm := range helmchartsReleases {
-		if !certtool.IsReleaseCertified(helm, env.K8sVersion, out) {
+		if !releasehelper.IsReleaseCertified(helm, env.K8sVersion, out, chartsdb) {
 			failedHelmCharts = append(failedHelmCharts, []string{helm.Chart.Metadata.Version, helm.Name})
 		} else {
 			logrus.Info(fmt.Sprintf("Helm %s with version %s is certified", helm.Name, helm.Chart.Metadata.Version))

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -126,12 +126,14 @@ type ContainerCatalogEntry struct {
 		TopLayerID             string `json:"top_layer_id"`
 		UncompressedTopLayerID string `json:"uncompressed_top_layer_id"`*/
 }
+
+type ChartEntry struct {
+	Name        string `yaml:"name"`
+	Version     string `yaml:"version"`
+	KubeVersion string `yaml:"kubeVersion"`
+}
 type ChartStruct struct {
-	Entries map[string][]struct {
-		Name        string `yaml:"name"`
-		Version     string `yaml:"version"`
-		KubeVersion string `yaml:"kubeVersion"`
-	} `yaml:"entries"`
+	Entries map[string][]ChartEntry `yaml:"entries"`
 }
 
 type catalogQueryResponse struct {

--- a/internal/registry/helm.go
+++ b/internal/registry/helm.go
@@ -4,12 +4,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
-	"github.com/hashicorp/go-version"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
-	"helm.sh/helm/v3/pkg/release"
 )
 
 const (
@@ -49,42 +46,4 @@ func loadHelmCatalog(pathToRoot string) {
 		log.Error("error while parsing the yaml file of the helm certification list ", err)
 	}
 	chartsdb = charts.Entries
-}
-
-// CompareVersion compare between versions
-func CompareVersion(ver1, ver2 string) bool {
-	ourKubeVersion, _ := version.NewVersion(ver1)
-	kubeVersion := strings.ReplaceAll(ver2, " ", "")[2:]
-	if strings.Contains(kubeVersion, "<") {
-		kubever := strings.Split(kubeVersion, "<")
-		minVersion, _ := version.NewVersion(kubever[0])
-		maxVersion, _ := version.NewVersion(kubever[1])
-		if ourKubeVersion.GreaterThanOrEqual(minVersion) && ourKubeVersion.LessThan(maxVersion) {
-			return true
-		}
-	} else {
-		kubever := strings.Split(kubeVersion, "-")
-		minVersion, _ := version.NewVersion(kubever[0])
-		if ourKubeVersion.GreaterThanOrEqual(minVersion) {
-			return true
-		}
-	}
-	return false
-}
-
-func IsReleaseCertified(helm *release.Release, ourKubeVersion string) bool {
-	for _, entryList := range chartsdb {
-		for _, entry := range entryList {
-			if entry.Name == helm.Chart.Metadata.Name && entry.Version == helm.Chart.Metadata.Version {
-				if entry.KubeVersion != "" {
-					if CompareVersion(ourKubeVersion, entry.KubeVersion) {
-						return true
-					}
-				} else {
-					return true
-				}
-			}
-		}
-	}
-	return false
 }

--- a/internal/registry/helm.go
+++ b/internal/registry/helm.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/test-network-function/cnf-certification-test/internal/api"
 	"gopkg.in/yaml.v2"
 )
 
@@ -13,16 +14,7 @@ const (
 	helmRelativePath = "%s/../cmd/tnf/fetch/data/helm/helm.db"
 )
 
-type ChartEntry struct {
-	Name        string `yaml:"name"`
-	Version     string `yaml:"version"`
-	KubeVersion string `yaml:"kubeVersion"`
-}
-type ChartStruct struct {
-	Entries map[string][]ChartEntry `yaml:"entries"`
-}
-
-var chartsdb = make(map[string][]ChartEntry)
+var chartsdb = make(map[string][]api.ChartEntry)
 var loaded = false
 
 func loadHelmCatalog(pathToRoot string) {
@@ -41,7 +33,7 @@ func loadHelmCatalog(pathToRoot string) {
 	if err != nil {
 		log.Error("can't process file", f.Name(), err, " trying to proceed")
 	}
-	var charts ChartStruct
+	var charts api.ChartStruct
 	if err = yaml.Unmarshal(bytes, &charts); err != nil {
 		log.Error("error while parsing the yaml file of the helm certification list ", err)
 	}

--- a/pkg/releasehelper/releasehelper.go
+++ b/pkg/releasehelper/releasehelper.go
@@ -1,12 +1,28 @@
+// Copyright (C) 2020-2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
 package releasehelper
 
 import (
-	"github.com/test-network-function/cnf-certification-test/internal/registry"
+	"github.com/test-network-function/cnf-certification-test/internal/api"
 	"github.com/test-network-function/cnf-certification-test/pkg/stringhelper"
 	"helm.sh/helm/v3/pkg/release"
 )
 
-func IsReleaseCertified(helm *release.Release, ourKubeVersion string, chartsdb map[string][]registry.ChartEntry) bool {
+func IsReleaseCertified(helm *release.Release, ourKubeVersion string, chartsdb map[string][]api.ChartEntry) bool {
 	for _, entryList := range chartsdb {
 		for _, entry := range entryList {
 			if entry.Name == helm.Chart.Metadata.Name && entry.Version == helm.Chart.Metadata.Version {

--- a/pkg/releasehelper/releasehelper.go
+++ b/pkg/releasehelper/releasehelper.go
@@ -1,0 +1,24 @@
+package releasehelper
+
+import (
+	"github.com/test-network-function/cnf-certification-test/internal/registry"
+	"github.com/test-network-function/cnf-certification-test/pkg/stringhelper"
+	"helm.sh/helm/v3/pkg/release"
+)
+
+func IsReleaseCertified(helm *release.Release, ourKubeVersion string, chartsdb map[string][]registry.ChartEntry) bool {
+	for _, entryList := range chartsdb {
+		for _, entry := range entryList {
+			if entry.Name == helm.Chart.Metadata.Name && entry.Version == helm.Chart.Metadata.Version {
+				if entry.KubeVersion != "" {
+					if stringhelper.CompareVersion(ourKubeVersion, entry.KubeVersion) {
+						return true
+					}
+				} else {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/pkg/releasehelper/releasehelper_test.go
+++ b/pkg/releasehelper/releasehelper_test.go
@@ -1,0 +1,73 @@
+package releasehelper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/cnf-certification-test/internal/api"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/release"
+)
+
+//nolint:funlen
+func TestIsReleaseCertified(t *testing.T) {
+	// Create a helm object
+	generateHelm := func(name, version string) *release.Release {
+		return &release.Release{
+			Chart: &chart.Chart{
+				Metadata: &chart.Metadata{
+					Name:    name,
+					Version: version,
+				},
+			},
+		}
+	}
+	// Create a chart struct
+	generateChartStruct := func(name, version, kubeVersion string) api.ChartStruct {
+		return api.ChartStruct{
+			Entries: map[string][]struct {
+				Name        string "yaml:\"name\""
+				Version     string "yaml:\"version\""
+				KubeVersion string "yaml:\"kubeVersion\""
+			}{
+				"entry1": {
+					{
+						Name:        name,
+						Version:     version,
+						KubeVersion: kubeVersion,
+					},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		testKubeVersion   string
+		testRelease       *release.Release
+		testChartStruct   api.ChartStruct
+		expectedCertified bool
+	}{
+		{ // Test Case #1 - FAIL the entries mismatched helm1 vs. helm2
+			testRelease:       generateHelm("helm1", "0.0.1"),
+			testKubeVersion:   "1.18.1",
+			testChartStruct:   generateChartStruct("helm2", "0.0.1", ">= 1.19"),
+			expectedCertified: false,
+		},
+		{ // Test Case #2 - PASS the entries matched
+			testRelease:       generateHelm("helm1", "0.0.1"),
+			testKubeVersion:   "1.20.1",
+			testChartStruct:   generateChartStruct("helm1", "0.0.1", ">= 1.19"),
+			expectedCertified: true,
+		},
+		{ // Test Case #3 - FAIL the versions mismatch 0.0.1 vs 0.0.2
+			testRelease:       generateHelm("helm1", "0.0.1"),
+			testKubeVersion:   "1.18.1",
+			testChartStruct:   generateChartStruct("helm1", "0.0.2", ">= 1.19"),
+			expectedCertified: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedCertified, IsReleaseCertified(tc.testRelease, tc.testKubeVersion, tc.testChartStruct))
+	}
+}

--- a/pkg/releasehelper/releasehelper_test.go
+++ b/pkg/releasehelper/releasehelper_test.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2020-2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
 package releasehelper
 
 import (
@@ -25,17 +41,9 @@ func TestIsReleaseCertified(t *testing.T) {
 	// Create a chart struct
 	generateChartStruct := func(name, version, kubeVersion string) api.ChartStruct {
 		return api.ChartStruct{
-			Entries: map[string][]struct {
-				Name        string "yaml:\"name\""
-				Version     string "yaml:\"version\""
-				KubeVersion string "yaml:\"kubeVersion\""
-			}{
-				"entry1": {
-					{
-						Name:        name,
-						Version:     version,
-						KubeVersion: kubeVersion,
-					},
+			Entries: map[string][]api.ChartEntry{
+				"entry1": []api.ChartEntry{
+					{Name: name, Version: version, KubeVersion: kubeVersion},
 				},
 			},
 		}
@@ -68,6 +76,6 @@ func TestIsReleaseCertified(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		assert.Equal(t, tc.expectedCertified, IsReleaseCertified(tc.testRelease, tc.testKubeVersion, tc.testChartStruct))
+		assert.Equal(t, tc.expectedCertified, IsReleaseCertified(tc.testRelease, tc.testKubeVersion, tc.testChartStruct.Entries))
 	}
 }

--- a/pkg/stringhelper/stringhelper.go
+++ b/pkg/stringhelper/stringhelper.go
@@ -18,6 +18,8 @@ package stringhelper
 
 import (
 	"strings"
+
+	"github.com/hashicorp/go-version"
 )
 
 // StringInSlice checks a slice for a given string.
@@ -47,4 +49,25 @@ func RemoveDuplicates(str []string) []string {
 		}
 	}
 	return list
+}
+
+// CompareVersion compare between versions
+func CompareVersion(ver1, ver2 string) bool {
+	ourKubeVersion, _ := version.NewVersion(ver1)
+	kubeVersion := strings.ReplaceAll(ver2, " ", "")[2:]
+	if strings.Contains(kubeVersion, "<") {
+		kubever := strings.Split(kubeVersion, "<")
+		minVersion, _ := version.NewVersion(kubever[0])
+		maxVersion, _ := version.NewVersion(kubever[1])
+		if ourKubeVersion.GreaterThanOrEqual(minVersion) && ourKubeVersion.LessThan(maxVersion) {
+			return true
+		}
+	} else {
+		kubever := strings.Split(kubeVersion, "-")
+		minVersion, _ := version.NewVersion(kubever[0])
+		if ourKubeVersion.GreaterThanOrEqual(minVersion) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/stringhelper/stringhelper_test.go
+++ b/pkg/stringhelper/stringhelper_test.go
@@ -76,3 +76,33 @@ func TestStringInSlice(t *testing.T) {
 		assert.Equal(t, tc.expected, StringInSlice(tc.testSlice, tc.testString, tc.containsFeature))
 	}
 }
+
+func TestCompareVersion(t *testing.T) {
+	// Note: These values pertain to 'kubeVersion' fields found:
+	// https://charts.openshift.io/index.yaml
+	testCases := []struct {
+		ver1           string
+		ver2           string
+		expectedOutput bool
+	}{
+		{
+			ver1:           "1.18.1",
+			ver2:           ">= 1.19",
+			expectedOutput: false,
+		},
+		{
+			ver1:           "1.19.1",
+			ver2:           ">= 1.19",
+			expectedOutput: true,
+		},
+		{
+			ver1:           "1.19",
+			ver2:           ">= 1.16.0 < 1.22.0",
+			expectedOutput: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedOutput, CompareVersion(tc.ver1, tc.ver2))
+	}
+}


### PR DESCRIPTION
The functions `CompareVersion` and `IsReleaseCertified` were duplicated in the code so I created the `releasehelper` package to hold the `IsReleaseCertified` func.  `CompareVersion` now lives in the `stringhelper` package since it was just comparing some strings but I could be persuaded to move it elsewhere.

The struct `ChartStruct` already existed in `internal/api/api.go` so I just left it there as well.