### PR TITLE
Fix capitalization in 'OpenShift'

### DIFF
--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -864,7 +864,7 @@ that there are no changes to the following directories:
 		Identifier: TestOCPReservedPortsUsage,
 		Type:       normativeResult,
 		Description: formDescription(TestOCPReservedPortsUsage,
-			`Check that containers do not listen on ports that are reserved by Openshift`),
+			`Check that containers do not listen on ports that are reserved by OpenShift`),
 		Remediation:           OCPReservedPortsUsageRemediation,
 		BestPracticeReference: bestPracticeDocV1dot4URL + " Section 3.5.9",
 		ExceptionProcess:      NoDocumentedProcess,

--- a/cnf-certification-test/identifiers/remediation.go
+++ b/cnf-certification-test/identifiers/remediation.go
@@ -167,7 +167,7 @@ const (
 
 	SYSNiceRealtimeCapabilityRemediation = `If pods are scheduled to realtime kernel nodes, they must add SYS_NICE capability to their spec.`
 
-	OCPReservedPortsUsageRemediation = `Ensure that CNF apps do not listen on ports that are reserved by Openshift`
+	OCPReservedPortsUsageRemediation = `Ensure that CNF apps do not listen on ports that are reserved by OpenShift`
 
 	RequestsAndLimitsRemediation = `Add requests and limits to your container spec.  See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits`
 

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -188,7 +188,7 @@ func testNetworkConnectivity(env *provider.TestEnvironment, aIPVersion netcommon
 
 //nolint:funlen
 func testOCPReservedPortsUsage(env *provider.TestEnvironment) {
-	// List of all ports reserved by Openshift
+	// List of all ports reserved by OpenShift
 	OCPReservedPorts := map[int32]bool{22623: true, 22624: true}
 
 	var failedContainers int
@@ -199,7 +199,7 @@ func testOCPReservedPortsUsage(env *provider.TestEnvironment) {
 	for _, cut := range env.Containers {
 		for _, port := range cut.Data.Ports {
 			if OCPReservedPorts[port.ContainerPort] {
-				tnf.ClaimFilePrintf("%s has declared a port (%d) reserved by Openshift", cut, port.ContainerPort)
+				tnf.ClaimFilePrintf("%s has declared a port (%d) reserved by OpenShift", cut, port.ContainerPort)
 				rogueContainers = append(rogueContainers, cut.String())
 				break
 			}
@@ -218,7 +218,7 @@ func testOCPReservedPortsUsage(env *provider.TestEnvironment) {
 		}
 		for port := range listeningPorts {
 			if OCPReservedPorts[int32(port.PortNumber)] {
-				tnf.ClaimFilePrintf("%s has one container listening on port %d reserved by Openshift", put, port.PortNumber)
+				tnf.ClaimFilePrintf("%s has one container listening on port %d reserved by OpenShift", put, port.PortNumber)
 				roguePods = append(roguePods, put.String())
 				break
 			}
@@ -226,13 +226,13 @@ func testOCPReservedPortsUsage(env *provider.TestEnvironment) {
 	}
 
 	if n := len(rogueContainers); n > 0 {
-		errMsg := fmt.Sprintf("Number of containers declaring ports reserved by Openshift: %d", n)
+		errMsg := fmt.Sprintf("Number of containers declaring ports reserved by OpenShift: %d", n)
 		tnf.ClaimFilePrintf(errMsg)
 		ginkgo.Fail(errMsg)
 	}
 
 	if n := len(roguePods); n > 0 {
-		errMsg := fmt.Sprintf("Number of pods having one or more containers listening on ports reserved by Openshift: %d", n)
+		errMsg := fmt.Sprintf("Number of pods having one or more containers listening on ports reserved by OpenShift: %d", n)
 		tnf.ClaimFilePrintf(errMsg)
 		ginkgo.Fail(errMsg)
 	}

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -184,7 +184,7 @@ func GetVersionK8s() (out string) {
 func GetVersionOcp() (out string) {
 	env := provider.GetTestEnvironment()
 	if env.OpenshiftVersion == "" {
-		return "n/a, (non-Openshift cluster)" //nolint:goconst
+		return "n/a, (non-OpenShift cluster)" //nolint:goconst
 	}
 	return env.OpenshiftVersion
 }


### PR DESCRIPTION
I wanted to fix the inconsistency between the capitalization of the word `OpenShift` to better align with the naming convention used by the rest of the docs.

`Openshift --> OpenShift`