### PR TITLE
Optimize around strings.Builder

### DIFF
--- a/cnf-certification-test/networking/netcommons/netcommons.go
+++ b/cnf-certification-test/networking/netcommons/netcommons.go
@@ -19,6 +19,7 @@ package netcommons
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
 	corev1 "k8s.io/api/core/v1"
@@ -56,14 +57,15 @@ type ContainerIP struct {
 
 // String displays the NetTestContext data structure
 func (testContext NetTestContext) String() string {
-	output := fmt.Sprintf("From initiating container: %s\n", testContext.TesterSource.String())
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("From initiating container: %s\n", testContext.TesterSource.String()))
 	if len(testContext.DestTargets) == 0 {
-		output = "--> No target containers to test for this network" //nolint:goconst // this is only one time
+		sb.WriteString("--> No target containers to test for this network")
 	}
 	for _, target := range testContext.DestTargets {
-		output += fmt.Sprintf("--> To target container: %s\n", target.String())
+		sb.WriteString(fmt.Sprintf("--> To target container: %s\n", target.String()))
 	}
-	return output
+	return sb.String()
 }
 
 // String Displays the ContainerIP data structure
@@ -76,15 +78,15 @@ func (cip *ContainerIP) String() string {
 
 // PrintNetTestContextMap displays the NetTestContext full map
 func PrintNetTestContextMap(netsUnderTest map[string]NetTestContext) string {
-	var output string
+	var sb strings.Builder
 	if len(netsUnderTest) == 0 {
-		output = "No networks to test.\n" //nolint:goconst // this is only one time
+		sb.WriteString("No networks to test.\n")
 	}
 	for netName, netUnderTest := range netsUnderTest {
-		output += fmt.Sprintf("***Test for Network attachment: %s\n", netName)
-		output += fmt.Sprintf("%s\n", netUnderTest.String())
+		sb.WriteString(fmt.Sprintf("***Test for Network attachment: %s\n", netName))
+		sb.WriteString(fmt.Sprintf("%s\n", netUnderTest.String()))
 	}
-	return output
+	return sb.String()
 }
 
 // PodIPsToStringList converts a list of corev1.PodIP objects into a list of strings

--- a/cnf-certification-test/platform/hugepages/hugepages.go
+++ b/cnf-certification-test/platform/hugepages/hugepages.go
@@ -44,15 +44,15 @@ func (numaHugepages numaHugePagesPerSize) String() string {
 	}
 	sort.Ints(numaIndexes)
 
-	str := ""
+	var sb strings.Builder
 	for _, numaIdx := range numaIndexes {
 		hugepagesPerSize := numaHugepages[numaIdx]
-		str += fmt.Sprintf("Numa=%d ", numaIdx)
+		sb.WriteString(fmt.Sprintf("Numa=%d ", numaIdx))
 		for _, hugepages := range hugepagesPerSize {
-			str += fmt.Sprintf("[Size=%dkB Count=%d] ", hugepages.hugepagesSize, hugepages.hugepagesCount)
+			sb.WriteString(fmt.Sprintf("[Size=%dkB Count=%d] ", hugepages.hugepagesSize, hugepages.hugepagesCount))
 		}
 	}
-	return str
+	return sb.String()
 }
 
 type Tester struct {
@@ -273,11 +273,12 @@ func getMcSystemdUnitsHugepagesConfig(mc *provider.MachineConfig) (hugepages num
 }
 
 func logMcKernelArgumentsHugepages(hugepagesPerSize map[int]int, defhugepagesz int) {
-	logStr := fmt.Sprintf("MC KernelArguments hugepages config: default_hugepagesz=%d-kB", defhugepagesz)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("MC KernelArguments hugepages config: default_hugepagesz=%d-kB", defhugepagesz))
 	for size, count := range hugepagesPerSize {
-		logStr += fmt.Sprintf(", size=%dkB - count=%d", size, count)
+		sb.WriteString(fmt.Sprintf(", size=%dkB - count=%d", size, count))
 	}
-	logrus.Info(logStr)
+	logrus.Info(sb.String())
 }
 
 // getMcHugepagesFromMcKernelArguments gets the hugepages params from machineconfig's kernelArguments

--- a/cnf-certification-test/platform/nodetainted/nodetainted.go
+++ b/cnf-certification-test/platform/nodetainted/nodetainted.go
@@ -122,17 +122,17 @@ func GetTaintedBitValues() []string {
 //nolint:gocritic
 func DecodeKernelTaints(bitmap uint64) (string, []string) {
 	values := GetTaintedBitValues()
-	var out string
+	var sb strings.Builder
 	individualTaints := []string{}
 	for i := 0; i < 32; i++ {
 		bit := (bitmap >> i) & 1
 		if bit == 1 {
-			out += fmt.Sprintf("%s, ", values[i])
+			sb.WriteString(fmt.Sprintf("%s, ", values[i]))
 			// Storing the individual taint messages for extra parsing.
 			individualTaints = append(individualTaints, values[i])
 		}
 	}
-	return out, individualTaints
+	return sb.String(), individualTaints
 }
 
 func (nt *NodeTainted) GetOutOfTreeModules(modules []string, ctx clientsholder.Context) []string {


### PR DESCRIPTION
`strings.Builder` is a more efficient way of building strings.

More information about efficiency: 
https://medium.com/@ramseyjiang_22278/join-string-using-strings-builder-6-simple-ways-to-optimise-golang-4-59f3fdf630f

Examples: https://zetcode.com/golang/builder/