### PR TITLE
Fix for platform-alteration-base-image test case.

### DIFF
--- a/cnf-certification-test/platform/cnffsdiff/fsdiff_test.go
+++ b/cnf-certification-test/platform/cnffsdiff/fsdiff_test.go
@@ -36,6 +36,8 @@ func (o ClientHoldersMock) ExecCommandContainer(ctx clientsholder.Context, comma
 	stdout, stderr, err = o.stdout, o.stderr, o.err
 	return stdout, stderr, err
 }
+
+//nolint:funlen
 func TestRunTest(t *testing.T) {
 	testCases := []struct {
 		clientErr      error
@@ -57,18 +59,34 @@ func TestRunTest(t *testing.T) {
 			clientErr:      nil,
 			clientStdErr:   "container id not found",
 		},
-		{ // test when a package was installed
+		{ // test when folder /usr/lib has been removed
 			expectedResult: testhelper.FAILURE,
 			clientErr:      nil,
 			clientStdErr:   "",
 			clientStdOut: `{
-				changed: [
-					/usr/bin/lp,
-					/usr/local,
-					/usr/local/bin
+				"changed": [
+					"/usr"
 				],
-				added: [
-					/usr/local/bin/docker-entrypoint.sh
+				"deleted": [
+					"/usr/lib"
+				]
+			}`,
+		},
+		{ // test when a package "lp" was installed in /usr/bin and a file docker-entrypoint.sh
+			// is created under /usr/local/bin
+			expectedResult: testhelper.FAILURE,
+			clientErr:      nil,
+			clientStdErr:   "",
+			clientStdOut: `{
+				"changed": [
+					"/usr",
+					"/usr/bin",
+					"/usr/local",
+					"/usr/local/bin"
+				],
+				"added": [
+					"/usr/bin/lp",
+					"/usr/local/bin/docker-entrypoint.sh"
 				]
 			}`,
 		},


### PR DESCRIPTION
The current podman diff --json output won't match the expected regex, as
the output won't come as in the original UT, which added indentation
before the folder and it was expected by the regex.

The actual output currently comes as a single line, like this:
{"changed":["/root","/usr","/usr/lib"],"added":["/root/.bash_history","/usr/lib/blablah"]}

I've changed the implementation to unmarshall the output in order to be more
clear and verbose in the log/claim file when the test case fails.

Also, added lib64 folders to be tested.