### PR TITLE
Avoid nil panic when debug pod missing

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -412,7 +412,6 @@ func TestOneProcessPerContainer(env *provider.TestEnvironment) {
 		debugPod := env.DebugPods[cut.NodeName]
 		if debugPod == nil {
 			ginkgo.Fail(fmt.Sprintf("Debug pod not found on Node: %s", cut.NodeName))
-			continue
 		}
 
 		ocpContext := clientsholder.Context{

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -123,6 +123,10 @@ func testContainersFsDiff(env *provider.TestEnvironment) {
 	for _, cut := range env.Containers {
 		logrus.Debug(fmt.Sprintf("%s(%s) should not install new packages after starting", cut.Podname, cut.Data.Name))
 		debugPod := env.DebugPods[cut.NodeName]
+		if debugPod == nil {
+			ginkgo.Fail(fmt.Sprintf("Debug pod not found on Node: %s", cut.NodeName))
+		}
+
 		fsDiffTester := cnffsdiff.NewFsDiffTester(clientsholder.GetClientsHolder())
 		fsDiffTester.RunTest(clientsholder.Context{
 			Namespace:     debugPod.Namespace,


### PR DESCRIPTION
We perform the same nil check in the following spots:
- https://github.com/test-network-function/cnf-certification-test/blob/main/cnf-certification-test/accesscontrol/suite.go#L412-L416
- https://github.com/test-network-function/cnf-certification-test/blob/main/cnf-certification-test/platform/bootparams/bootparams.go#L36-L40

I think the underlying issue we were seeing in a [recent failure](https://www.distributed-ci.io/jobs/9048dacf-b2cc-440d-b0af-5a10170434bd/files) was that the debug pods either weren't spawned correctly or unresponsive but this nil check should have been in place to catch it in the first place.