### PR TITLE
Add toleration check test

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -175,6 +175,18 @@ Description|http://test-network-function.com/testcases/access-control/requests-a
 Result Type|informative
 Suggested Remediation|Add requests and limits to your container spec.  See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
 Best Practice Reference|https://TODO Section 4.6.11
+#### pod-toleration-bypass
+
+Property|Description
+---|---
+Test Case Name|pod-toleration-bypass
+Test Case Label|access-control-pod-toleration-bypass
+Unique ID|http://test-network-function.com/testcases/access-control/pod-toleration-bypass
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/access-control/pod-toleration-bypass Check that pods do not have NoExecute, PreferNoSchedule, or NoSchedule tolerations that have been modified from the default.
+Result Type|informative
+Suggested Remediation|Do not allow pods to bypass the NoExecute, PreferNoSchedule, or NoSchedule tolerations that are default applied by Kubernetes.
+Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 10.6
 Exception Process|
 #### security-context-capabilities-check
 

--- a/cnf-certification-test/accesscontrol/tolerations/tolerations.go
+++ b/cnf-certification-test/accesscontrol/tolerations/tolerations.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package tolerations
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+var (
+	nonCompliantTolerations  = []v1.TaintEffect{v1.TaintEffectNoExecute, v1.TaintEffectNoSchedule, v1.TaintEffectPreferNoSchedule}
+	tolerationSecondsDefault = 300
+)
+
+func IsTolerationModified(t v1.Toleration) bool {
+	const (
+		notReadyStr    = "node.kubernetes.io/not-ready"
+		unreachableStr = "node.kubernetes.io/unreachable"
+	)
+	// Check each of the tolerations to make sure they are the default tolerations added by k8s:
+	// tolerations:
+	// - effect: NoExecute
+	//   key: node.kubernetes.io/not-ready
+	//   operator: Exists
+	//   tolerationSeconds: 300
+	// - effect: NoExecute
+	//   key: node.kubernetes.io/unreachable
+	//   operator: Exists
+	//   tolerationSeconds: 300
+
+	if t.Effect == v1.TaintEffectNoExecute {
+		if t.Key == notReadyStr || t.Key == unreachableStr &&
+			(t.Operator == v1.TolerationOpExists && t.TolerationSeconds != nil && *t.TolerationSeconds == int64(tolerationSecondsDefault)) {
+			return false
+		}
+	}
+
+	// Check through the list of non-compliant tolerations to see if anything snuck by the above short circuit
+	for _, nct := range nonCompliantTolerations {
+		if t.Effect == nct {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cnf-certification-test/accesscontrol/tolerations/tolerations_test.go
+++ b/cnf-certification-test/accesscontrol/tolerations/tolerations_test.go
@@ -1,0 +1,86 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package tolerations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+)
+
+//nolint:funlen
+func TestIsTolerationModified(t *testing.T) {
+	getInt64Pointer := func(val int64) *int64 {
+		return &val
+	}
+
+	testCases := []struct {
+		testToleration v1.Toleration
+		expectedOutput bool
+	}{
+		{ // Test Case #1 - default not-ready toleration
+			testToleration: v1.Toleration{
+				Key:               "node.kubernetes.io/not-ready",
+				Operator:          v1.TolerationOpExists,
+				Effect:            v1.TaintEffectNoExecute,
+				TolerationSeconds: getInt64Pointer(300),
+			},
+			expectedOutput: false,
+		},
+		{ // Test Case #2 - default unreachable toleration
+			testToleration: v1.Toleration{
+				Key:               "node.kubernetes.io/unreachable",
+				Operator:          v1.TolerationOpExists,
+				Effect:            v1.TaintEffectNoExecute,
+				TolerationSeconds: getInt64Pointer(300),
+			},
+			expectedOutput: false,
+		},
+		{ // Test Case #3 - modified unreachable toleration
+			testToleration: v1.Toleration{
+				Key:               "node.kubernetes.io/unreachable",
+				Operator:          v1.TolerationOpExists,
+				Effect:            v1.TaintEffectNoExecute,
+				TolerationSeconds: getInt64Pointer(350), // modified from 300
+			},
+			expectedOutput: true,
+		},
+		{ // Test Case #4 - modified unreachable toleration
+			testToleration: v1.Toleration{
+				Key:               "node.kubernetes.io/unreachable",
+				Operator:          v1.TolerationOpEqual, // modified from exists
+				Effect:            v1.TaintEffectNoExecute,
+				TolerationSeconds: getInt64Pointer(300),
+			},
+			expectedOutput: true,
+		},
+		{ // Test Case #5 - missing effect
+			testToleration: v1.Toleration{
+				Key:      "node.kubernetes.io/unreachable",
+				Operator: v1.TolerationOpExists,
+				// Effect:            v1.TaintEffectNoExecute,
+				TolerationSeconds: getInt64Pointer(300),
+			},
+			expectedOutput: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedOutput, IsTolerationModified(tc.testToleration))
+	}
+}

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -341,6 +341,10 @@ var (
 		Url:     formTestURL(common.AccessControlTestKey, "namespace-resource-quota"),
 		Version: versionOne,
 	}
+	TestPodTolerationBypassIdentifier = claim.Identifier{
+		Url:     formTestURL(common.AccessControlTestKey, "pod-toleration-bypass"),
+		Version: versionOne,
+	}
 )
 
 func formDescription(identifier claim.Identifier, description string) string {
@@ -942,6 +946,7 @@ that there are no changes to the following directories:
 		Description:           formDescription(TestPodRequestsAndLimitsIdentifier, `Check that containers have resource requests and limits specified in their spec.`),
 		Remediation:           RequestsAndLimitsRemediation,
 		BestPracticeReference: bestPracticeDocV1dot4URL + " Section 4.6.11",
+		ExceptionProcess:      NoDocumentedProcess,
 	},
 	TestNamespaceResourceQuotaIdentifier: {
 		Identifier:            TestNamespaceResourceQuotaIdentifier,
@@ -949,5 +954,14 @@ that there are no changes to the following directories:
 		Description:           formDescription(TestNamespaceResourceQuotaIdentifier, `Checks to see if CNF workload pods are running in namespaces that have resource quotas applied.`),
 		Remediation:           NamespaceResourceQuotaRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 4.6.8", // TODO Change this to v1.4 when available
+		ExceptionProcess:      NoDocumentedProcess,
+	},
+	TestPodTolerationBypassIdentifier: {
+		Identifier:            TestPodTolerationBypassIdentifier,
+		Type:                  informativeResult,
+		Description:           formDescription(TestPodTolerationBypassIdentifier, `Check that pods do not have NoExecute, PreferNoSchedule, or NoSchedule tolerations that have been modified from the default.`),
+		Remediation:           PodTolerationBypassRemediation,
+		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 10.6",
+		ExceptionProcess:      NoDocumentedProcess,
 	},
 }

--- a/cnf-certification-test/identifiers/remediation.go
+++ b/cnf-certification-test/identifiers/remediation.go
@@ -170,4 +170,7 @@ const (
 	RequestsAndLimitsRemediation = `Add requests and limits to your container spec.  See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits`
 
 	NamespaceResourceQuotaRemediation = `Apply a ResourceQuota to the namespace your CNF is running in`
+
+	//nolint:gosec
+	PodTolerationBypassRemediation = `Do not allow pods to bypass the NoExecute, PreferNoSchedule, or NoSchedule tolerations that are default applied by Kubernetes.`
 )


### PR DESCRIPTION
A new test that will check the existence of the default k8s tolerations on pods and if they are modified or added to this will flag a failure.

This is referenced in section 10.6 of the [v1.3 requirements doc](https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf).