### PR TITLE
Increased timeout for waiting for the debug pods to be up.

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -45,7 +45,8 @@ import (
 const (
 	daemonSetNamespace               = "default"
 	daemonSetName                    = "debug"
-	debugPodsTimeout                 = 60 * time.Second
+	debugPodsTimeout                 = 5 * time.Minute
+	debugPodsRetryInterval           = 5 * time.Second
 	CniNetworksStatusKey             = "k8s.v1.cni.cncf.io/networks-status"
 	skipConnectivityTestsLabel       = "test-network-function.com/skip_connectivity_tests"
 	skipMultusConnectivityTestsLabel = "test-network-function.com/skip_multus_connectivity_tests"
@@ -336,7 +337,7 @@ func WaitDebugPodsReady() error {
 			break
 		}
 
-		time.Sleep(time.Second)
+		time.Sleep(debugPodsRetryInterval)
 	}
 
 	if !isReady {


### PR DESCRIPTION
On slow connections or overloaded clusters, downloading the container
image and starting it may take a bit more than one minute.