### PR TITLE
Move DenyAllIdentifier to new scheme

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -59,19 +59,6 @@ Result Type|informative
 Suggested Remediation|Apply a ResourceQuota to the namespace your CNF is running in
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 4.6.8
 Exception Process|There is no documented exception process for this.
-#### network-policy-deny-all
-
-Property|Description
----|---
-Test Case Name|network-policy-deny-all
-Test Case Label|access-control-network-policy-deny-all
-Unique ID|http://test-network-function.com/testcases/access-control/network-policy-deny-all
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/access-control/network-policy-deny-all Check that network policies attached to namespaces running CNF pods contain a default deny-all rule for both ingress and egress traffic
-Result Type|informative
-Suggested Remediation|Ensure that a NetworkPolicy with a default deny-all is applied. After the default is applied, apply a network policy to allow the traffic your application requires.
-Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 10.6
-Exception Process|There is no documented exception process for this.
 #### one-process-per-container
 
 Property|Description
@@ -590,6 +577,19 @@ Description|http://test-network-function.com/testcases/networking/iptables Check
 Result Type|normative
 Suggested Remediation|Do not configure iptables on any CNF container.
 Best Practice Reference|https://TODO Section 4.6.23
+Exception Process|There is no documented exception process for this.
+#### network-policy-deny-all
+
+Property|Description
+---|---
+Test Case Name|network-policy-deny-all
+Test Case Label|networking-network-policy-deny-all
+Unique ID|http://test-network-function.com/testcases/networking/network-policy-deny-all
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/networking/network-policy-deny-all Check that network policies attached to namespaces running CNF pods contain a default deny-all rule for both ingress and egress traffic
+Result Type|informative
+Suggested Remediation|Ensure that a NetworkPolicy with a default deny-all is applied. After the default is applied, apply a network policy to allow the traffic your application requires.
+Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 10.6
 Exception Process|There is no documented exception process for this.
 #### nftables
 

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -93,7 +93,8 @@ func AddCatalogEntry(testID, description, remediation, testType, exception, vers
 }
 
 var (
-	TestICMPv4ConnectivityIdentifier claim.Identifier
+	TestICMPv4ConnectivityIdentifier   claim.Identifier
+	TestNetworkPolicyDenyAllIdentifier claim.Identifier
 )
 
 func InitCatalog() map[claim.Identifier]TestCaseDescription {
@@ -109,6 +110,16 @@ The label value is not important, only its presence.`,
 		NoDocumentedProcess,
 		versionOne,
 		bestPracticeDocV1dot3URL+" Section 5.2",
+		tagCommon)
+
+	TestNetworkPolicyDenyAllIdentifier = AddCatalogEntry(
+		"network-policy-deny-all",
+		`Check that network policies attached to namespaces running CNF pods contain a default deny-all rule for both ingress and egress traffic`,
+		NetworkPolicyDenyAllRemediation,
+		informativeResult,
+		NoDocumentedProcess,
+		versionOne,
+		bestPracticeDocV1dot3URL+" Section 10.6",
 		tagCommon)
 
 	return Catalog
@@ -494,11 +505,6 @@ var (
 		Tags:    formTestTags(tagCommon),
 		Url:     formTestURL(common.AccessControlTestKey, "ssh-daemons"),
 		Version: versionOne,
-	}
-	TestNetworkPolicyDenyAllIdentifier = claim.Identifier{
-		Url:     formTestURL(common.AccessControlTestKey, "network-policy-deny-all"),
-		Version: versionOne,
-		Tags:    formTestTags(tagCommon),
 	}
 )
 
@@ -1177,14 +1183,6 @@ that there are no changes to the following directories:
 		Description:           formDescription(TestNoSSHDaemonsAllowedIdentifier, `Check that pods do not run SSH daemons.`),
 		Remediation:           NoSSHDaemonsAllowedRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 4.6.12", // TODO Change this to v1.4 when available
-		ExceptionProcess:      NoDocumentedProcess,
-	},
-	TestNetworkPolicyDenyAllIdentifier: {
-		Identifier:            TestNetworkPolicyDenyAllIdentifier,
-		Type:                  informativeResult,
-		Description:           formDescription(TestNetworkPolicyDenyAllIdentifier, `Check that network policies attached to namespaces running CNF pods contain a default deny-all rule for both ingress and egress traffic`),
-		Remediation:           NetworkPolicyDenyAllRemediation,
-		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 10.6",
 		ExceptionProcess:      NoDocumentedProcess,
 	},
 }


### PR DESCRIPTION
Building upon https://github.com/test-network-function/cnf-certification-test/pull/452 to build catalog entries with `AddCatalogEntry()`.  Other entries can be switched later as well.