### PR TITLE
Manually bump Ginkgo to v2.1.5

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -145,7 +145,7 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Install ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.4
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.5
 
       - name: Execute `make build`
         run: make build

--- a/.github/workflows/update-certification.yml
+++ b/.github/workflows/update-certification.yml
@@ -30,7 +30,7 @@ jobs:
           ref: main
 
       - name: Install ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.4
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.5
 
       - name: Execute `make build`
         run: make build

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ build-cnf-tests-debug:
 
 # Install build tools and other required software.
 install-tools:
-	go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.4
+	go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.5
 
 # Install golangci-lint	
 install-lint:


### PR DESCRIPTION
https://github.com/test-network-function/cnf-certification-test/pull/463 bumped the go.mod, needs a manual change for the other references.