### PR TITLE
Address more lint problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ clean:
 
 # Run configured linters
 lint:
-	golangci-lint run --timeout 6m0s
+	golangci-lint run --timeout 10m0s
 
 # Build and run unit tests
 test:

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -179,23 +179,23 @@ func testContainersFsDiff(env *provider.TestEnvironment) {
 		debugPod := env.DebugPods[cut.NodeName]
 		if debugPod == nil {
 			ginkgo.Fail(fmt.Sprintf("Debug pod not found on Node: %s", cut.NodeName))
-		}
-
-		fsDiffTester := cnffsdiff.NewFsDiffTester(clientsholder.GetClientsHolder())
-		fsDiffTester.RunTest(clientsholder.Context{
-			Namespace:     debugPod.Namespace,
-			Podname:       debugPod.Name,
-			Containername: debugPod.Spec.Containers[0].Name,
-		}, cut.UID)
-		switch fsDiffTester.GetResults() {
-		case testhelper.SUCCESS:
-			continue
-		case testhelper.FAILURE:
-			tnf.ClaimFilePrintf("%s - changed folders: %v, deleted folders: %v", cut, fsDiffTester.ChangedFolders, fsDiffTester.DeletedFolders)
-			badContainers = append(badContainers, cut.Data.Name)
-		case testhelper.ERROR:
-			tnf.ClaimFilePrintf("%s - error while running fs-diff: %v: ", cut, fsDiffTester.Error)
-			errContainers = append(errContainers, cut.Data.Name)
+		} else {
+			fsDiffTester := cnffsdiff.NewFsDiffTester(clientsholder.GetClientsHolder())
+			fsDiffTester.RunTest(clientsholder.Context{
+				Namespace:     debugPod.Namespace,
+				Podname:       debugPod.Name,
+				Containername: debugPod.Spec.Containers[0].Name,
+			}, cut.UID)
+			switch fsDiffTester.GetResults() {
+			case testhelper.SUCCESS:
+				continue
+			case testhelper.FAILURE:
+				tnf.ClaimFilePrintf("%s - changed folders: %v, deleted folders: %v", cut, fsDiffTester.ChangedFolders, fsDiffTester.DeletedFolders)
+				badContainers = append(badContainers, cut.Data.Name)
+			case testhelper.ERROR:
+				tnf.ClaimFilePrintf("%s - error while running fs-diff: %v: ", cut, fsDiffTester.Error)
+				errContainers = append(errContainers, cut.Data.Name)
+			}
 		}
 	}
 


### PR DESCRIPTION
`staticcheck` seems to hate that `debugPod == nil` doesn't return immediately after instead of calling ginkgo.Fail.

Semi related to #369.  Not sure why it didn't flag these originally. The PR [passed the CI](https://github.com/test-network-function/cnf-certification-test/actions/runs/2733634001).

Also, I had to bump the timeout again because of https://github.com/golangci/golangci-lint/issues/2997