### PR TITLE
Add compatibility matrix for testing OCP versions

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -580,6 +580,18 @@ Description|http://test-network-function.com/testcases/platform-alteration/isred
 Result Type|normative
 Suggested Remediation|build a new docker image that's based on UBI (redhat universal base image).
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
+#### ocp-lifecycle
+
+Property|Description
+---|---
+Test Case Name|ocp-lifecycle
+Test Case Label|platform-alteration-ocp-lifecycle
+Unique ID|http://test-network-function.com/testcases/platform-alteration/ocp-lifecycle
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/platform-alteration/ocp-lifecycle Tests that the running OCP version is not end of life.
+Result Type|normative
+Suggested Remediation|Please update your cluster to a version that is generally available.
+Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section x.x
 #### service-mesh
 
 Property|Description

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -275,6 +275,11 @@ var (
 		Url:     formTestURL(common.PlatformAlterationTestKey, "service-mesh"),
 		Version: versionOne,
 	}
+	// TestOCPLifecycleIdentifier ensures the OCP version of the cluster is within the valid lifecycle status
+	TestOCPLifecycleIdentifier = claim.Identifier{
+		Url:     formTestURL(common.PlatformAlterationTestKey, "ocp-lifecycle"),
+		Version: versionOne,
+	}
 	// TestScalingIdentifier ensures deployment scale in/out operations work correctly.
 	TestScalingIdentifier = claim.Identifier{
 		Url:     formTestURL(common.LifecycleTestKey, "scaling"),
@@ -352,6 +357,14 @@ func GetSuiteAndTestFromIdentifier(identifier claim.Identifier) []string {
 
 // Catalog is the JUnit testcase catalog of tests.
 var Catalog = map[claim.Identifier]TestCaseDescription{
+
+	TestOCPLifecycleIdentifier: {
+		Identifier:            TestOCPLifecycleIdentifier,
+		Type:                  normativeResult,
+		Description:           formDescription(TestOCPLifecycleIdentifier, `Tests that the running OCP version is not end of life.`),
+		Remediation:           `Please update your cluster to a version that is generally available.`,
+		BestPracticeReference: bestPracticeDocV1dot3URL + " Section x.x", // TODO: Update this with correct section of requirements doc.
+	},
 
 	TestDeploymentScalingIdentifier: {
 		Identifier: TestDeploymentScalingIdentifier,

--- a/pkg/compatibility/compatibility.go
+++ b/pkg/compatibility/compatibility.go
@@ -1,0 +1,152 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package compatibility
+
+import (
+	"strings"
+	"time"
+)
+
+/* Notes for this package
+* Refer to this document for more information about OCP compatibility: https://access.redhat.com/support/policy/updates/openshift
+
+* This module will help compare the running OCP version against a matrix of end of life dates.
+ */
+
+const (
+	// OCP Lifecycle Statuses
+	OCPStatusGA      = "generally-available"
+	OCPStatusMS      = "maintenance-support"
+	OCPStatusEOL     = "end-of-life"
+	OCPStatusUnknown = "unknown"
+	OCPStatusPreGA   = "pre-general-availability"
+)
+
+type VersionInfo struct {
+	GADate  time.Time // General Availability Date
+	FSEDate time.Time // Full Support Ends Date
+	MSEDate time.Time // Maintenance Support Ends Date
+}
+
+var (
+	ocpLifeCycleDates = map[string]VersionInfo{
+		// TODO: Adjust all of these periodically to make sure they are up to date with the lifecycle
+		// update documentation.
+
+		// Full Support
+		"4.10": {
+			GADate:  time.Date(2022, 3, 10, 0, 0, 0, 0, time.UTC), // March 10, 2022
+			FSEDate: time.Date(2022, 9, 10, 0, 0, 0, 0, time.UTC), // September 10, 2022
+			MSEDate: time.Date(2023, 9, 10, 0, 0, 0, 0, time.UTC), // September 10, 2023
+			// Note: FSEDate (Release of 4.11 + 3 months) is currently a "guess".  Update when available.
+		},
+		"4.9": {
+			GADate:  time.Date(2021, 10, 18, 0, 0, 0, 0, time.UTC), // October 18, 2021
+			FSEDate: time.Date(2022, 6, 8, 0, 0, 0, 0, time.UTC),   // June 8, 2022
+			MSEDate: time.Date(2023, 4, 18, 0, 0, 0, 0, time.UTC),  // April 18, 2023
+			// Note: FSEDate (Release of 4.10 + 3 months) is currently a "guess".  Update when available.
+		},
+
+		// Maintenance Support
+		"4.8": {
+			GADate:  time.Date(2021, 7, 27, 0, 0, 0, 0, time.UTC), // July 27, 2021
+			FSEDate: time.Date(2022, 1, 27, 0, 0, 0, 0, time.UTC), // January 27, 2022
+			MSEDate: time.Date(2023, 1, 27, 0, 0, 0, 0, time.UTC), // January 27, 2023
+		},
+		"4.7": {
+			GADate:  time.Date(2021, 2, 24, 0, 0, 0, 0, time.UTC),  // February 24, 2021
+			FSEDate: time.Date(2021, 10, 27, 0, 0, 0, 0, time.UTC), // October 27, 2021
+			MSEDate: time.Date(2022, 8, 24, 0, 0, 0, 0, time.UTC),  // August 24, 2022
+		},
+
+		// End of life
+		"4.6": {
+			GADate:  time.Date(2020, 10, 27, 0, 0, 0, 0, time.UTC), // October 27, 2020
+			FSEDate: time.Date(2021, 3, 24, 0, 0, 0, 0, time.UTC),  // March 24, 2021
+			MSEDate: time.Date(2021, 10, 18, 0, 0, 0, 0, time.UTC), // October 18, 2022
+		},
+		"4.5": {
+			GADate:  time.Date(2020, 7, 13, 0, 0, 0, 0, time.UTC),  // July 13, 2020
+			FSEDate: time.Date(2020, 11, 27, 0, 0, 0, 0, time.UTC), // November 27, 2020
+			MSEDate: time.Date(2021, 7, 27, 0, 0, 0, 0, time.UTC),  // July 27, 2021
+		},
+		"4.4": {
+			GADate:  time.Date(2020, 5, 5, 0, 0, 0, 0, time.UTC),  // May 5, 2020
+			FSEDate: time.Date(2020, 8, 13, 0, 0, 0, 0, time.UTC), // August 13, 2020
+			MSEDate: time.Date(2021, 2, 24, 0, 0, 0, 0, time.UTC), // February 24, 2021
+		},
+		"4.3": {
+			GADate:  time.Date(2020, 1, 23, 0, 0, 0, 0, time.UTC),  // January 23, 2020
+			FSEDate: time.Date(2020, 6, 5, 0, 0, 0, 0, time.UTC),   // June 5, 2020
+			MSEDate: time.Date(2020, 10, 27, 0, 0, 0, 0, time.UTC), // October 27, 2020
+		},
+		"4.2": {
+			GADate:  time.Date(2019, 10, 16, 0, 0, 0, 0, time.UTC), // October 16, 2019
+			FSEDate: time.Date(2020, 2, 23, 0, 0, 0, 0, time.UTC),  // February 23, 2020
+			MSEDate: time.Date(2020, 7, 13, 0, 0, 0, 0, time.UTC),  // July 13, 2020
+		},
+		"4.1": {
+			GADate:  time.Date(2019, 6, 4, 0, 0, 0, 0, time.UTC),   // June 4, 2019
+			FSEDate: time.Date(2019, 11, 16, 0, 0, 0, 0, time.UTC), // November 16, 2019
+			MSEDate: time.Date(2020, 5, 5, 0, 0, 0, 0, time.UTC),   // May 5, 2020
+		},
+	}
+)
+
+func GetLifeCycleDates() map[string]VersionInfo {
+	return ocpLifeCycleDates
+}
+
+func DetermineOCPStatus(version string, date time.Time) string {
+	// Safeguard against empty values being passed in
+	if version == "" || date.IsZero() {
+		return OCPStatusUnknown
+	}
+
+	// Split the incoming version on the "." and make sure we are only looking at major.minor.
+	splitVersion := strings.Split(version, ".")
+	version = splitVersion[0] + "." + splitVersion[1]
+
+	// Check if the version exists in our local map
+	lifecycleDates := GetLifeCycleDates()
+	if entry, ok := lifecycleDates[version]; ok {
+		// Safeguard against the latest versions not having a date set for FSEDate set.
+		// See the OpenShift lifecycle website link (above) for more details on this.
+		if entry.FSEDate.IsZero() {
+			entry.FSEDate = entry.MSEDate
+		}
+
+		// Pre-GA
+		if date.Before(entry.GADate) {
+			return OCPStatusPreGA
+		}
+		// Generally Available
+		if date.Equal(entry.GADate) || date.After(entry.GADate) && date.Before(entry.FSEDate) {
+			return OCPStatusGA
+		}
+		// Maintenance Support
+		if date.Equal(entry.FSEDate) || (date.After(entry.FSEDate) && date.Before(entry.MSEDate)) {
+			return OCPStatusMS
+		}
+		// End of Life
+		if date.Equal(entry.MSEDate) || date.After(entry.MSEDate) {
+			return OCPStatusEOL
+		}
+	}
+
+	return OCPStatusUnknown
+}

--- a/pkg/compatibility/compatibility_test.go
+++ b/pkg/compatibility/compatibility_test.go
@@ -1,0 +1,92 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package compatibility
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//nolint:funlen
+func TestDetermineOCPStatus(t *testing.T) {
+	testCases := []struct {
+		testDate       time.Time
+		testVersion    string
+		expectedOutput string
+	}{
+		{ // Test Case #1 - End of life
+			testDate:       time.Date(2022, 11, 1, 0, 0, 0, 0, time.UTC),
+			testVersion:    "4.6",
+			expectedOutput: OCPStatusEOL, // 4.6 expires on 10/18/2021
+		},
+		{ // Test Case #2 - Maintenance Mode
+			testDate:       time.Date(2021, 10, 17, 0, 0, 0, 0, time.UTC),
+			testVersion:    "4.6",
+			expectedOutput: OCPStatusMS, // 4.6 expires on 10/18/2021
+		},
+		{ // Test Case #3 - Invalid Version
+			testVersion:    "1.3",
+			expectedOutput: OCPStatusUnknown, // Version 1.3 is not valid, so nothing to check
+		},
+		{ // Test Case #4 - Maintenance on day of
+			testDate:       time.Date(2022, 1, 27, 0, 0, 0, 0, time.UTC),
+			testVersion:    "4.8",
+			expectedOutput: OCPStatusMS, // 4.8 enters maintenance on 1/27/2022
+		},
+		{ // Test Case #5 - Maintenance in window
+			testDate:       time.Date(2022, 1, 28, 0, 0, 0, 0, time.UTC),
+			testVersion:    "4.8",
+			expectedOutput: OCPStatusMS, // 4.8 enters maintenance on 1/27/2022
+		},
+		{ // Test Case #6 - GA on day of
+			testDate:       time.Date(2021, 7, 27, 0, 0, 0, 0, time.UTC),
+			testVersion:    "4.8",
+			expectedOutput: OCPStatusGA, // 4.8 enters GA on 1/27/2021
+		},
+		{ // Test Case #7 - Post GA, not yet in maintenance
+			testDate:       time.Date(2022, 1, 26, 0, 0, 0, 0, time.UTC),
+			testVersion:    "4.8",
+			expectedOutput: OCPStatusGA, // 4.8 enters GA on 1/27/2022
+		},
+		{ // Test Case #8 - Not in maintenance window (yet)
+			testDate:       time.Date(2022, 1, 26, 0, 0, 0, 0, time.UTC),
+			testVersion:    "4.8",
+			expectedOutput: OCPStatusGA, // 4.8 enters maintenance on 1/27/2022
+		},
+		{ // Test Case #9 - Not yet in GA
+			testDate:       time.Date(2021, 1, 26, 0, 0, 0, 0, time.UTC),
+			testVersion:    "4.8",
+			expectedOutput: OCPStatusPreGA, // 4.8 enters maintenance on 1/27/2022
+		},
+		{ // Test Case #10 - Extended version number x.y.z
+			testDate:       time.Date(2021, 1, 26, 0, 0, 0, 0, time.UTC),
+			testVersion:    "4.8.2",
+			expectedOutput: OCPStatusPreGA, // 4.8 enters maintenance on 1/27/2022
+		},
+		{ // Test Case #11 - 4.10 does not have a Maintenance date yet
+			testDate:       time.Date(2022, 6, 7, 0, 0, 0, 0, time.UTC),
+			testVersion:    "4.10.12",
+			expectedOutput: OCPStatusGA, // 4.8 enters maintenance on 1/27/2022
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedOutput, DetermineOCPStatus(tc.testVersion, tc.testDate))
+	}
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -108,6 +108,7 @@ type TestEnvironment struct { // rename this with testTarget
 	Nodes             map[string]Node                               `json:"-"`
 	K8sVersion        string                                        `json:"-"`
 	OpenshiftVersion  string                                        `json:"-"`
+	OCPStatus         string                                        `json:"-"`
 	HelmChartReleases []*release.Release                            `json:"testHelmChartReleases"`
 	IstioServiceMesh  bool
 }
@@ -236,6 +237,7 @@ func buildTestEnvironment() { //nolint:funlen
 	}
 
 	env.OpenshiftVersion = data.OpenshiftVersion
+	env.OCPStatus = data.OCPStatus
 	env.K8sVersion = data.K8sVersion
 	for _, nsHelmChartReleases := range data.HelmChartReleases {
 		for _, helmChartRelease := range nsHelmChartReleases {


### PR DESCRIPTION
Adds what is essentially a hardcoded set of dates tied to specific OCP version based on the table found [here](https://access.redhat.com/support/policy/updates/openshift).

We already pulled in the OCP version from the cluster version operator so it was just a matter of comparing that version to the table and logging the results.

As far as I could find, there wasn't an API that served this information out so I figured the next best way would be to keep some sort of local table since this date-based information doesn't seem to change very often anyways.

The second part of the issue 205 is that we wanted to compare the RHEL worker version to the OCP version to see if any workers were incompatible but I haven't been able to find a table comparing those numbers.