### PR TITLE
Add scenario-based labeling

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -48,6 +48,11 @@ type AcceptedKernelTaintsInfo struct {
 	Module string `yaml:"module" json:"module"`
 }
 
+// TestScenarioLabels will help determine which set of tests we want to run for different types of scenarios
+type TestScenarioLabels struct {
+	Scenario string `yaml:"scenario" json:"scenario"`
+}
+
 // Label ns/name/value for resource lookup
 type Label struct {
 	Prefix string `yaml:"prefix" json:"prefix"`
@@ -98,6 +103,8 @@ type TestConfiguration struct {
 	SkipHelmChartList    []SkipHelmChartList        `yaml:"skipHelmChartList" json:"skipHelmChartList"`
 	// CheckDiscoveredContainerCertificationStatus controls whether the container certification test will validate images used by autodiscovered containers, in addition to the configured image list
 	CheckDiscoveredContainerCertificationStatus bool `yaml:"checkDiscoveredContainerCertificationStatus" json:"checkDiscoveredContainerCertificationStatus"`
+	// Scenarios is a configurable set of labels that are applied to certain tests that only desired ran in certain scenarios
+	Scenarios []TestScenarioLabels `yaml:"scenarioLabels,omitempty" json:"scenarioLabels,omitempty"`
 }
 
 type TestParameters struct {


### PR DESCRIPTION
We have been discussing how we could potentially break up some of the test cases to only run in certain scenarios where they are deemed applicable.  For example, there could be two separate CNF workloads "xyz" and "abc" that might have certain requirements as far as tests but they also might have tests that overlap.  We should be able to label individual tests to belong to certain scenarios/CNFs (DU, CU, etc) and let them be configurable.

Marked WIP for discussion.

See https://github.com/test-network-function/test-network-function-claim/pull/57

I am updating the -claim repo to add a `tags` section into the `Identifier` struct.  This will let us be able to define certain tags/scenarios for when each test is ran.