### PR TITLE
Upgrade YAML package to v3

### DIFF
--- a/cmd/tnf/fetch/fetch.go
+++ b/cmd/tnf/fetch/fetch.go
@@ -11,7 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/test-network-function/cnf-certification-test/internal/registry"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/stretchr/testify v1.7.1
 	github.com/test-network-function/test-network-function-claim v1.0.5
 	github.com/xeipuuv/gojsonschema v1.2.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
 require k8s.io/client-go v0.24.1
@@ -143,7 +143,6 @@ require (
 	google.golang.org/grpc v1.43.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiserver v0.24.0 // indirect
 	k8s.io/cli-runtime v0.24.0 // indirect
 	k8s.io/component-base v0.24.0 // indirect
@@ -160,7 +159,6 @@ require (
 )
 
 require (
-	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/hashicorp/go-version v1.5.0
 	k8s.io/apiextensions-apiserver v0.24.0
 )
@@ -168,6 +166,7 @@ require (
 require (
 	github.com/openshift/api v0.0.0-20220124143425-d74727069f6f
 	github.com/openshift/machine-config-operator v0.0.0-00010101000000-000000000000
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 
 replace github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20200913004441-7eba765c69c9

--- a/go.sum
+++ b/go.sum
@@ -401,8 +401,6 @@ github.com/go-toolsmith/pkgload v0.0.0-20181119091011-e9e65178eee8/go.mod h1:WoM
 github.com/go-toolsmith/pkgload v1.0.0/go.mod h1:5eFArkbO80v7Z0kdngIxsRXRMTaX4Ilcwuh3clNrQJc=
 github.com/go-toolsmith/strparse v1.0.0/go.mod h1:YI2nUKP9YGZnL/L1/DLFBfixrcjslWct4wyljWhSRy8=
 github.com/go-toolsmith/typep v1.0.0/go.mod h1:JSQCQMUPdRlMZFswiq3TGpNp1GMktqkR2Ns5AIQkATU=
-github.com/go-yaml/yaml v2.1.0+incompatible h1:RYi2hDdss1u4YE7GwixGzWwVo47T8UQwnTLB6vQiq+o=
-github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
 github.com/gobuffalo/logger v1.0.6 h1:nnZNpxYo0zx+Aj9RfMPBm+x9zAU2OayFh/xrAWi34HU=
 github.com/gobuffalo/logger v1.0.6/go.mod h1:J31TBEHR1QLV2683OXTAItYIg8pv2JMHnF/quuAbMjs=
 github.com/gobuffalo/packd v1.0.1 h1:U2wXfRr4E9DH8IdsDLlRFwTZTK7hLfq9qT/QHXGVe/0=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -7,9 +7,9 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/go-yaml/yaml"
 	log "github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
+	"gopkg.in/yaml.v3"
 )
 
 // Endpoints document can be found here

--- a/internal/registry/helm.go
+++ b/internal/registry/helm.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"helm.sh/helm/v3/pkg/release"
 )
 

--- a/pkg/configuration/utils.go
+++ b/pkg/configuration/utils.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var (


### PR DESCRIPTION
Upstream repo: https://github.com/go-yaml/yaml

Switches all references to the upstream YAML package we use from `"gopkg.in/yaml.v2"` to `"gopkg.in/yaml.v3"`.  Then I ran `go mod tidy` to finish it up.

Also see: https://github.com/test-network-function/cnf-certification-test/security/dependabot/7