### PR TITLE
Remove unused diagnostic and common key

### DIFF
--- a/cnf-certification-test/common/constant.go
+++ b/cnf-certification-test/common/constant.go
@@ -20,7 +20,6 @@ package common
 const (
 	defaultTimeoutSeconds     = 10
 	AccessControlTestKey      = "access-control"
-	DiagnosticTestKey         = "diagnostic"
 	LifecycleTestKey          = "lifecycle"
 	ChaosTesting              = "chaostesting"
 	AffiliatedCertTestKey     = "affiliated-certification"
@@ -28,5 +27,4 @@ const (
 	ObservabilityTestKey      = "observability"
 	OperatorTestKey           = "operator"
 	PlatformAlterationTestKey = "platform-alteration"
-	CommonTestKey             = "common"
 )


### PR DESCRIPTION
Related to: https://github.com/test-network-function/test-network-function/pull/591

This must have fell through the cracks when we were copying things over from the old repo.