### PR TITLE
Copy chaostesting files in via Dockerfile

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -173,7 +173,7 @@ jobs:
       # Perform smoke tests.
 
       - name: 'Test: Run test suites'
-        run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./run-cnf-suites.sh --focus access-control lifecycle platform observability networking affiliated-certification operator chaostesting
+        run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./run-cnf-suites.sh --focus access-control lifecycle platform observability networking affiliated-certification operator #TODO: Add chaostesting suite
 
       - name: Upload smoke test results as an artifact
         uses: actions/upload-artifact@v3
@@ -211,7 +211,7 @@ jobs:
         run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./run-tnf-container.sh ${{ env.TESTING_CMD_PARAMS }}
           
       - name: 'Test: Run Smoke Tests in a TNF container'
-        run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./run-tnf-container.sh ${{ env.TESTING_CMD_PARAMS }} -f access-control lifecycle platform observability networking affiliated-certification operator chaostesting
+        run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./run-tnf-container.sh ${{ env.TESTING_CMD_PARAMS }} -f access-control lifecycle platform observability networking affiliated-certification operator #TODO: Add chaostesting suite
 
       - name: Upload container test results as an artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -20,8 +20,6 @@ env:
   TNF_SRC_URL: 'https://github.com/${{ github.repository }}'
   TESTING_CMD_PARAMS: '-n host -i ${REGISTRY_LOCAL}/${IMAGE_NAME}:${IMAGE_TAG} -t ${TNF_CONFIG_DIR} -o ${TNF_OUTPUT_DIR}'
   TNF_SMOKE_TESTS_LOG_LEVEL: trace
-  TNF_PARTNER_DIR: '/usr/tnf-partner'
-  TNF_PARTNER_SRC_DIR: '${TNF_PARTNER_DIR}/src'
   ON_DEMAND_DEBUG_PODS: false
   TERM: xterm-color
 

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -173,7 +173,7 @@ jobs:
       # Perform smoke tests.
 
       - name: 'Test: Run test suites'
-        run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./run-cnf-suites.sh --focus access-control lifecycle platform observability networking affiliated-certification operator
+        run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./run-cnf-suites.sh --focus access-control lifecycle platform observability networking affiliated-certification operator chaostesting
 
       - name: Upload smoke test results as an artifact
         uses: actions/upload-artifact@v3
@@ -211,7 +211,7 @@ jobs:
         run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./run-tnf-container.sh ${{ env.TESTING_CMD_PARAMS }}
           
       - name: 'Test: Run Smoke Tests in a TNF container'
-        run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./run-tnf-container.sh ${{ env.TESTING_CMD_PARAMS }} -f access-control lifecycle platform observability networking affiliated-certification operator
+        run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./run-tnf-container.sh ${{ env.TESTING_CMD_PARAMS }} -f access-control lifecycle platform observability networking affiliated-certification operator chaostesting
 
       - name: Upload container test results as an artifact
         uses: actions/upload-artifact@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,10 @@ RUN mkdir ${TNF_BIN_DIR} && \
     cp --parents `find -name \*.db*` ${TNF_DIR} && \
 	# copy all JSON files to allow tests to run
 	cp --parents `find -name \*.json*` ${TNF_DIR} && \
-	cp cnf-certification-test/cnf-certification-test.test ${TNF_BIN_DIR}
+	cp cnf-certification-test/cnf-certification-test.test ${TNF_BIN_DIR} && \
+    # copy all of the chaos-test-files
+    mkdir -p ${TNF_DIR}/chaostesting/chaos-test-files && \
+    cp /cnf-certification-test/chaostesting/chaos-test-files/ ${TNF_DIR}/chaostesting/chaos-test-files/
 
 WORKDIR ${TNF_DIR}
 
@@ -96,7 +99,6 @@ RUN yum remove -y gcc git wget && \
 FROM scratch
 ARG TNF_PARTNER_DIR=/usr/tnf-partner
 COPY --from=build / /
-COPY /cnf-certification-test/chaostesting/chaos-test-files/ /usr/tnf/chaostesting/chaos-test-files/
 ENV TNF_CONFIGURATION_PATH=/usr/tnf/config/tnf_config.yml
 ENV KUBECONFIG=/usr/tnf/kubeconfig/config
 ENV TNF_PARTNER_SRC_DIR=$TNF_PARTNER_DIR/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,8 +78,8 @@ RUN mkdir ${TNF_BIN_DIR} && \
 	cp --parents `find -name \*.json*` ${TNF_DIR} && \
 	cp cnf-certification-test/cnf-certification-test.test ${TNF_BIN_DIR} && \
     # copy all of the chaos-test-files
-    mkdir -p ${TNF_DIR}/chaostesting/chaos-test-files && \
-    cp /cnf-certification-test/chaostesting/chaos-test-files/ ${TNF_DIR}/chaostesting/chaos-test-files/
+    mkdir -p ${TNF_DIR}/cnf-certification-test/chaostesting && \
+    cp -a cnf-certification-test/chaostesting/chaos-test-files ${TNF_DIR}/cnf-certification-test/chaostesting
 
 WORKDIR ${TNF_DIR}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,7 @@ RUN yum remove -y gcc git wget && \
 FROM scratch
 ARG TNF_PARTNER_DIR=/usr/tnf-partner
 COPY --from=build / /
+COPY /cnf-certification-test/chaostesting/chaos-test-files/ /usr/tnf/chaostesting/chaos-test-files/
 ENV TNF_CONFIGURATION_PATH=/usr/tnf/config/tnf_config.yml
 ENV KUBECONFIG=/usr/tnf/kubeconfig/config
 ENV TNF_PARTNER_SRC_DIR=$TNF_PARTNER_DIR/src

--- a/cnf-certification-test/chaostesting/suite.go
+++ b/cnf-certification-test/chaostesting/suite.go
@@ -33,7 +33,7 @@ var _ = ginkgo.Describe(common.ChaosTesting, func() {
 		// Note: Reloading test environment here because it is possible
 		// that some of the resources that are gathered prior to the chaos test
 		// have been deleted and need another record created.
-		provider.ReloadTestEnvironment()
+		env.SetNeedsRefresh()
 	})
 
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestPodDeleteIdentifier)

--- a/cnf-certification-test/chaostesting/suite.go
+++ b/cnf-certification-test/chaostesting/suite.go
@@ -29,6 +29,12 @@ var _ = ginkgo.Describe(common.ChaosTesting, func() {
 		env = provider.GetTestEnvironment()
 	})
 	ginkgo.ReportAfterEach(results.RecordResult)
+	ginkgo.AfterEach(func() {
+		// Note: Reloading test environment here because it is possible
+		// that some of the resources that are gathered prior to the chaos test
+		// have been deleted and need another record created.
+		provider.ReloadTestEnvironment()
+	})
 
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestPodDeleteIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -294,11 +294,6 @@ func isSkipHelmChart(helmName string, skipHelmChartList []configuration.SkipHelm
 	return false
 }
 
-func ReloadTestEnvironment() TestEnvironment {
-	buildTestEnvironment()
-	return env
-}
-
 func GetTestEnvironment() TestEnvironment {
 	if !loaded {
 		buildTestEnvironment()

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -294,6 +294,11 @@ func isSkipHelmChart(helmName string, skipHelmChartList []configuration.SkipHelm
 	return false
 }
 
+func ReloadTestEnvironment() TestEnvironment {
+	buildTestEnvironment()
+	return env
+}
+
 func GetTestEnvironment() TestEnvironment {
 	if !loaded {
 		buildTestEnvironment()

--- a/run-cnf-suites.sh
+++ b/run-cnf-suites.sh
@@ -100,10 +100,10 @@ if [[ ! -f "/proc/1/cgroup" ]] || grep -q init\.scope /proc/1/cgroup; then
 	cd ..
 fi
 
-if [[ -z "${TNF_PARTNER_SRC_DIR}" ]]; then
-	echo "env var \"TNF_PARTNER_SRC_DIR\" not set, running the script without updating infra"
-else
+if [ -d ${TNF_PARTNER_DIR}/src ] && [[ ! -z "${TNF_PARTNER_SRC_DIR}" ]]; then
+	echo "attempting to install partner pods"
 	make -C $TNF_PARTNER_SRC_DIR install-partner-pods
+	echo "attempting to install litmus"
 	make -C $TNF_PARTNER_SRC_DIR install-litmus
 fi
 
@@ -127,3 +127,8 @@ else
 fi
 
 cd ./cnf-certification-test && ./cnf-certification-test.test $FOCUS_STRING $SKIP_STRING $LABEL_STRING ${GINKGO_ARGS}
+
+if [ -d ${TNF_PARTNER_DIR}/src ] &&  [[ ! -z "${TNF_PARTNER_SRC_DIR}" ]]; then
+	echo "attempting to delete litmus"
+	make -C $TNF_PARTNER_SRC_DIR delete-litmus
+fi

--- a/run-cnf-suites.sh
+++ b/run-cnf-suites.sh
@@ -104,6 +104,7 @@ if [[ -z "${TNF_PARTNER_SRC_DIR}" ]]; then
 	echo "env var \"TNF_PARTNER_SRC_DIR\" not set, running the script without updating infra"
 else
 	make -C $TNF_PARTNER_SRC_DIR install-partner-pods
+	make -C $TNF_PARTNER_SRC_DIR install-litmus
 fi
 
 echo "Running with focus '$FOCUS'"

--- a/run-cnf-suites.sh
+++ b/run-cnf-suites.sh
@@ -100,7 +100,7 @@ if [[ ! -f "/proc/1/cgroup" ]] || grep -q init\.scope /proc/1/cgroup; then
 	cd ..
 fi
 
-if [ -d ${TNF_PARTNER_DIR}/src ] && [[ ! -z "${TNF_PARTNER_SRC_DIR}" ]]; then
+if [[ ! -z "${TNF_PARTNER_SRC_DIR}" ]]; then
 	echo "attempting to install partner pods"
 	make -C $TNF_PARTNER_SRC_DIR install-partner-pods
 	echo "attempting to install litmus"
@@ -128,7 +128,7 @@ fi
 
 cd ./cnf-certification-test && ./cnf-certification-test.test $FOCUS_STRING $SKIP_STRING $LABEL_STRING ${GINKGO_ARGS}
 
-if [ -d ${TNF_PARTNER_DIR}/src ] &&  [[ ! -z "${TNF_PARTNER_SRC_DIR}" ]]; then
+if [[ ! -z "${TNF_PARTNER_SRC_DIR}" ]]; then
 	echo "attempting to delete litmus"
 	make -C $TNF_PARTNER_SRC_DIR delete-litmus
 fi


### PR DESCRIPTION
Okay I set the folder where to copy the files as `/usr/tnf/chaostesting/chaos-test-files/`.

I believe the binary lives in `/usr/tnf` as well:
```
ENV TNF_DIR=/usr/tnf
ENV TNF_SRC_DIR=${TNF_DIR}/tnf-src
ENV TNF_BIN_DIR=${TNF_DIR}/cnf-certification-test
```

This should be the correct path but I'll need some additional reviews.