### PR TITLE
Update partner tag to v4.0.2

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "partner_tag": "v4.0.1"
+  "partner_tag": "v4.0.2"
 }


### PR DESCRIPTION
https://github.com/test-network-function/cnf-certification-test-partner/releases/tag/v4.0.2

Preparing for v4.0.2 by pointing it at the correct tag of the -partner repo.