### PR TITLE
Fix projectpath to handle proper workingdir

### DIFF
--- a/internal/projectpath/projectpath.go
+++ b/internal/projectpath/projectpath.go
@@ -1,14 +1,25 @@
 package projectpath
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 var (
 	_, b, _, _ = runtime.Caller(0)
-
-	// Root folder of this project
-	//nolint:gocritic
-	Root = filepath.Join(filepath.Dir(b), "../..")
+	Root       = getCorrectPath()
 )
+
+func getCorrectPath() string {
+	if os.Getenv("UNIT_TEST") != "" || strings.HasSuffix(os.Args[0], ".test") || strings.Contains(os.Args[0], "/T/") {
+		// Root folder of this project used for unit testing
+		//nolint:gocritic
+		return filepath.Join(filepath.Dir(b), "../..")
+	}
+
+	// The real working directory of anything non unit test related
+	path, _ := os.Getwd()
+	return path
+}


### PR DESCRIPTION
The `projectpath` package was causing the QE failures such as: 

`Error: open /usr/tnf/tnf-src/cnf-certification-test/platform/operatingsystem/files/rhcos_version_map: no such file or directory`

This was because we were asking for the root directory instead of just using the working directory.  Using `os.Getwd()` this allows us to get the working directory correctly which should point us correctly at `cnf-certification-test/platform/operatingsystem/files/rhcos_version_map`.