### PR TITLE
Use CSV name to search in online catalog.

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -10,7 +10,7 @@ import (
 //go:generate moq -out api_moq.go . CertAPIClientFuncs
 type CertificationValidator interface {
 	IsContainerCertified(registry, repository, tag, digest string) bool
-	IsOperatorCertified(operatorName, ocpVersion, channel string) bool
+	IsOperatorCertified(csvName, ocpVersion, channel string) bool
 	IsReleaseCertified(helm *release.Release, ourKubeVersion string) bool
 	IsServiceReachable() bool
 }
@@ -31,17 +31,20 @@ func IsContainerCertified(registry, repository, tag, digest string) bool {
 	if onlineClient.IsServiceReachable() {
 		return onlineClient.IsContainerCertified(registry, repository, tag, digest)
 	}
+	logrus.Warnf("Online Catalog not available. Testing with offline db.")
 	return offlineClient.IsContainerCertified(registry, repository, tag, digest)
 }
 func IsOperatorCertified(operatorName, ocpVersion, channel string) bool {
 	if onlineClient.IsServiceReachable() {
 		return onlineClient.IsOperatorCertified(operatorName, ocpVersion, channel)
 	}
+	logrus.Warnf("Online Catalog not available. Testing with offline db.")
 	return offlineClient.IsOperatorCertified(operatorName, ocpVersion, channel)
 }
 func IsReleaseCertified(helm *release.Release, ourKubeVersion string) bool {
 	if onlineClient.IsServiceReachable() {
 		return onlineClient.IsReleaseCertified(helm, ourKubeVersion)
 	}
+	logrus.Warnf("Online Catalog not available. Testing with offline db.")
 	return offlineClient.IsReleaseCertified(helm, ourKubeVersion)
 }

--- a/internal/api/offlinecheck/operator.go
+++ b/internal/api/offlinecheck/operator.go
@@ -120,8 +120,8 @@ func loadOperatorsCatalog(pathToRoot string) {
 // isOperatorCertified check the presence of operator name in certified operators db
 // the operator name is the csv
 // ocpVersion is Major.Minor OCP version
-func (checker OfflineChecker) IsOperatorCertified(operatorName, ocpVersion, channel string) bool {
-	name, operatorVersion := ExtractNameVersionFromName(operatorName)
+func (checker OfflineChecker) IsOperatorCertified(csvName, ocpVersion, channel string) bool {
+	name, operatorVersion := ExtractNameVersionFromName(csvName)
 	if v, ok := operatordb[name]; ok {
 		for _, version := range v {
 			if version.operatorVersion == operatorVersion && version.channel == channel {

--- a/internal/api/offlinecheck/operator_test.go
+++ b/internal/api/offlinecheck/operator_test.go
@@ -38,4 +38,6 @@ func TestIsOperatorCertified(t *testing.T) {
 	assert.True(t, checker.IsOperatorCertified(name, ocpversion, channel))
 	name = "falcon-alpha"
 	assert.False(t, checker.IsOperatorCertified(name, ocpversion, channel))
+
+	assert.True(t, checker.IsOperatorCertified("artifactory-ha-operator.v1.2.0", "4.9", "alpha"))
 }


### PR DESCRIPTION
The URL to get the operator info was using the "package" field to filter, but there's also a "csv_name" on each entry that can be used as a filter, as that's exactly the field we're using in our TC. Also, the offline checker uses the csv name by default (see `buildOperatorKey()` so now both checkers online/offline are aligned.