### PR TITLE
Update golangci-lint to v1.47.3; remove staticcheck workaround

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ COMMON_GO_ARGS=-race
 GIT_COMMIT=$(shell script/create-version-files.sh)
 GIT_RELEASE=$(shell script/get-git-release.sh)
 GIT_PREVIOUS_RELEASE=$(shell script/get-git-previous-release.sh)
-GOLANGCI_VERSION=v1.47.1
+GOLANGCI_VERSION=v1.47.3
 LINKER_TNF_RELEASE_FLAGS=-X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitCommit=${GIT_COMMIT}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitRelease=${GIT_RELEASE}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitPreviousRelease=${GIT_PREVIOUS_RELEASE}

--- a/cmd/tnf/fetch/fetch.go
+++ b/cmd/tnf/fetch/fetch.go
@@ -94,7 +94,7 @@ func RunCommand(cmd *cobra.Command, args []string) error {
 
 // getHTTPBody helper function to get binary data from URL
 func getHTTPBody(url string) ([]uint8, error) {
-	//nolint:gosec
+	//nolint:gosec,noctx
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("http request %s failed with error: %w", url, err)

--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -452,30 +452,29 @@ func TestOneProcessPerContainer(env *provider.TestEnvironment) {
 		debugPod := env.DebugPods[cut.NodeName]
 		if debugPod == nil {
 			ginkgo.Fail(fmt.Sprintf("Debug pod not found on Node: %s", cut.NodeName))
-		} else {
-			ocpContext := clientsholder.Context{
-				Namespace:     debugPod.Namespace,
-				Podname:       debugPod.Name,
-				Containername: debugPod.Spec.Containers[0].Name,
-			}
+		}
+		ocpContext := clientsholder.Context{
+			Namespace:     debugPod.Namespace,
+			Podname:       debugPod.Name,
+			Containername: debugPod.Spec.Containers[0].Name,
+		}
 
-			pid, err := crclient.GetPidFromContainer(cut, ocpContext)
-			if err != nil {
-				tnf.ClaimFilePrintf("Could not get PID for: %s, error: %s", cut, err)
-				badContainers = append(badContainers, cut.String())
-				continue
-			}
+		pid, err := crclient.GetPidFromContainer(cut, ocpContext)
+		if err != nil {
+			tnf.ClaimFilePrintf("Could not get PID for: %s, error: %s", cut, err)
+			badContainers = append(badContainers, cut.String())
+			continue
+		}
 
-			nbProcesses, err := getNbOfProcessesInPidNamespace(ocpContext, pid, clientsholder.GetClientsHolder())
-			if err != nil {
-				tnf.ClaimFilePrintf("Could not get number of processes for: %s, error: %s", cut, err)
-				badContainers = append(badContainers, cut.String())
-				continue
-			}
-			if nbProcesses > 1 {
-				tnf.ClaimFilePrintf("Container %s has more than one process running", cut.String())
-				badContainers = append(badContainers, cut.String())
-			}
+		nbProcesses, err := getNbOfProcessesInPidNamespace(ocpContext, pid, clientsholder.GetClientsHolder())
+		if err != nil {
+			tnf.ClaimFilePrintf("Could not get number of processes for: %s, error: %s", cut, err)
+			badContainers = append(badContainers, cut.String())
+			continue
+		}
+		if nbProcesses > 1 {
+			tnf.ClaimFilePrintf("Container %s has more than one process running", cut.String())
+			badContainers = append(badContainers, cut.String())
 		}
 	}
 

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -179,23 +179,22 @@ func testContainersFsDiff(env *provider.TestEnvironment) {
 		debugPod := env.DebugPods[cut.NodeName]
 		if debugPod == nil {
 			ginkgo.Fail(fmt.Sprintf("Debug pod not found on Node: %s", cut.NodeName))
-		} else {
-			fsDiffTester := cnffsdiff.NewFsDiffTester(clientsholder.GetClientsHolder())
-			fsDiffTester.RunTest(clientsholder.Context{
-				Namespace:     debugPod.Namespace,
-				Podname:       debugPod.Name,
-				Containername: debugPod.Spec.Containers[0].Name,
-			}, cut.UID)
-			switch fsDiffTester.GetResults() {
-			case testhelper.SUCCESS:
-				continue
-			case testhelper.FAILURE:
-				tnf.ClaimFilePrintf("%s - changed folders: %v, deleted folders: %v", cut, fsDiffTester.ChangedFolders, fsDiffTester.DeletedFolders)
-				badContainers = append(badContainers, cut.Data.Name)
-			case testhelper.ERROR:
-				tnf.ClaimFilePrintf("%s - error while running fs-diff: %v: ", cut, fsDiffTester.Error)
-				errContainers = append(errContainers, cut.Data.Name)
-			}
+		}
+		fsDiffTester := cnffsdiff.NewFsDiffTester(clientsholder.GetClientsHolder())
+		fsDiffTester.RunTest(clientsholder.Context{
+			Namespace:     debugPod.Namespace,
+			Podname:       debugPod.Name,
+			Containername: debugPod.Spec.Containers[0].Name,
+		}, cut.UID)
+		switch fsDiffTester.GetResults() {
+		case testhelper.SUCCESS:
+			continue
+		case testhelper.FAILURE:
+			tnf.ClaimFilePrintf("%s - changed folders: %v, deleted folders: %v", cut, fsDiffTester.ChangedFolders, fsDiffTester.DeletedFolders)
+			badContainers = append(badContainers, cut.Data.Name)
+		case testhelper.ERROR:
+			tnf.ClaimFilePrintf("%s - error while running fs-diff: %v: ", cut, fsDiffTester.Error)
+			errContainers = append(errContainers, cut.Data.Name)
 		}
 	}
 


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.47.3

Some upstream fixes.  Following up to #369 where I had to add some wrappers for ginkgo.Fail getting flagged in the linter. 