### PR TITLE
Add nil check in testhelper

### DIFF
--- a/pkg/testhelper/testhelper_test.go
+++ b/pkg/testhelper/testhelper_test.go
@@ -69,29 +69,42 @@ func TestSkipIfEmptyFuncs(t *testing.T) {
 			skippedAny: true,
 			skippedAll: false,
 		},
-		// Note: Cannot test calls to panic
+		{ // Test Case #5 - Nil objects panic
+			slice1:     nil,
+			map1:       nil,
+			skippedAny: true,
+			skippedAll: true,
+		},
 	}
 
 	for _, tc := range testCases {
 		result := false
 
-		SkipIfEmptyAll(func(s string, i ...int) {
-			if strings.Contains(s, "Test skipped") {
-				result = true
-			} else {
-				result = false
-			}
-		}, tc.slice1, tc.map1)
-		assert.Equal(t, tc.skippedAll, result)
+		if tc.slice1 == nil || tc.map1 == nil {
+			assert.Panics(t, func() {
+				SkipIfEmptyAll(func(s string, i ...int) {}, tc.slice1, tc.map1)
+			})
+			assert.Panics(t, func() {
+				SkipIfEmptyAny(func(s string, i ...int) {}, tc.slice1, tc.map1)
+			})
+		} else {
+			SkipIfEmptyAll(func(s string, i ...int) {
+				if strings.Contains(s, "Test skipped") {
+					result = true
+				} else {
+					result = false
+				}
+			}, tc.slice1, tc.map1)
+			assert.Equal(t, tc.skippedAll, result)
 
-		SkipIfEmptyAny(func(s string, i ...int) {
-			if strings.Contains(s, "Test skipped") {
-				result = true
-			} else {
-				result = false
-			}
-		}, tc.slice1, tc.map1)
-
-		assert.Equal(t, tc.skippedAny, result)
+			SkipIfEmptyAny(func(s string, i ...int) {
+				if strings.Contains(s, "Test skipped") {
+					result = true
+				} else {
+					result = false
+				}
+			}, tc.slice1, tc.map1)
+			assert.Equal(t, tc.skippedAny, result)
+		}
 	}
 }


### PR DESCRIPTION
Adding a unit test case in the TestHelper unit tests for nil objects.  No functional change.  Utilizes the `assert.Panics` func.