### PR TITLE
Fix RHCOS automation

### DIFF
--- a/.github/workflows/update-rhcos-mapping.yml
+++ b/.github/workflows/update-rhcos-mapping.yml
@@ -12,9 +12,15 @@ jobs:
       SHELL: /bin/bash        
 
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
       - name: Execute `make update-rhcos-versions`
         run: make update-rhcos-versions
-      - name: create PR
+
+      - name: Create PR
         uses: peter-evans/create-pull-request@v3
         env:
           GITHUB_TOKEN: ${{ secrets.UPDATE_CERTIFIED_DB_TOKEN }}


### PR DESCRIPTION
- Checkout the actual code before running.  😄 
- Add spacing.

The [latest run](https://github.com/test-network-function/cnf-certification-test/runs/7225806609?check_suite_focus=true#step:2:8) failed because the Github Action was not checking out the code properly prior to running.