### PR TITLE
Chaos testing pod-delete test case disabled and removed from catalog.

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -215,21 +215,6 @@ Result Type|normative
 Suggested Remediation|Ensure that your Operator has passed Red Hat's Operator Certification Program (OCP).
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.12 and 5.3.3
 
-### chaostesting
-
-#### pod-delete
-
-Property|Description
----|---
-Test Case Name|pod-delete
-Test Case Label|chaostesting-pod-delete
-Unique ID|http://test-network-function.com/testcases/chaostesting/pod-delete
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/chaostesting/pod-delete Using the litmus chaos operator, this test checks that pods are recreated successfully after deleting them.
-Result Type|normative
-Suggested Remediation|Make sure that the pods can be recreated successfully after deleting them
-Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
-
 ### lifecycle
 
 #### container-shutdown

--- a/cnf-certification-test/chaostesting/suite.go
+++ b/cnf-certification-test/chaostesting/suite.go
@@ -44,6 +44,8 @@ var _ = ginkgo.Describe(common.ChaosTesting, func() {
 })
 
 func testPodDelete(env *provider.TestEnvironment) {
+	ginkgo.Skip("This TC is under construction.")
+
 	for _, dep := range env.Deployments {
 		namespace := dep.Namespace
 		var label string

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -417,14 +417,14 @@ var Catalog = map[claim.Identifier]TestCaseDescription{
 `),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
 	},
-	TestPodDeleteIdentifier: {
-		Identifier:  TestPodDeleteIdentifier,
-		Type:        normativeResult,
-		Remediation: `Make sure that the pods can be recreated successfully after deleting them`,
-		Description: formDescription(TestPodDeleteIdentifier,
-			`Using the litmus chaos operator, this test checks that pods are recreated successfully after deleting them.`),
-		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
-	},
+	// TestPodDeleteIdentifier: {
+	// 	Identifier:  TestPodDeleteIdentifier,
+	// 	Type:        normativeResult,
+	// 	Remediation: `Make sure that the pods can be recreated successfully after deleting them`,
+	// 	Description: formDescription(TestPodDeleteIdentifier,
+	// 		`Using the litmus chaos operator, this test checks that pods are recreated successfully after deleting them.`),
+	// 	BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
+	// },
 	TestSecConNonRootUserIdentifier: {
 		Identifier:  TestSecConNonRootUserIdentifier,
 		Type:        normativeResult,


### PR DESCRIPTION
The TC code is still there so it can also be manually run (after
removing the skip), for internal tests, but the catalog entry has been
removed so we can decide whether to keep chaos testing as part of TNF or
just agree on the final list of chaos test cases to be implemented
here.