### PR TITLE
Rebuild catalog; add additional logging for onlinecheck

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -36,6 +36,7 @@ func IsContainerCertified(registry, repository, tag, digest string) bool {
 }
 func IsOperatorCertified(operatorName, ocpVersion, channel string) bool {
 	if onlineClient.IsServiceReachable() {
+		logrus.Debug("Online service is reachable")
 		return onlineClient.IsOperatorCertified(operatorName, ocpVersion, channel)
 	}
 	logrus.Warnf("Online Catalog not available. Testing with offline db.")
@@ -43,6 +44,7 @@ func IsOperatorCertified(operatorName, ocpVersion, channel string) bool {
 }
 func IsReleaseCertified(helm *release.Release, ourKubeVersion string) bool {
 	if onlineClient.IsServiceReachable() {
+		logrus.Debug("Online service is reachable")
 		return onlineClient.IsReleaseCertified(helm, ourKubeVersion)
 	}
 	logrus.Warnf("Online Catalog not available. Testing with offline db.")

--- a/internal/api/onlinecheck/onlinecheck.go
+++ b/internal/api/onlinecheck/onlinecheck.go
@@ -180,7 +180,7 @@ func (checker OnlineValidator) IsOperatorCertified(csvName, ocpVersion, channel 
 	var responseData []byte
 	var err error
 	url := fmt.Sprintf(certifiedOperatorsCatalogURL, csvName, filterCertifiedOperatorsOrg)
-	log.Trace(url)
+	log.Debug(url)
 	if responseData, err = checker.GetRequest(url); err != nil || len(responseData) == 0 {
 		return false
 	}


### PR DESCRIPTION
Some random changes. 

- Added some more logging whenever an online check is available for the certification check.
- Rebuilt the catalog to bring in changes from #310 