### PR TITLE
Add test for persistent volume reclaim policy

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,7 +54,6 @@ linters:
     - deadcode
     - depguard
     - dogsled
-    - dupl
     - errcheck
     - exhaustive
     - exportloopref
@@ -73,7 +72,6 @@ linters:
     - lll
     - misspell
     - nakedret
-    - noctx
     - nolintlint
     - revive
     - rowserrcheck
@@ -87,6 +85,7 @@ linters:
     - whitespace
   # do not enable:
   # - asciicheck
+  # - dupl
   # - gochecknoglobals
   # - gochecknoinits
   # - gocognit
@@ -95,6 +94,7 @@ linters:
   # - goerr113
   # - maligned
   # - nestif
+  # - noctx
   # - prealloc
   # - exportloopref
   # - structcheck

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -351,6 +351,19 @@ Result Type|normative
 Suggested Remediation|Add a liveness probe to deployed containers
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.16, 12.1 and 12.5
 Exception Process|There is no documented exception process for this.
+#### persistent-volume-reclaim-policy
+
+Property|Description
+---|---
+Test Case Name|persistent-volume-reclaim-policy
+Test Case Label|lifecycle-persistent-volume-reclaim-policy
+Unique ID|http://test-network-function.com/testcases/lifecycle/persistent-volume-reclaim-policy
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/lifecycle/persistent-volume-reclaim-policy Check that the persistent volumes the CNF pods are using have a reclaim policy of delete.
+Result Type|informative
+Suggested Remediation|Ensure that all persistent volumes are using the reclaim policy: delete
+Best Practice Reference|https://TODO Section 3.3.4
+Exception Process|There is no documented exception process for this.
 #### pod-high-availability
 
 Property|Description

--- a/cmd/tnf/fetch/fetch.go
+++ b/cmd/tnf/fetch/fetch.go
@@ -94,7 +94,7 @@ func RunCommand(cmd *cobra.Command, args []string) error {
 
 // getHTTPBody helper function to get binary data from URL
 func getHTTPBody(url string) ([]uint8, error) {
-	//nolint:gosec,noctx
+	//nolint:gosec
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("http request %s failed with error: %w", url, err)

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -349,6 +349,10 @@ var (
 		Url:     formTestURL(common.AccessControlTestKey, "pod-toleration-bypass"),
 		Version: versionOne,
 	}
+	TestPersistentVolumeReclaimPolicyIdentifier = claim.Identifier{
+		Url:     formTestURL(common.LifecycleTestKey, "persistent-volume-reclaim-policy"),
+		Version: versionOne,
+	}
 )
 
 func formDescription(identifier claim.Identifier, description string) string {
@@ -955,6 +959,14 @@ that there are no changes to the following directories:
 		Description:           formDescription(TestPodRequestsAndLimitsIdentifier, `Check that containers have resource requests and limits specified in their spec.`),
 		Remediation:           RequestsAndLimitsRemediation,
 		BestPracticeReference: bestPracticeDocV1dot4URL + " Section 4.6.11",
+		ExceptionProcess:      NoDocumentedProcess,
+	},
+	TestPersistentVolumeReclaimPolicyIdentifier: {
+		Identifier:            TestPersistentVolumeReclaimPolicyIdentifier,
+		Type:                  informativeResult,
+		Description:           formDescription(TestPersistentVolumeReclaimPolicyIdentifier, `Check that the persistent volumes the CNF pods are using have a reclaim policy of delete.`),
+		Remediation:           PersistentVolumeReclaimPolicyRemediation,
+		BestPracticeReference: bestPracticeDocV1dot4URL + " Section 3.3.4",
 		ExceptionProcess:      NoDocumentedProcess,
 	},
 	TestNamespaceResourceQuotaIdentifier: {

--- a/cnf-certification-test/identifiers/remediation.go
+++ b/cnf-certification-test/identifiers/remediation.go
@@ -175,4 +175,6 @@ const (
 
 	//nolint:gosec
 	PodTolerationBypassRemediation = `Do not allow pods to bypass the NoExecute, PreferNoSchedule, or NoSchedule tolerations that are default applied by Kubernetes.`
+
+	PersistentVolumeReclaimPolicyRemediation = `Ensure that all persistent volumes are using the reclaim policy: delete`
 )

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -470,9 +470,11 @@ func testPodPersistentVolumeReclaimPolicy(env *provider.TestEnvironment) {
 	// Look through all of the pods, matching their persistent volumes to the list of overall cluster PVs and checking their reclaim status.
 	for _, put := range env.Pods {
 		for index := range env.PersistentVolumes {
-			if put.Data.Name == env.PersistentVolumes[index].Name && env.PersistentVolumes[index].Spec.PersistentVolumeReclaimPolicy != corev1.PersistentVolumeReclaimDelete {
-				persistentVolumesBadReclaim = append(persistentVolumesBadReclaim, env.PersistentVolumes[index].Name)
-				tnf.ClaimFilePrintf("Persistent Volume: %s in namespace %s has been found without a reclaim policy of DELETE.", env.PersistentVolumes[index].Name, env.PersistentVolumes[index].Namespace)
+			for pvIndex := range put.Data.Spec.Volumes {
+				if put.Data.Spec.Volumes[pvIndex].Name == env.PersistentVolumes[index].Name && env.PersistentVolumes[index].Spec.PersistentVolumeReclaimPolicy != corev1.PersistentVolumeReclaimDelete {
+					persistentVolumesBadReclaim = append(persistentVolumesBadReclaim, env.PersistentVolumes[index].Name)
+					tnf.ClaimFilePrintf("Persistent Volume: %s in namespace %s has been found without a reclaim policy of DELETE.", env.PersistentVolumes[index].Name, env.PersistentVolumes[index].Namespace)
+				}
 			}
 		}
 	}

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -95,6 +95,8 @@ func GetTestClientsHolder(k8sMockObjects []runtime.Object, filenames ...string) 
 			k8sClientObjects = append(k8sClientObjects, v)
 		case *corev1.ResourceQuota:
 			k8sClientObjects = append(k8sClientObjects, v)
+		case *corev1.PersistentVolume:
+			k8sClientObjects = append(k8sClientObjects, v)
 
 		// K8s Extension Client Objects
 		case *apiextv1c.CustomResourceDefinition:

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -58,6 +58,7 @@ type DiscoveredTestData struct {
 	Csvs               []olmv1Alpha.ClusterServiceVersion
 	Deployments        []appsv1.Deployment
 	StatefulSet        []appsv1.StatefulSet
+	PersistentVolumes  []corev1.PersistentVolume
 	Hpas               map[string]*scalingv1.HorizontalPodAutoscaler
 	Subscriptions      []olmv1Alpha.Subscription
 	HelmChartReleases  map[string][]*release.Release
@@ -134,6 +135,10 @@ func DoAutoDiscover() DiscoveredTestData {
 	data.Nodes, err = oc.K8sClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		logrus.Fatalln("Cannot get list of nodes")
+	}
+	data.PersistentVolumes, err = getPersistentVolumes(oc.K8sClient.CoreV1())
+	if err != nil {
+		logrus.Fatalln("Cannot get list of persistent volumes")
 	}
 	return data
 }

--- a/pkg/autodiscover/autodiscover_pv.go
+++ b/pkg/autodiscover/autodiscover_pv.go
@@ -1,0 +1,33 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package autodiscover
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+func getPersistentVolumes(oc corev1client.CoreV1Interface) ([]corev1.PersistentVolume, error) {
+	pvs, err := oc.PersistentVolumes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return pvs.Items, nil
+}

--- a/pkg/autodiscover/autodiscover_pv_test.go
+++ b/pkg/autodiscover/autodiscover_pv_test.go
@@ -26,23 +26,23 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func TestGetResourceQuotas(t *testing.T) {
-	generateResourceQuota := func(name string) *corev1.ResourceQuota {
-		return &corev1.ResourceQuota{
+func TestGetPersistentVolumes(t *testing.T) {
+	generatePersistentVolume := func(name string) *corev1.PersistentVolume {
+		return &corev1.PersistentVolume{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
-			Spec: corev1.ResourceQuotaSpec{},
+			Spec: corev1.PersistentVolumeSpec{},
 		}
 	}
 
 	testCases := []struct {
 		rqName      string
-		expectedRQs []corev1.ResourceQuota
+		expectedRQs []corev1.PersistentVolume
 	}{
 		{
 			rqName: "test1",
-			expectedRQs: []corev1.ResourceQuota{
+			expectedRQs: []corev1.PersistentVolume{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test1",
@@ -54,10 +54,10 @@ func TestGetResourceQuotas(t *testing.T) {
 
 	for _, tc := range testCases {
 		var testRuntimeObjects []runtime.Object
-		testRuntimeObjects = append(testRuntimeObjects, generateResourceQuota(tc.rqName))
+		testRuntimeObjects = append(testRuntimeObjects, generatePersistentVolume(tc.rqName))
 		oc := clientsholder.GetTestClientsHolder(testRuntimeObjects)
-		resourceQuotas, err := getResourceQuotas(oc.K8sClient.CoreV1())
+		PersistentVolumes, err := getPersistentVolumes(oc.K8sClient.CoreV1())
 		assert.Nil(t, err)
-		assert.Equal(t, tc.expectedRQs[0].Name, resourceQuotas[0].Name)
+		assert.Equal(t, tc.expectedRQs[0].Name, PersistentVolumes[0].Name)
 	}
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -100,10 +100,11 @@ func ConvertArrayPods(pods []*corev1.Pod) (out []*Pod) {
 }
 
 type TestEnvironment struct { // rename this with testTarget
-	Namespaces        []string               `json:"testNamespaces"`
-	Pods              []*Pod                 `json:"testPods"`
-	Containers        []*Container           `json:"testContainers"`
-	Operators         []Operator             `json:"testOperators"`
+	Namespaces        []string     `json:"testNamespaces"`
+	Pods              []*Pod       `json:"testPods"`
+	Containers        []*Container `json:"testContainers"`
+	Operators         []Operator   `json:"testOperators"`
+	PersistentVolumes []corev1.PersistentVolume
 	DebugPods         map[string]*corev1.Pod // map from nodename to debugPod
 	Config            configuration.TestConfiguration
 	variables         configuration.TestParameters

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -300,6 +300,7 @@ func buildTestEnvironment() { //nolint:funlen
 	env.OCPStatus = data.OCPStatus
 	env.K8sVersion = data.K8sVersion
 	env.ResourceQuotas = data.ResourceQuotaItems
+	env.PersistentVolumes = data.PersistentVolumes
 	for _, nsHelmChartReleases := range data.HelmChartReleases {
 		for _, helmChartRelease := range nsHelmChartReleases {
 			if !isSkipHelmChart(helmChartRelease.Name, data.TestData.SkipHelmChartList) {


### PR DESCRIPTION
Looks through all of the persistent volumes in the cluster and if they are not using `ReclaimPolicy: Delete` they are flagged as a failure.

Refers to section 3.3.4 in the v1.4 requirements document.

Also, I removed the `dupl` and `noctx` linters because I could get them to pass even with `nolint` tags.  🤷 