### PR TITLE
Remove 'cnf-certification-test/' from path to RHCOS map file

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -61,7 +61,7 @@ const (
 var (
 	WorkerLabels      = []string{"node-role.kubernetes.io/worker"}
 	MasterLabels      = []string{"node-role.kubernetes.io/master", "node-role.kubernetes.io/control-plane"}
-	rhcosRelativePath = "%s/cnf-certification-test/platform/operatingsystem/files/rhcos_version_map"
+	rhcosRelativePath = "%s/platform/operatingsystem/files/rhcos_version_map"
 )
 
 type Pod struct {


### PR DESCRIPTION
#350 once again had the wrong path.

```
/usr/tnf/cnf-certification-test/platform/operatingsystem/files
versus
/usr/tnf/cnf-certification-test/cnf-certification-test/platform/operatingsystem/files
```