### PR TITLE
Add test for deny-all network policy

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -59,6 +59,19 @@ Result Type|informative
 Suggested Remediation|Apply a ResourceQuota to the namespace your CNF is running in
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 4.6.8
 Exception Process|There is no documented exception process for this.
+#### network-policy-deny-all
+
+Property|Description
+---|---
+Test Case Name|network-policy-deny-all
+Test Case Label|access-control-network-policy-deny-all
+Unique ID|http://test-network-function.com/testcases/access-control/network-policy-deny-all
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/access-control/network-policy-deny-all Check that network policies attached to namespaces running CNF pods contain a default deny-all rule for both ingress and egress traffic
+Result Type|informative
+Suggested Remediation|Ensure that a NetworkPolicy with a default deny-all is applied. After the default is applied, apply a network policy to allow the traffic your application requires.
+Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 10.6
+Exception Process|There is no documented exception process for this.
 #### one-process-per-container
 
 Property|Description

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -498,6 +498,7 @@ var (
 	TestNetworkPolicyDenyAllIdentifier = claim.Identifier{
 		Url:     formTestURL(common.AccessControlTestKey, "network-policy-deny-all"),
 		Version: versionOne,
+		Tags:    formTestTags(tagCommon),
 	}
 )
 

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -495,6 +495,10 @@ var (
 		Url:     formTestURL(common.AccessControlTestKey, "ssh-daemons"),
 		Version: versionOne,
 	}
+	TestNetworkPolicyDenyAllIdentifier = claim.Identifier{
+		Url:     formTestURL(common.AccessControlTestKey, "network-policy-deny-all"),
+		Version: versionOne,
+	}
 )
 
 func formDescription(identifier claim.Identifier, description string) string {
@@ -1172,6 +1176,14 @@ that there are no changes to the following directories:
 		Description:           formDescription(TestNoSSHDaemonsAllowedIdentifier, `Check that pods do not run SSH daemons.`),
 		Remediation:           NoSSHDaemonsAllowedRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 4.6.12", // TODO Change this to v1.4 when available
+		ExceptionProcess:      NoDocumentedProcess,
+	},
+	TestNetworkPolicyDenyAllIdentifier: {
+		Identifier:            TestNetworkPolicyDenyAllIdentifier,
+		Type:                  informativeResult,
+		Description:           formDescription(TestNetworkPolicyDenyAllIdentifier, `Check that network policies attached to namespaces running CNF pods contain a default deny-all rule for both ingress and egress traffic`),
+		Remediation:           NetworkPolicyDenyAllRemediation,
+		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 10.6",
 		ExceptionProcess:      NoDocumentedProcess,
 	},
 }

--- a/cnf-certification-test/identifiers/remediation.go
+++ b/cnf-certification-test/identifiers/remediation.go
@@ -189,4 +189,6 @@ const (
 	ContainersImageTag = `Ensure that all the container images are tagged`
 
 	NoSSHDaemonsAllowedRemediation = `Ensure that no SSH daemons are running inside a pod`
+
+	NetworkPolicyDenyAllRemediation = `Ensure that a NetworkPolicy with a default deny-all is applied. After the default is applied, apply a network policy to allow the traffic your application requires.`
 )

--- a/cnf-certification-test/networking/policies/policies.go
+++ b/cnf-certification-test/networking/policies/policies.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package policies
+
+import (
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+func IsNetworkPolicyDenyAll(np *networkingv1.NetworkPolicy) (bool, []networkingv1.PolicyType) {
+	if len(np.Spec.PodSelector.MatchLabels) != 0 {
+		return false, nil
+	}
+
+	// As long as we have decided above that there is no pod selector,
+	// we just have to make sure that the policy type is either Ingress or Egress (or both) we can return true.
+	// For more information about deny-all policies, there are some good examples on:
+	// https://kubernetes.io/docs/concepts/services-networking/network-policies/
+
+	if len(np.Spec.PolicyTypes) == 0 {
+		return false, nil
+	}
+
+	// Ingress and Egress rules should be "empty" if it is a default rule.
+	if np.Spec.Egress != nil {
+		return false, nil
+	}
+	if np.Spec.Ingress != nil {
+		return false, nil
+	}
+
+	return true, np.Spec.PolicyTypes
+}

--- a/cnf-certification-test/networking/policies/policies.go
+++ b/cnf-certification-test/networking/policies/policies.go
@@ -18,13 +18,10 @@ package policies
 
 import (
 	networkingv1 "k8s.io/api/networking/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func IsNetworkPolicyDenyAll(np *networkingv1.NetworkPolicy) (bool, []networkingv1.PolicyType) {
-	if len(np.Spec.PodSelector.MatchLabels) != 0 {
-		return false, nil
-	}
-
 	// As long as we have decided above that there is no pod selector,
 	// we just have to make sure that the policy type is either Ingress or Egress (or both) we can return true.
 	// For more information about deny-all policies, there are some good examples on:
@@ -43,4 +40,21 @@ func IsNetworkPolicyDenyAll(np *networkingv1.NetworkPolicy) (bool, []networkingv
 	}
 
 	return true, np.Spec.PolicyTypes
+}
+
+func LabelsMatch(podSelectorLabels v1.LabelSelector, podLabels map[string]string) bool {
+	labelMatch := false
+	for psLabelKey, psLabelValue := range podSelectorLabels.MatchLabels {
+		for podLabelKey, podLabelValue := range podLabels {
+			if psLabelKey == podLabelKey && psLabelValue == podLabelValue {
+				labelMatch = true
+				break
+			}
+		}
+		if labelMatch {
+			break
+		}
+	}
+
+	return labelMatch
 }

--- a/cnf-certification-test/networking/policies/policies.go
+++ b/cnf-certification-test/networking/policies/policies.go
@@ -17,44 +17,47 @@
 package policies
 
 import (
-	"errors"
-
+	"github.com/sirupsen/logrus"
 	networkingv1 "k8s.io/api/networking/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func IsNetworkPolicyCompliant(np *networkingv1.NetworkPolicy, policyType networkingv1.PolicyType) error {
+func IsNetworkPolicyCompliant(np *networkingv1.NetworkPolicy, policyType networkingv1.PolicyType) bool {
 	// As long as we have decided above that there is no pod selector,
 	// we just have to make sure that the policy type is either Ingress or Egress (or both) we can return true.
 	// For more information about deny-all policies, there are some good examples on:
 	// https://kubernetes.io/docs/concepts/services-networking/network-policies/
 
 	if len(np.Spec.PolicyTypes) == 0 {
-		return errors.New("PolicyTypes is empty")
+		logrus.Debugf("%s: policy types found empty", np.Name)
+		return false
 	}
 
 	// Ingress and Egress rules should be "empty" if it is a default rule.
-	if np.Spec.Egress != nil {
-		return errors.New("egress spec is not empty")
-	}
-	if np.Spec.Ingress != nil {
-		return errors.New("ingress spec is not empty")
-	}
-
-	policyTypeFound := false
-
-	// Look through the returned policies to make sure they include both ingress and egress.
-	for _, p := range np.Spec.PolicyTypes {
-		if p == policyType {
-			policyTypeFound = true
+	if policyType == networkingv1.PolicyTypeEgress {
+		if np.Spec.Egress != nil || len(np.Spec.Egress) > 0 {
+			logrus.Debugf("%s: egress spec found not empty", np.Name)
+			return false
 		}
 	}
 
-	if !policyTypeFound {
-		return errors.New("deny all network policy not found")
+	if policyType == networkingv1.PolicyTypeIngress {
+		if np.Spec.Ingress != nil || len(np.Spec.Ingress) > 0 {
+			logrus.Debugf("%s: ingress spec found not empty", np.Name)
+			return false
+		}
 	}
 
-	return nil
+	policyTypeFound := false
+	// Look through the returned policies to see if they match the desired policyType
+	for _, p := range np.Spec.PolicyTypes {
+		if p == policyType {
+			policyTypeFound = true
+			break
+		}
+	}
+
+	return policyTypeFound
 }
 
 func LabelsMatch(podSelectorLabels v1.LabelSelector, podLabels map[string]string) bool {

--- a/cnf-certification-test/networking/policies/policies_test.go
+++ b/cnf-certification-test/networking/policies/policies_test.go
@@ -45,7 +45,13 @@ func TestIsNetworkPolicyDenyAll(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test1",
 				},
-				Spec: networkingv1.NetworkPolicySpec{},
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"key1": "value1",
+						},
+					},
+				},
 			},
 			expectedPolicies: nil,
 			expectedOutput:   false,
@@ -56,7 +62,11 @@ func TestIsNetworkPolicyDenyAll(t *testing.T) {
 					Name: "test2",
 				},
 				Spec: networkingv1.NetworkPolicySpec{
-					PodSelector: metav1.LabelSelector{},
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"key1": "value1",
+						},
+					},
 					PolicyTypes: []networkingv1.PolicyType{
 						networkingv1.PolicyTypeEgress,
 						networkingv1.PolicyTypeIngress,

--- a/cnf-certification-test/networking/policies/policies_test.go
+++ b/cnf-certification-test/networking/policies/policies_test.go
@@ -1,0 +1,82 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package policies
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+//nolint:funlen
+func TestIsNetworkPolicyDenyAll(t *testing.T) {
+	policyInSlice := func(s []networkingv1.PolicyType, pt networkingv1.PolicyType) bool {
+		for _, v := range s {
+			if v == pt {
+				return true
+			}
+		}
+		return false
+	}
+
+	testCases := []struct {
+		testNP           networkingv1.NetworkPolicy
+		expectedPolicies []networkingv1.PolicyType
+		expectedOutput   bool
+	}{
+		{ // Test #1 - Network Policy with no label selector, no policy types, fails.
+			testNP: networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test1",
+				},
+				Spec: networkingv1.NetworkPolicySpec{},
+			},
+			expectedPolicies: nil,
+			expectedOutput:   false,
+		},
+		{ // Test #2 - Network Policy with label selector, and both ingress/egress policy types
+			testNP: networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test2",
+				},
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{},
+					PolicyTypes: []networkingv1.PolicyType{
+						networkingv1.PolicyTypeEgress,
+						networkingv1.PolicyTypeIngress,
+					},
+				},
+			},
+			expectedPolicies: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeEgress,
+				networkingv1.PolicyTypeIngress,
+			},
+			expectedOutput: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		result, policyResult := IsNetworkPolicyDenyAll(&tc.testNP)
+		assert.Equal(t, tc.expectedOutput, result)
+
+		for _, pr := range policyResult {
+			assert.True(t, policyInSlice(tc.expectedPolicies, pr))
+		}
+	}
+}

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -321,7 +321,6 @@ func testIsIPTablesConfigPresent(env *provider.TestEnvironment) {
 	testIsConfigPresent(env, ip6Tables)
 }
 
-//nolint:funlen
 func testNetworkPolicyDenyAll(env *provider.TestEnvironment) {
 	ginkgo.By("Test for Deny All in network policies")
 	var podsMissingDenyAllDefaultPolicies []string
@@ -344,18 +343,11 @@ func testNetworkPolicyDenyAll(env *provider.TestEnvironment) {
 
 			// Match the pod namespace with the network policy namespace.
 			if policies.LabelsMatch(env.NetworkPolicies[index].Spec.PodSelector, put.Data.Labels) {
-				// Check if compliant for egress network policy
-				if err := policies.IsNetworkPolicyCompliant(&env.NetworkPolicies[index], networkingv1.PolicyTypeEgress); err != nil {
-					logrus.Error(err)
-				} else {
-					denyAllEgressFound = true
+				if !denyAllEgressFound {
+					denyAllEgressFound = policies.IsNetworkPolicyCompliant(&env.NetworkPolicies[index], networkingv1.PolicyTypeEgress)
 				}
-
-				// Check if compliant for ingress network policy
-				if err := policies.IsNetworkPolicyCompliant(&env.NetworkPolicies[index], networkingv1.PolicyTypeIngress); err != nil {
-					logrus.Error(err)
-				} else {
-					denyAllIngressFound = true
+				if !denyAllIngressFound {
+					denyAllIngressFound = policies.IsNetworkPolicyCompliant(&env.NetworkPolicies[index], networkingv1.PolicyTypeIngress)
 				}
 			}
 		}

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -37,19 +37,21 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextv1fake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	k8sFakeClient "k8s.io/client-go/kubernetes/fake"
+	networkingv1 "k8s.io/client-go/kubernetes/typed/networking/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 type ClientsHolder struct {
-	RestConfig    *rest.Config
-	DynamicClient dynamic.Interface
-	APIExtClient  apiextv1.Interface
-	OlmClient     olmClient.Interface
-	OcpClient     clientconfigv1.ConfigV1Interface
-	K8sClient     kubernetes.Interface
-	MachineCfg    ocpMachine.Interface
-	ready         bool
+	RestConfig          *rest.Config
+	DynamicClient       dynamic.Interface
+	APIExtClient        apiextv1.Interface
+	OlmClient           olmClient.Interface
+	OcpClient           clientconfigv1.ConfigV1Interface
+	K8sClient           kubernetes.Interface
+	K8sNetworkingClient networkingv1.NetworkingV1Interface
+	MachineCfg          ocpMachine.Interface
+	ready               bool
 }
 
 var clientsHolder = ClientsHolder{}
@@ -181,6 +183,10 @@ func newClientsHolder(filenames ...string) (*ClientsHolder, error) { //nolint:fu
 	clientsHolder.MachineCfg, err = ocpMachine.NewForConfig(clientsHolder.RestConfig)
 	if err != nil {
 		return nil, fmt.Errorf("cannot instantiate MachineCfg client: %s", err)
+	}
+	clientsHolder.K8sNetworkingClient, err = networkingv1.NewForConfig(clientsHolder.RestConfig)
+	if err != nil {
+		return nil, fmt.Errorf("cannot instantiate k8s networking client: %s", err)
 	}
 	clientsHolder.ready = true
 	return &clientsHolder, nil

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -33,6 +33,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	scalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -55,6 +56,7 @@ type DiscoveredTestData struct {
 	DebugPods            []corev1.Pod
 	ResourceQuotaItems   []corev1.ResourceQuota
 	PodDisruptionBudgets []policyv1.PodDisruptionBudget
+	NetworkPolicies      []networkingv1.NetworkPolicy
 	Crds                 []*apiextv1.CustomResourceDefinition
 	Namespaces           []string
 	Csvs                 []olmv1Alpha.ClusterServiceVersion
@@ -120,6 +122,10 @@ func DoAutoDiscover() DiscoveredTestData {
 	data.PodDisruptionBudgets, err = getPodDisruptionBudgets(oc.K8sClient.PolicyV1(), data.Namespaces)
 	if err != nil {
 		logrus.Fatalln("Cannot get pod disruption budgets")
+	}
+	data.NetworkPolicies, err = getNetworkPolicies(oc.K8sNetworkingClient)
+	if err != nil {
+		logrus.Fatalln("Cannot get network policies")
 	}
 	data.Crds = FindTestCrdNames(data.TestData.CrdFilters)
 	data.Csvs = findOperatorsByLabel(oc.OlmClient, []configuration.Label{{Name: tnfCsvTargetLabelName, Prefix: tnfLabelPrefix, Value: tnfCsvTargetLabelValue}}, data.TestData.TargetNameSpaces)

--- a/pkg/autodiscover/autodiscover_networkpolicies.go
+++ b/pkg/autodiscover/autodiscover_networkpolicies.go
@@ -1,0 +1,33 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package autodiscover
+
+import (
+	"context"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	networkingv1client "k8s.io/client-go/kubernetes/typed/networking/v1"
+)
+
+func getNetworkPolicies(oc networkingv1client.NetworkingV1Interface) ([]networkingv1.NetworkPolicy, error) {
+	nps, err := oc.NetworkPolicies("").List(context.TODO(), v1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return nps.Items, nil
+}

--- a/pkg/autodiscover/autodiscover_networkpolicies_test.go
+++ b/pkg/autodiscover/autodiscover_networkpolicies_test.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package autodiscover

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -39,6 +39,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	scalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -121,6 +122,7 @@ type TestEnvironment struct { // rename this with testTarget
 	HelmChartReleases    []*release.Release                            `json:"testHelmChartReleases"`
 	ResourceQuotas       []corev1.ResourceQuota
 	PodDisruptionBudgets []policyv1.PodDisruptionBudget
+	NetworkPolicies      []networkingv1.NetworkPolicy
 	IstioServiceMesh     bool
 }
 
@@ -306,6 +308,7 @@ func buildTestEnvironment() { //nolint:funlen
 	env.PodDisruptionBudgets = data.PodDisruptionBudgets
 	env.PersistentVolumes = data.PersistentVolumes
 	env.Services = data.Services
+	env.NetworkPolicies = data.NetworkPolicies
 	for _, nsHelmChartReleases := range data.HelmChartReleases {
 		for _, helmChartRelease := range nsHelmChartReleases {
 			if !isSkipHelmChart(helmChartRelease.Name, data.TestData.SkipHelmChartList) {


### PR DESCRIPTION
build-depends: 25993

Depends on: https://github.com/test-network-function/cnf-certification-test-partner/pull/144

Adds a test to make sure that any network policies attached to namespaces running CNF workloads have a default `deny-all` type of network policy for both ingress and egress traffic.

This requires work on the side of the partner running their CNF workload to make sure they have not only a default network policy but a policy that allows the traffic that they need specifically.  Eg. allowing pods in a single namespace to talk to each other.