### PR TITLE
Add safeguard for SNO clusters

### DIFF
--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -39,7 +39,7 @@ const (
 	timeout                    = 60 * time.Second
 	timeoutPodRecreationPerPod = time.Minute
 	timeoutPodSetReady         = 7 * time.Minute
-	minNodesForLifecycle       = 2
+	minWorkerNodesForLifecycle = 2
 )
 
 //
@@ -97,7 +97,7 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestPodRecreationIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
 		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Deployments, env.StatetfulSets)
-		if len(env.Nodes) < minNodesForLifecycle {
+		if env.GetWorkerCount() < minWorkerNodesForLifecycle {
 			ginkgo.Skip("Skipping pod recreation scaling test because invalid number of available workers.")
 		}
 		// Testing pod re-creation for deployments
@@ -108,7 +108,7 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 		testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestDeploymentScalingIdentifier)
 		ginkgo.It(testID, ginkgo.Label(testID), func() {
 			testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Deployments)
-			if len(env.Nodes) < minNodesForLifecycle {
+			if env.GetWorkerCount() < minWorkerNodesForLifecycle {
 				// Note: We skip this test because 'testHighAvailability' in the lifecycle suite is already
 				// testing the replicas and antiaffinity rules that should already be in place for deployments.
 				ginkgo.Skip("Skipping deployment scaling test because invalid number of available workers.")
@@ -118,7 +118,7 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 		testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestStateFulSetScalingIdentifier)
 		ginkgo.It(testID, ginkgo.Label(testID), func() {
 			testhelper.SkipIfEmptyAny(ginkgo.Skip, env.StatetfulSets)
-			if len(env.Nodes) < minNodesForLifecycle {
+			if env.GetWorkerCount() < minWorkerNodesForLifecycle {
 				// Note: We skip this test because 'testHighAvailability' in the lifecycle suite is already
 				// testing the replicas and antiaffinity rules that should already be in place for statefulset.
 				ginkgo.Skip("Skipping statefulset scaling test because invalid number of available workers.")

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -39,6 +39,7 @@ const (
 	timeout                    = 60 * time.Second
 	timeoutPodRecreationPerPod = time.Minute
 	timeoutPodSetReady         = 7 * time.Minute
+	minNodesForLifecycle       = 2
 )
 
 //
@@ -96,6 +97,9 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestPodRecreationIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
 		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Deployments, env.StatetfulSets)
+		if len(env.Nodes) < minNodesForLifecycle {
+			ginkgo.Skip("Skipping pod recreation scaling test because invalid number of available workers.")
+		}
 		// Testing pod re-creation for deployments
 		testPodsRecreation(&env)
 	})
@@ -104,11 +108,21 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 		testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestDeploymentScalingIdentifier)
 		ginkgo.It(testID, ginkgo.Label(testID), func() {
 			testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Deployments)
+			if len(env.Nodes) < minNodesForLifecycle {
+				// Note: We skip this test because 'testHighAvailability' in the lifecycle suite is already
+				// testing the replicas and antiaffinity rules that should already be in place for deployments.
+				ginkgo.Skip("Skipping deployment scaling test because invalid number of available workers.")
+			}
 			testDeploymentScaling(&env, timeout)
 		})
 		testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestStateFulSetScalingIdentifier)
 		ginkgo.It(testID, ginkgo.Label(testID), func() {
 			testhelper.SkipIfEmptyAny(ginkgo.Skip, env.StatetfulSets)
+			if len(env.Nodes) < minNodesForLifecycle {
+				// Note: We skip this test because 'testHighAvailability' in the lifecycle suite is already
+				// testing the replicas and antiaffinity rules that should already be in place for statefulset.
+				ginkgo.Skip("Skipping statefulset scaling test because invalid number of available workers.")
+			}
 			testStatefulSetScaling(&env, timeout)
 		})
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -482,6 +482,26 @@ func (env *TestEnvironment) IsIntrusive() bool {
 	return !env.variables.NonIntrusiveOnly
 }
 
+func (env *TestEnvironment) GetWorkerCount() int {
+	workerCount := 0
+	for _, e := range env.Nodes {
+		if e.IsWorkerNode() {
+			workerCount++
+		}
+	}
+	return workerCount
+}
+
+func (env *TestEnvironment) GetMasterCount() int {
+	masterCount := 0
+	for _, e := range env.Nodes {
+		if e.IsMasterNode() {
+			masterCount++
+		}
+	}
+	return masterCount
+}
+
 // getInstallPlansInNamespace is a helper function to get the installPlans in a namespace. The
 // map installPlans is used to store them in order to avoid repeating http requests for a namespace
 // whose installPlans were already obtained.

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -966,3 +966,48 @@ func TestIsMasterNode(t *testing.T) {
 		assert.Equal(t, tc.expectedResult, node.IsMasterNode())
 	}
 }
+
+func TestGetNodeCount(t *testing.T) {
+	generateEnv := func(isMaster bool) *TestEnvironment {
+		key := "node-role.kubernetes.io/worker"
+		if isMaster {
+			key = "node-role.kubernetes.io/master"
+		}
+
+		return &TestEnvironment{
+			Nodes: map[string]Node{
+				"node1": {
+					Data: &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   "node1",
+							Labels: map[string]string{key: ""},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		testIsMaster bool
+	}{
+		{
+			testIsMaster: true,
+		},
+		{
+			testIsMaster: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tEnv := generateEnv(tc.testIsMaster)
+
+		if tc.testIsMaster {
+			assert.Equal(t, 1, tEnv.GetMasterCount())
+			assert.Equal(t, 0, tEnv.GetWorkerCount())
+		} else {
+			assert.Equal(t, 1, tEnv.GetWorkerCount())
+			assert.Equal(t, 0, tEnv.GetMasterCount())
+		}
+	}
+}


### PR DESCRIPTION
Adding a safeguard against running the pod-recreation test case against a cluster with less than two workers.

Bonus, I also added the same check around the `testDeploymentScaling` and `testStatefulSetScaling` tests because even if we are attempting to scale these up/down, if they are properly using anti-affinity rules they'll never scale correctly anyways.