### PR TITLE
Add SYS_NICE realtime kernel check

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -175,6 +175,18 @@ Description|http://test-network-function.com/testcases/access-control/security-c
 Result Type|normative
 Suggested Remediation|Configure privilege escalation to false
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
+#### sys-nice-realtime-capability
+
+Property|Description
+---|---
+Test Case Name|sys-nice-realtime-capability
+Test Case Label|access-control-sys-nice-realtime-capability
+Unique ID|http://test-network-function.com/testcases/access-control/sys-nice-realtime-capability
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/access-control/sys-nice-realtime-capability Check that pods running on nodes with realtime kernel enabled have the SYS_NICE capability enabled in their spec.
+Result Type|informative
+Suggested Remediation|If pods are scheduled to realtime kernel nodes, they must add SYS_NICE capability to their spec.
+Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 2.7.4
 
 ### affiliated-certification
 

--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -481,7 +481,7 @@ func TestOneProcessPerContainer(env *provider.TestEnvironment) {
 }
 
 func TestSYSNiceRealtimeCapability(env *provider.TestEnvironment) {
-	var podsWithoutSysNice []string
+	var containersWithoutSysNice []string
 
 	// Loop through all of the labeled containers and compare their security context capabilities and whether
 	// or not the node's kernel is realtime enabled.
@@ -489,11 +489,11 @@ func TestSYSNiceRealtimeCapability(env *provider.TestEnvironment) {
 		n := env.Nodes[cut.NodeName]
 		if n.IsRTKernel() && !strings.Contains(cut.Data.SecurityContext.Capabilities.String(), "SYS_NICE") {
 			logrus.Debugf("Container: %s has been found running on a realtime kernel enabled node without SYS_NICE capability.", cut.String())
-			podsWithoutSysNice = append(podsWithoutSysNice, cut.String())
+			containersWithoutSysNice = append(containersWithoutSysNice, cut.String())
 		}
 	}
 
-	if n := len(podsWithoutSysNice); n > 0 {
+	if n := len(containersWithoutSysNice); n > 0 {
 		errMsg := fmt.Sprintf("Number of containers running on realtime kernels without SYS_NICE: %d", n)
 		tnf.ClaimFilePrintf(errMsg)
 		ginkgo.Fail(errMsg)

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -317,6 +317,10 @@ var (
 		Url:     formTestURL(common.AccessControlTestKey, "one-process-per-container"),
 		Version: versionOne,
 	}
+	TestSYSNiceRealtimeCapabilityIdentifier = claim.Identifier{
+		Url:     formTestURL(common.AccessControlTestKey, "sys-nice-realtime-capability"),
+		Version: versionOne,
+	}
 )
 
 func formDescription(identifier claim.Identifier, description string) string {
@@ -880,5 +884,12 @@ the changes for you.`,
 		have only one process running`),
 		Remediation:           `launch only one process per container`,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 10.8.3",
+	},
+	TestSYSNiceRealtimeCapabilityIdentifier: {
+		Identifier:            TestSYSNiceRealtimeCapabilityIdentifier,
+		Type:                  informativeResult,
+		Description:           formDescription(TestSYSNiceRealtimeCapabilityIdentifier, `Check that pods running on nodes with realtime kernel enabled have the SYS_NICE capability enabled in their spec.`),
+		Remediation:           `If pods are scheduled to realtime kernel nodes, they must add SYS_NICE capability to their spec.`,
+		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 2.7.4",
 	},
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -197,6 +197,11 @@ func (node *Node) IsRHEL() bool {
 	return strings.Contains(strings.TrimSpace(node.Data.Status.NodeInfo.OSImage), rhelName)
 }
 
+func (node *Node) IsRTKernel() bool {
+	// More information: https://www.redhat.com/sysadmin/real-time-kernel
+	return strings.Contains(strings.TrimSpace(node.Data.Status.NodeInfo.KernelVersion), "rt")
+}
+
 func (node *Node) GetRHCOSVersion() (string, error) {
 	// Check if the node is running CoreOS or not
 	if !node.IsRHCOS() {

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1012,6 +1012,46 @@ func TestGetNodeCount(t *testing.T) {
 	}
 }
 
+func TestIsRTKernel(t *testing.T) {
+	generateNode := func(kernel string) *Node {
+		return &Node{
+			Data: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
+						KernelVersion: kernel,
+					},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		testKernel     string
+		expectedOutput bool
+	}{
+		{ // Test Case #1 - Kernel is RT
+			testKernel:     "3.10.0-1127.10.1.rt56.1106.el7",
+			expectedOutput: true,
+		},
+		{ // Test Case #2 - Kernel is standard
+			testKernel:     "3.10.0-1127.10.1.1106.el7",
+			expectedOutput: false,
+		},
+		{ // Test Case #3 - Kernel string empty
+			testKernel:     "",
+			expectedOutput: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		n := generateNode(tc.testKernel)
+		assert.Equal(t, n.IsRTKernel(), tc.expectedOutput)
+	}
+}
+
 func TestIsRHCOS(t *testing.T) {
 	testCases := []struct {
 		testImageName  string


### PR DESCRIPTION
Adds a new test to the `access-control` test suite.

Compares the containers labeled for test and whichever node's kernel type they are running on to see if they have `SYS_NICE` security context capability enabled. 

Some helpful links:
- https://www.redhat.com/sysadmin/real-time-kernel
