### PR TITLE
Add fix for the sysctlCommand in sysctl-config tc

### DIFF
--- a/cnf-certification-test/platform/sysctlconfig/sysctlconfig.go
+++ b/cnf-certification-test/platform/sysctlconfig/sysctlconfig.go
@@ -48,7 +48,7 @@ func parseSysctlSystemOutput(sysctlSystemOutput string) map[string]string {
 
 func GetSysctlSettings(env *provider.TestEnvironment, nodeName string) (map[string]string, error) {
 	const (
-		sysctlCommand = "sysctl --system"
+		sysctlCommand = "chroot /host sysctl --system"
 	)
 
 	o := clientsholder.GetClientsHolder()


### PR DESCRIPTION
Added a fix to the GetSysctlSettings func, the sysctlCommand should run with a chroot /host prefix.