### PR TITLE
Do not fail if memory-pressure toleration is present and qosClass is different than BestEffort

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -579,7 +579,8 @@ func TestPodTolerationBypass(env *provider.TestEnvironment) {
 	for _, put := range env.Pods {
 		for _, t := range put.Data.Spec.Tolerations {
 			// Check if the tolerations fall outside the 'default' and are modified versions
-			if tolerations.IsTolerationModified(t) {
+			// Take also into account the qosClass applied to the pod
+			if tolerations.IsTolerationModified(t, put.Data.Status.QOSClass) {
 				podsWithRestrictedTolerationsNotDefault = append(podsWithRestrictedTolerationsNotDefault, put.String())
 				tnf.ClaimFilePrintf("%s has been found with non-default toleration %s which is not allowed.", put.String(), t.Effect)
 			}

--- a/cnf-certification-test/accesscontrol/tolerations/tolerations.go
+++ b/cnf-certification-test/accesscontrol/tolerations/tolerations.go
@@ -55,7 +55,7 @@ func IsTolerationModified(t v1.Toleration, qosClass v1.PodQOSClass) bool {
 		// If toleration is NoSchedule - node.kubernetes.io/memory-pressure - Exists and the QoS class for
 		// the pod is different than BestEffort, it is also a default toleration added by k8s
 		if (t.Key == memoryPressureStr) &&
-			(t.Operator == v1.TolerationOpExists && t.TolerationSeconds == nil) &&
+			(t.Operator == v1.TolerationOpExists) &&
 			(qosClass != v1.PodQOSBestEffort) {
 			return false
 		}

--- a/cnf-certification-test/accesscontrol/tolerations/tolerations.go
+++ b/cnf-certification-test/accesscontrol/tolerations/tolerations.go
@@ -50,11 +50,13 @@ func IsTolerationModified(t v1.Toleration, qosClass v1.PodQOSClass) bool {
 		if t.Key == notReadyStr || t.Key == unreachableStr &&
 			(t.Operator == v1.TolerationOpExists && t.TolerationSeconds != nil && *t.TolerationSeconds == int64(tolerationSecondsDefault)) {
 			return false
-		} else if (t.Key == memoryPressureStr) &&
+		}
+	} else if t.Effect == v1.TaintEffectNoSchedule {
+		// If toleration is NoSchedule - node.kubernetes.io/memory-pressure - Exists and the QoS class for
+		// the pod is different than BestEffort, it is also a default toleration added by k8s
+		if (t.Key == memoryPressureStr) &&
 			(t.Operator == v1.TolerationOpExists && t.TolerationSeconds == nil) &&
 			(qosClass != v1.PodQOSBestEffort) {
-			// If toleration is NoSchedule - node.kubernetes.io/memory-pressure - Exists and the QoS class for
-			// the pod is different than BestEffort, it is also a default toleration added by k8s
 			return false
 		}
 	}

--- a/cnf-certification-test/accesscontrol/tolerations/tolerations.go
+++ b/cnf-certification-test/accesscontrol/tolerations/tolerations.go
@@ -25,10 +25,11 @@ var (
 	tolerationSecondsDefault = 300
 )
 
-func IsTolerationModified(t v1.Toleration) bool {
+func IsTolerationModified(t v1.Toleration, qosClass v1.PodQOSClass) bool {
 	const (
-		notReadyStr    = "node.kubernetes.io/not-ready"
-		unreachableStr = "node.kubernetes.io/unreachable"
+		notReadyStr       = "node.kubernetes.io/not-ready"
+		unreachableStr    = "node.kubernetes.io/unreachable"
+		memoryPressureStr = "node.kubernetes.io/memory-pressure"
 	)
 	// Check each of the tolerations to make sure they are the default tolerations added by k8s:
 	// tolerations:
@@ -40,10 +41,20 @@ func IsTolerationModified(t v1.Toleration) bool {
 	//   key: node.kubernetes.io/unreachable
 	//   operator: Exists
 	//   tolerationSeconds: 300
+	// # this last one, only if QoS class for the pod is different than BestEffort
+	// - effect: NoSchedule
+	//   key: node.kubernetes.io/memory-pressure
+	//   operator: Exists
 
 	if t.Effect == v1.TaintEffectNoExecute {
 		if t.Key == notReadyStr || t.Key == unreachableStr &&
 			(t.Operator == v1.TolerationOpExists && t.TolerationSeconds != nil && *t.TolerationSeconds == int64(tolerationSecondsDefault)) {
+			return false
+		} else if (t.Key == memoryPressureStr) &&
+			(t.Operator == v1.TolerationOpExists && t.TolerationSeconds == nil) &&
+			(qosClass != v1.PodQOSBestEffort) {
+			// If toleration is NoSchedule - node.kubernetes.io/memory-pressure - Exists and the QoS class for
+			// the pod is different than BestEffort, it is also a default toleration added by k8s
 			return false
 		}
 	}

--- a/cnf-certification-test/accesscontrol/tolerations/tolerations_test.go
+++ b/cnf-certification-test/accesscontrol/tolerations/tolerations_test.go
@@ -32,6 +32,7 @@ func TestIsTolerationModified(t *testing.T) {
 	testCases := []struct {
 		testToleration v1.Toleration
 		expectedOutput bool
+		qosClass       v1.PodQOSClass
 	}{
 		{ // Test Case #1 - default not-ready toleration
 			testToleration: v1.Toleration{
@@ -41,6 +42,7 @@ func TestIsTolerationModified(t *testing.T) {
 				TolerationSeconds: getInt64Pointer(300),
 			},
 			expectedOutput: false,
+			qosClass:       v1.PodQOSGuaranteed,
 		},
 		{ // Test Case #2 - default unreachable toleration
 			testToleration: v1.Toleration{
@@ -50,6 +52,7 @@ func TestIsTolerationModified(t *testing.T) {
 				TolerationSeconds: getInt64Pointer(300),
 			},
 			expectedOutput: false,
+			qosClass:       v1.PodQOSGuaranteed,
 		},
 		{ // Test Case #3 - modified unreachable toleration
 			testToleration: v1.Toleration{
@@ -59,6 +62,7 @@ func TestIsTolerationModified(t *testing.T) {
 				TolerationSeconds: getInt64Pointer(350), // modified from 300
 			},
 			expectedOutput: true,
+			qosClass:       v1.PodQOSGuaranteed,
 		},
 		{ // Test Case #4 - modified unreachable toleration
 			testToleration: v1.Toleration{
@@ -68,6 +72,7 @@ func TestIsTolerationModified(t *testing.T) {
 				TolerationSeconds: getInt64Pointer(300),
 			},
 			expectedOutput: true,
+			qosClass:       v1.PodQOSGuaranteed,
 		},
 		{ // Test Case #5 - missing effect
 			testToleration: v1.Toleration{
@@ -77,10 +82,32 @@ func TestIsTolerationModified(t *testing.T) {
 				TolerationSeconds: getInt64Pointer(300),
 			},
 			expectedOutput: false,
+			qosClass:       v1.PodQOSGuaranteed,
+		},
+		{ // Test Case #6 - example from QE and DCI - this should pass only if qosClass is
+			// different than BestEffort, which is the case
+			testToleration: v1.Toleration{
+				Key:      "node.kubernetes.io/memory-pressure",
+				Operator: v1.TolerationOpExists,
+				Effect:   v1.TaintEffectNoSchedule,
+			},
+			expectedOutput: false,
+			qosClass:       v1.PodQOSGuaranteed,
+		},
+		{ // Test Case #7 - example from QE and DCI - however, if qosClass is BestEffort, it
+			// must be considered as a modified toleration
+			testToleration: v1.Toleration{
+				Key:      "node.kubernetes.io/memory-pressure",
+				Operator: v1.TolerationOpExists,
+				Effect:   v1.TaintEffectNoSchedule,
+			},
+			expectedOutput: true,
+			qosClass:       v1.PodQOSBestEffort,
 		},
 	}
 
 	for _, tc := range testCases {
-		assert.Equal(t, tc.expectedOutput, IsTolerationModified(tc.testToleration))
+		// Testing with Guaranteed qosClass
+		assert.Equal(t, tc.expectedOutput, IsTolerationModified(tc.testToleration, tc.qosClass))
 	}
 }

--- a/cnf-certification-test/accesscontrol/tolerations/tolerations_test.go
+++ b/cnf-certification-test/accesscontrol/tolerations/tolerations_test.go
@@ -107,7 +107,6 @@ func TestIsTolerationModified(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		// Testing with Guaranteed qosClass
 		assert.Equal(t, tc.expectedOutput, IsTolerationModified(tc.testToleration, tc.qosClass))
 	}
 }


### PR DESCRIPTION
**Context**

In [this change](https://github.com/test-network-function/cnf-certification-test/pull/407), it was discussed that there is a toleration that seems to be added by k8s and is not being treated by the `access-control-pod-toleration-bypass`, so that it is not considered as a modified toleration.

The reason why this memory-issue toleration is appearing is because QoS class applied to the pods under test. If resource limits (for CPU and RAM) are defined, according to this [k8s docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#taint-nodes-by-condition), it is said that "The control plane also adds the node.kubernetes.io/memory-pressure toleration on pods that have a [QoS class](https://kubernetes.io/docs/reference/glossary/?all=true#term-qos-class) other than BestEffort".

So, if the QoS class applied to the pod is different than BestEffort, this toleration should not be considered as modified and the access-control test must pass in that case.

**Changes included**

- Include QoSClass as a parameter to be interpreted by toleration check
- Also consider that a toleration is not modified if we have NoSchedule - memory-pressure toleration with QoS class different than BestEffort, following k8s docs
- New unit tests