### PR TITLE
Manual certified db update.

### DIFF
--- a/cmd/tnf/fetch/data/archive.json
+++ b/cmd/tnf/fetch/data/archive.json
@@ -1,1 +1,1 @@
-{"containers":22110,"operators":3972,"charts":0}
+{"containers":22119,"operators":3972,"charts":0}

--- a/internal/registry/container_test.go
+++ b/internal/registry/container_test.go
@@ -32,8 +32,8 @@ func TestIsCertified(t *testing.T) {
 	}
 	loadContainersCatalog(path + "/../")
 	ans := IsCertified("registry.connect.redhat.com", "bitnami/nodejs", "11.14.0-rhel-7-r5-5", "")
-	assert.Equal(t, ans, true)
+	assert.Equal(t, true, ans)
 
 	ans = IsCertified("registry.connect.redhat.com", "nearform/nearform-s2i-nodejs10", "10.1.0", "")
-	assert.Equal(t, ans, true)
+	assert.Equal(t, true, ans)
 }


### PR DESCRIPTION
Either the previous offline catalog version was broken or, for some
days, one of the containers for unit test was removed as certified from
the online catalog...

time="2022-05-23T13:15:46Z" level=error msg="container is not certified registry.connect.redhat.comnearform/nearform-s2i-nodejs1010.1.0"

+ Modified arguments order of the assert.Equal() in container_test.go to
  match the signature (t, expected, actual).