### PR TITLE
GolangCI-lint v1.47.1; fix lint problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ COMMON_GO_ARGS=-race
 GIT_COMMIT=$(shell script/create-version-files.sh)
 GIT_RELEASE=$(shell script/get-git-release.sh)
 GIT_PREVIOUS_RELEASE=$(shell script/get-git-previous-release.sh)
-GOLANGCI_VERSION=v1.47.0
+GOLANGCI_VERSION=v1.47.1
 LINKER_TNF_RELEASE_FLAGS=-X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitCommit=${GIT_COMMIT}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitRelease=${GIT_RELEASE}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitPreviousRelease=${GIT_PREVIOUS_RELEASE}
@@ -75,7 +75,7 @@ clean:
 
 # Run configured linters
 lint:
-	golangci-lint run --timeout 5m0s
+	golangci-lint run --timeout 6m0s
 
 # Build and run unit tests
 test:

--- a/cnf-certification-test/lifecycle/podrecreation/podrecreation.go
+++ b/cnf-certification-test/lifecycle/podrecreation/podrecreation.go
@@ -134,10 +134,7 @@ func deletePod(pod *corev1.Pod, mode string, wg *sync.WaitGroup) error {
 	podName := pod.Name
 	namespace := pod.Namespace
 	go func() {
-		err = waitPodDeleted(namespace, podName, gracePeriodSeconds, watcher)
-		if err != nil {
-			logrus.Errorf("waitPodDeleted failed with err=%s", err)
-		}
+		waitPodDeleted(namespace, podName, gracePeriodSeconds, watcher)
 		wg.Done()
 	}()
 	return nil
@@ -150,7 +147,7 @@ func CordonCleanup(node string) {
 	}
 }
 
-func waitPodDeleted(ns, podName string, timeout int64, watcher watch.Interface) error {
+func waitPodDeleted(ns, podName string, timeout int64, watcher watch.Interface) {
 	logrus.Tracef("Entering waitPodDeleted ns=%s pod=%s", ns, podName)
 	defer watcher.Stop()
 
@@ -159,11 +156,11 @@ func waitPodDeleted(ns, podName string, timeout int64, watcher watch.Interface) 
 		case event := <-watcher.ResultChan():
 			if event.Type == watch.Deleted || event.Type == "" {
 				logrus.Debugf("ns=%s pod=%s deleted", ns, podName)
-				return nil
+				return
 			}
 		case <-time.After(time.Duration(timeout) * time.Second):
 			logrus.Infof("watch for pod deletion timedout after %d seconds", timeout)
-			return nil
+			return
 		}
 	}
 }

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -63,25 +63,25 @@ var _ = ginkgo.Describe(common.NetworkingTestKey, func() {
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestICMPv4ConnectivityIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
 		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers, env.Pods)
-		testNetworkConnectivity(&env, defaultNumPings, netcommons.IPv4, netcommons.DEFAULT)
+		testNetworkConnectivity(&env, netcommons.IPv4, netcommons.DEFAULT)
 	})
 	// Multus interfaces ICMP IPv4 test case
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestICMPv4ConnectivityMultusIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
 		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers, env.Pods)
-		testNetworkConnectivity(&env, defaultNumPings, netcommons.IPv4, netcommons.MULTUS)
+		testNetworkConnectivity(&env, netcommons.IPv4, netcommons.MULTUS)
 	})
 	// Default interface ICMP IPv6 test case
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestICMPv6ConnectivityIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
 		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers, env.Pods)
-		testNetworkConnectivity(&env, defaultNumPings, netcommons.IPv6, netcommons.DEFAULT)
+		testNetworkConnectivity(&env, netcommons.IPv6, netcommons.DEFAULT)
 	})
 	// Multus interfaces ICMP IPv6 test case
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestICMPv6ConnectivityMultusIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
 		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers, env.Pods)
-		testNetworkConnectivity(&env, defaultNumPings, netcommons.IPv6, netcommons.MULTUS)
+		testNetworkConnectivity(&env, netcommons.IPv6, netcommons.MULTUS)
 	})
 	// Default interface ICMP IPv6 test case
 	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestUndeclaredContainerPortsUsage)
@@ -164,11 +164,11 @@ func testNodePort(env *provider.TestEnvironment) {
 }
 
 // testDefaultNetworkConnectivity test the connectivity between the default interfaces of containers under test
-func testNetworkConnectivity(env *provider.TestEnvironment, count int, aIPVersion netcommons.IPVersion, aType netcommons.IFType) {
+func testNetworkConnectivity(env *provider.TestEnvironment, aIPVersion netcommons.IPVersion, aType netcommons.IFType) {
 	netsUnderTest, claimsLog := icmp.BuildNetTestContext(env.Pods, aIPVersion, aType)
 	// Saving  curated logs to claims file
 	tnf.ClaimFilePrintf("%s", claimsLog.GetLogLines())
-	badNets, claimsLog, skip := icmp.RunNetworkingTests(netsUnderTest, count, aIPVersion)
+	badNets, claimsLog, skip := icmp.RunNetworkingTests(netsUnderTest, defaultNumPings, aIPVersion)
 	// Saving curated logs to claims file
 	tnf.ClaimFilePrintf("%s", claimsLog.GetLogLines())
 	if skip {


### PR DESCRIPTION
- `waitPodDeleted` doesn't return anything other than `nil`.
- `testNetworkConnectivity` was only ever using `defaultNumPings`.

Note I had to bump the timeout to 6 minutes because the CI was too slow (by a few seconds) running the linter.