### PR TITLE
Add test for requests and limits for containers

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -150,6 +150,19 @@ Result Type|normative
 Suggested Remediation|Ensure that the each CNF Pod is configured to use a valid Service Account
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.3 and 5.2.7
 Exception Process|There is no documented exception process for this.
+#### requests-and-limits
+
+Property|Description
+---|---
+Test Case Name|requests-and-limits
+Test Case Label|access-control-requests-and-limits
+Unique ID|http://test-network-function.com/testcases/access-control/requests-and-limits
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/access-control/requests-and-limits Check that containers have resource requests and limits specified in their spec.
+Result Type|informative
+Suggested Remediation|Add requests and limits to your container spec.  See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
+Best Practice Reference|https://TODO Section 4.6.11
+Exception Process|
 #### security-context-capabilities-check
 
 Property|Description

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -333,6 +333,10 @@ var (
 		Url:     formTestURL(common.AccessControlTestKey, "sys-ptrace-capability"),
 		Version: versionOne,
 	}
+	TestPodRequestsAndLimitsIdentifier = claim.Identifier{
+		Url:     formTestURL(common.AccessControlTestKey, "requests-and-limits"),
+		Version: versionOne,
+	}
 )
 
 func formDescription(identifier claim.Identifier, description string) string {
@@ -927,5 +931,12 @@ that there are no changes to the following directories:
 		Remediation:           SysPtraceCapabilityRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 2.7.5",
 		ExceptionProcess:      NoDocumentedProcess,
+	},
+	TestPodRequestsAndLimitsIdentifier: {
+		Identifier:            TestPodRequestsAndLimitsIdentifier,
+		Type:                  informativeResult,
+		Description:           formDescription(TestPodRequestsAndLimitsIdentifier, `Check that containers have resource requests and limits specified in their spec.`),
+		Remediation:           RequestsAndLimitsRemediation,
+		BestPracticeReference: bestPracticeDocV1dot4URL + " Section 4.6.11",
 	},
 }

--- a/cnf-certification-test/identifiers/remediation.go
+++ b/cnf-certification-test/identifiers/remediation.go
@@ -161,9 +161,11 @@ const (
 
 	OneProcessPerContainerRemediation = `Launch only one process per container`
 
-	SYSNiceRealtimeCapabilityRemediation = `If pods are scheduled to realtime kernel nodes, they must add SYS_NICE capability to their spec.`
-
 	SysPtraceCapabilityRemediation = `Allow the SYS_PTRACE capability when enabling process namespace sharing for a Pod`
 
+	SYSNiceRealtimeCapabilityRemediation = `If pods are scheduled to realtime kernel nodes, they must add SYS_NICE capability to their spec.`
+
 	OCPReservedPortsUsageRemediation = `Ensure that CNF apps do not listen on ports that are reserved by Openshift`
+
+	RequestsAndLimitsRemediation = `Add requests and limits to your container spec.  See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits`
 )

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -110,6 +110,12 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 		testPodsRecreation(&env)
 	})
 
+	testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestPodRequestsAndLimitsIdentifier)
+	ginkgo.It(testID, ginkgo.Label(testID), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testPodRequestsAndLimits(&env)
+	})
+
 	if env.IsIntrusive() {
 		testID = identifiers.XformToGinkgoItIdentifier(identifiers.TestDeploymentScalingIdentifier)
 		ginkgo.It(testID, ginkgo.Label(testID), func() {
@@ -376,5 +382,57 @@ func testPodsRecreation(env *provider.TestEnvironment) { //nolint:funlen
 		if err != nil {
 			logrus.Fatalf("error uncordoning the node: %s", n)
 		}
+	}
+}
+
+func testPodRequestsAndLimits(env *provider.TestEnvironment) {
+	var containersMissingRequestsOrLimits []string
+	ginkgo.By("Testing container resource requests and limits")
+
+	// Loop through the containers, looking for containers that are missing requests or limits.
+	// These need to be defined in order to pass.
+	for _, cut := range env.Containers {
+		badContainer := false
+		// Parse the limits.
+		if len(cut.Data.Resources.Limits) == 0 {
+			tnf.ClaimFilePrintf("Container has been found missing resource limits: %s", cut.String())
+			badContainer = true
+		} else {
+			if cut.Data.Resources.Limits.Cpu() == nil {
+				tnf.ClaimFilePrintf("Container has been found missing CPU limits: %s", cut.String())
+				badContainer = true
+			}
+
+			if cut.Data.Resources.Limits.Memory() == nil {
+				tnf.ClaimFilePrintf("Container has been found missing memory limits: %s", cut.String())
+				badContainer = true
+			}
+		}
+
+		// Parse the requests.
+		if len(cut.Data.Resources.Requests) == 0 {
+			tnf.ClaimFilePrintf("Container has been found missing resource requests: %s", cut.String())
+			badContainer = true
+		} else {
+			if cut.Data.Resources.Requests.Cpu() == nil {
+				tnf.ClaimFilePrintf("Container has been found missing CPU requests: %s", cut.String())
+				badContainer = true
+			}
+
+			if cut.Data.Resources.Requests.Memory() == nil {
+				tnf.ClaimFilePrintf("Container has been found missing memory requests: %s", cut.String())
+				badContainer = true
+			}
+		}
+
+		if badContainer {
+			containersMissingRequestsOrLimits = append(containersMissingRequestsOrLimits, cut.String())
+		}
+	}
+
+	if n := len(containersMissingRequestsOrLimits); n > 0 {
+		errMsg := fmt.Sprintf("Containers found that are missing either resource requests or limits: %d. See logs for more detail.", n)
+		tnf.ClaimFilePrintf(errMsg)
+		ginkgo.Fail(errMsg)
 	}
 }


### PR DESCRIPTION
Simple test to check for the existence of `requests` and `limits` on a container spec which corresponds to 4.6.11 in the new v1.4 requirements document.  Note, I don't know if we have a public link yet for the v1.4 document so I marked it as TODO.