### PR TITLE
Add QE failure to unit tests for tolerations

### DIFF
--- a/cnf-certification-test/accesscontrol/tolerations/tolerations_test.go
+++ b/cnf-certification-test/accesscontrol/tolerations/tolerations_test.go
@@ -78,6 +78,14 @@ func TestIsTolerationModified(t *testing.T) {
 			},
 			expectedOutput: false,
 		},
+		{ // Test Case #6 - example from QE
+			testToleration: v1.Toleration{
+				Key:      "node.kubernetes.io/memory-pressure",
+				Operator: v1.TolerationOpExists,
+				Effect:   v1.TaintEffectNoSchedule,
+			},
+			expectedOutput: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
QE has been running the new toleration test added in #365 and has been hitting a failure because pods have:

```
// - effect: NoSchedule
//   key: node.kubernetes.io/memory-pressure
//   operator: Exists
```