### PR TITLE
Remove deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - errcheck
@@ -81,7 +80,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
   # do not enable:
   # - asciicheck


### PR DESCRIPTION
```
$ make lint
golangci-lint run --timeout 10m0s
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
```