### PR TITLE
Fixed WaitDebugPodsReady to not return if DesiredNumberSchedued is not valid.

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -326,12 +326,11 @@ func WaitDebugPodsReady() error {
 			return fmt.Errorf("failed to get daemonset, err: %s", err)
 		}
 
-		if daemonSet.Status.DesiredNumberScheduled != nodesCount {
-			return fmt.Errorf("daemonset DesiredNumberScheduled not equal to number of nodes:%d, please instantiate debug pods on all nodes", nodesCount)
-		}
-
 		logrus.Infof("Waiting for (%d) debug pods to be ready: %+v", nodesCount, daemonSet.Status)
-		if isDaemonSetReady(&daemonSet.Status) {
+
+		if daemonSet.Status.DesiredNumberScheduled != nodesCount {
+			logrus.Warnf("daemonset DesiredNumberScheduled not equal to number of nodes:%d, please instantiate debug pods on all nodes", nodesCount)
+		} else if isDaemonSetReady(&daemonSet.Status) {
 			isReady = true
 			break
 		}


### PR DESCRIPTION
This is a tentative fix for a possible race condition when TNF v4.0.0
container runs right after a TNF v3.3.3 has finished. As the daemonset will
be updated, it can take a while for the daemonset to update the
DesiredNumberScheduled, making the WaitDebugPodsReady to fail
immediately. The result is the debug pods not being created and all TCs
who depend on them will fail.

This change just makes the loop to continue normally, giving
time for the daemonset to update that field.