### PR TITLE
Fix for observability-container-logging TC.

### DIFF
--- a/cnf-certification-test/observability/suite.go
+++ b/cnf-certification-test/observability/suite.go
@@ -68,7 +68,10 @@ var _ = ginkgo.Describe(common.ObservabilityTestKey, func() {
 func containerHasLoggingOutput(cut *provider.Container) (bool, error) {
 	ocpClient := clientsholder.GetClientsHolder()
 
-	numLogLines := int64(1)
+	// K8s' API won't return lines that don't have the newline termination char, so
+	// We need to ask for the last two lines.
+	const tailLogLines = 2
+	numLogLines := int64(tailLogLines)
 	podLogOptions := corev1.PodLogOptions{TailLines: &numLogLines, Container: cut.Data.Name}
 	req := ocpClient.K8sClient.CoreV1().Pods(cut.Namespace).GetLogs(cut.Podname, &podLogOptions)
 


### PR DESCRIPTION
When getting the log buffer from k8s containers, both the 'oc' client
and the go-client won't return the last line in case it doesn't have the
new line char at the end, so this TC will fail in rare cases when the
container has printed newline-ended lines before but the last one
doesn't have the newline char yet.

This fix just reads the last 2 log lines, so in case there's previous
valid lines, this TC will pass.