### PR TITLE
Remove gomega; add more context to failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,6 @@ build-cnf-tests-debug:
 # Install build tools and other required software.
 install-tools:
 	go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.4
-	go install github.com/onsi/gomega
 
 # Install golangci-lint	
 install-lint:

--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -411,6 +411,7 @@ func TestAutomountServiceToken(env *provider.TestEnvironment) {
 	for _, put := range env.Pods {
 		ginkgo.By(fmt.Sprintf("check the existence of pod service account %s (ns= %s )", put.Data.Namespace, put.Data.Name))
 		if put.Data.Spec.ServiceAccountName == "" {
+			tnf.ClaimFilePrintf("Pod %s has been found with an empty service account name.", put.Data.Name)
 			ginkgo.Fail("Pod has been found with an empty service account name.")
 		}
 

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/common"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/identifiers"
@@ -126,9 +125,9 @@ func testContainersPreStop(env *provider.TestEnvironment) {
 		}
 	}
 	if len(badcontainers) > 0 {
-		tnf.ClaimFilePrintf("bad containers %v", badcontainers)
+		tnf.ClaimFilePrintf("Containers have been found missing lifecycle preStop definitions: %v", badcontainers)
+		ginkgo.Fail("Containers have been found missing lifecycle preStop definitions.")
 	}
-	gomega.Expect(0).To(gomega.Equal(len(badcontainers)))
 }
 
 func testContainersImagePolicy(env *provider.TestEnvironment) {
@@ -142,9 +141,9 @@ func testContainersImagePolicy(env *provider.TestEnvironment) {
 		}
 	}
 	if len(badcontainers) > 0 {
-		tnf.ClaimFilePrintf("bad containers %v", badcontainers)
+		tnf.ClaimFilePrintf("Containers have been found with IfNotPresent missing from image pull policy: %v", badcontainers)
+		ginkgo.Fail("Containers have been found with IfNotPresent missing from image pull policy.")
 	}
-	gomega.Expect(0).To(gomega.Equal(len(badcontainers)))
 }
 
 func testContainersReadinessProbe(env *provider.TestEnvironment) {
@@ -157,9 +156,9 @@ func testContainersReadinessProbe(env *provider.TestEnvironment) {
 		}
 	}
 	if len(badcontainers) > 0 {
-		tnf.ClaimFilePrintf("bad containers %v", badcontainers)
+		tnf.ClaimFilePrintf("Containers have been found without readiness probes defined: %v", badcontainers)
+		ginkgo.Fail("Containers have been found without readiness probes defined.")
 	}
-	gomega.Expect(0).To(gomega.Equal(len(badcontainers)))
 }
 
 func testContainersLivenessProbe(env *provider.TestEnvironment) {
@@ -172,9 +171,9 @@ func testContainersLivenessProbe(env *provider.TestEnvironment) {
 		}
 	}
 	if len(badcontainers) > 0 {
-		tnf.ClaimFilePrintf("bad containers %v", badcontainers)
+		tnf.ClaimFilePrintf("Containers have been found without livenessProbe defined: %v", badcontainers)
+		ginkgo.Fail("Containers have been found without livenessProbe defined.")
 	}
-	gomega.Expect(0).To(gomega.Equal(len(badcontainers)))
 }
 
 func testPodsOwnerReference(env *provider.TestEnvironment) {
@@ -189,9 +188,9 @@ func testPodsOwnerReference(env *provider.TestEnvironment) {
 		}
 	}
 	if len(badPods) > 0 {
-		tnf.ClaimFilePrintf("bad containers %v", badPods)
+		tnf.ClaimFilePrintf("Containers were found with incorrect owner reference: %v", badPods)
+		ginkgo.Fail("Containers were found with incorrect owner reference.")
 	}
-	gomega.Expect(0).To(gomega.Equal(len(badPods)))
 }
 
 func testPodNodeSelectorAndAffinityBestPractices(env *provider.TestEnvironment) {
@@ -240,9 +239,9 @@ func testDeploymentScaling(env *provider.TestEnvironment, timeout time.Duration)
 	}
 
 	if len(failedDeployments) > 0 {
-		tnf.ClaimFilePrintf("failed deployments: %v", failedDeployments)
+		tnf.ClaimFilePrintf("Deployments were found to have failed the scaling test: %v", failedDeployments)
+		ginkgo.Fail("Deployments were found to have failed the scaling test.")
 	}
-	gomega.Expect(0).To(gomega.Equal(len(failedDeployments)))
 }
 
 //nolint:dupl
@@ -273,9 +272,9 @@ func testStatefulSetScaling(env *provider.TestEnvironment, timeout time.Duration
 	}
 
 	if len(failedStatetfulSets) > 0 {
-		tnf.ClaimFilePrintf(" failed statefulsets: %v", failedStatetfulSets)
+		tnf.ClaimFilePrintf("Statefulsets were found to have failed the scaling test: %v", failedStatetfulSets)
+		ginkgo.Fail("Statefulsets were found to have failed the scaling test.")
 	}
-	gomega.Expect(0).To(gomega.Equal(len(failedStatetfulSets)))
 }
 
 // testHighAvailability
@@ -308,13 +307,13 @@ func testHighAvailability(env *provider.TestEnvironment) {
 	if n := len(badDeployments); n > 0 {
 		logrus.Errorf("Deployments without a valid high availability : %+v", badDeployments)
 		tnf.ClaimFilePrintf("Deployments without a valid high availability : %+v", badDeployments)
+		ginkgo.Fail("Deployments were found without a valid high availability.")
 	}
 	if n := len(badStatefulSet); n > 0 {
 		logrus.Errorf("Statefulset without a valid podAntiAffinity rule: %+v", badStatefulSet)
 		tnf.ClaimFilePrintf("Statefulset without a valid podAntiAffinity rule: %+v", badStatefulSet)
+		ginkgo.Fail("Statefulsets were found without a valid high availability.")
 	}
-	gomega.Expect(0).To(gomega.Equal(len(badDeployments)))
-	gomega.Expect(0).To(gomega.Equal(len(badStatefulSet)))
 }
 
 // testPodsRecreation tests that pods belonging to deployments and statefulsets are re-created and ready in case a node is lost

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -38,7 +38,6 @@ import (
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/results"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/platform/nodetainted"
 )
 
@@ -144,10 +143,16 @@ func testContainersFsDiff(env *provider.TestEnvironment) {
 			errContainers = append(errContainers, cut.Data.Name)
 		}
 	}
-	logrus.Println("bad containers ", badContainers)
-	logrus.Println("err containers ", errContainers)
-	gomega.Expect(badContainers).To(gomega.BeNil())
-	gomega.Expect(errContainers).To(gomega.BeNil())
+
+	if len(badContainers) > 0 {
+		tnf.ClaimFilePrintf("Containers were found with changed or deleted folders: %v", badContainers)
+		ginkgo.Fail("Containers were found with changed or deleted folders.")
+	}
+
+	if len(errContainers) > 0 {
+		tnf.ClaimFilePrintf("Containers were unable to run fs-diff: %v", errContainers)
+		ginkgo.Fail("Containers were unable to run fs-diff.")
+	}
 }
 
 //nolint:funlen
@@ -241,8 +246,15 @@ func testTainted(env *provider.TestEnvironment, testerFuncs nodetainted.TaintedF
 	// We are expecting tainted nodes to be Nil, but only if:
 	// 1) The reason for the tainted node is contains(`module was loaded`)
 	// 2) The modules loaded are all whitelisted.
-	gomega.Expect(taintedNodes).To(gomega.BeNil())
-	gomega.Expect(errNodes).To(gomega.BeNil())
+	if len(taintedNodes) > 0 {
+		tnf.ClaimFilePrintf("Nodes have been found to be tainted: %v", taintedNodes)
+		ginkgo.Fail("Nodes have been found to be tainted.")
+	}
+
+	if len(errNodes) > 0 {
+		tnf.ClaimFilePrintf("Nodes have been found to be tainted: %v", taintedNodes)
+		ginkgo.Fail("Nodes have been found to be tainted.")
+	}
 }
 
 func testIsRedHatRelease(env *provider.TestEnvironment) {
@@ -266,7 +278,10 @@ func testIsRedHatRelease(env *provider.TestEnvironment) {
 		}
 	}
 
-	gomega.Expect(failedContainers).To(gomega.BeEmpty())
+	if len(failedContainers) > 0 {
+		tnf.ClaimFilePrintf("Containers have been found without a proper Red Hat version: %v", failedContainers)
+		ginkgo.Fail("Containers have been found without a proper Red Hat version.")
+	}
 }
 
 func testIsSELinuxEnforcing(env *provider.TestEnvironment) {
@@ -340,7 +355,11 @@ func testUnalteredBootParams(env *provider.TestEnvironment) {
 			tnf.ClaimFilePrintf("%s", claimsLog.GetLogLines())
 		}
 	}
-	gomega.Expect(failedNodes).To(gomega.BeEmpty())
+
+	if len(failedNodes) > 0 {
+		tnf.ClaimFilePrintf("Nodes have been found with altered boot params: %v", failedNodes)
+		ginkgo.Fail("Nodes have been found with altered boot params.")
+	}
 }
 
 //nolint:funlen

--- a/cnf-certification-test/suite_test.go
+++ b/cnf-certification-test/suite_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/results"
 	"github.com/test-network-function/cnf-certification-test/pkg/claimhelper"
@@ -139,8 +138,6 @@ func TestTest(t *testing.T) {
 
 	// Diagnostic functions will run also when no focus test suites were provided.
 	diagnosticMode := len(ginkgoConfig.FocusStrings) == 0
-
-	gomega.RegisterFailHandler(ginkgo.Fail)
 
 	// Set clientsholder singleton with the filenames from the env vars.
 	_ = clientsholder.GetClientsHolder(getK8sClientsConfigFileNames()...)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.18
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/basgys/goxml2json v1.1.0
-	github.com/onsi/gomega v1.19.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
 	github.com/stretchr/testify v1.7.2
@@ -67,7 +66,6 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect
-	github.com/go-yaml/yaml v2.1.0+incompatible // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -165,6 +163,7 @@ require (
 )
 
 require (
+	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/openshift/api v0.0.0-20220124143425-d74727069f6f
 	github.com/openshift/machine-config-operator v0.0.0-00010101000000-000000000000
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -790,7 +790,6 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
-github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=


### PR DESCRIPTION
Instead of seeing a failure like:

```
tnf.ClaimFilePrintf("bad containers: %v", badContainers)
gomega.Expect(badContainers).To(gomega.BeNil())
```

I wanted to add more context to the failures instead of just seeing a list of "bad containers" in DCI output.