### PR TITLE
Add extended test for reserved ports

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -656,6 +656,19 @@ Result Type|normative
 Suggested Remediation|Ensure that CNF apps do not listen on ports that are reserved by OpenShift
 Best Practice Reference|https://TODO Section 3.5.9
 Exception Process|There is no documented exception process for this.
+#### reserved-partner-ports
+
+Property|Description
+---|---
+Test Case Name|reserved-partner-ports
+Test Case Label|networking-reserved-partner-ports
+Unique ID|http://test-network-function.com/testcases/networking/reserved-partner-ports
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/networking/reserved-partner-ports Checks that pods and containers are not consuming ports designated as reserved by partner
+Result Type|informative
+Suggested Remediation|Ensure ports are not being used that are reserved by our partner
+Best Practice Reference|https://TODO Section 4.6.24
+Exception Process|There is no documented exception process for this.
 #### service-type
 
 Property|Description

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -98,6 +98,7 @@ var (
 	Test1337UIDIdentifier                    claim.Identifier
 	TestContainerIsCertifiedDigestIdentifier claim.Identifier
 	TestPodHugePages2M                       claim.Identifier
+	TestReservedExtendedPartnerPorts         claim.Identifier
 )
 
 //nolint:funlen
@@ -159,6 +160,17 @@ The label value is not important, only its presence.`,
 		NoDocumentedProcess,
 		VersionOne,
 		bestPracticeDocV1dot4URL+" Section 3.5.4",
+		TagExtended)
+
+	TestReservedExtendedPartnerPorts = AddCatalogEntry(
+		"reserved-partner-ports",
+		common.NetworkingTestKey,
+		`Checks that pods and containers are not consuming ports designated as reserved by partner`,
+		ReservedPartnerPortsRemediation,
+		InformativeResult,
+		NoDocumentedProcess,
+		VersionOne,
+		bestPracticeDocV1dot4URL+" Section 4.6.24",
 		TagExtended)
 
 	return Catalog

--- a/cnf-certification-test/identifiers/remediation.go
+++ b/cnf-certification-test/identifiers/remediation.go
@@ -195,4 +195,6 @@ const (
 	CPUIsolationRemediation = `CPU isolation testing is enabled.  Please ensure that all pods adhere to the CPU isolation requirements`
 
 	UID1337Remediation = `Use another process UID that is not 1337`
+
+	ReservedPartnerPortsRemediation = `Ensure ports are not being used that are reserved by our partner`
 )

--- a/cnf-certification-test/networking/netcommons/netcommons.go
+++ b/cnf-certification-test/networking/netcommons/netcommons.go
@@ -147,14 +147,13 @@ func FilterIPListByIPVersion(ipList []string, aIPVersion IPVersion) []string {
 	return filteredIPList
 }
 
-func FindRogueContainersDeclaredListeningToPorts(containers []*provider.Container, portsToTest map[int32]bool) []string {
+func FindRogueContainersDeclaringPorts(containers []*provider.Container, portsToTest map[int32]bool) []string {
 	var rogueContainers []string
 	for _, cut := range containers {
 		for _, port := range cut.Ports {
 			if portsToTest[port.ContainerPort] {
 				tnf.ClaimFilePrintf("%s has declared a port (%d) that has been reserved", cut, port.ContainerPort)
 				rogueContainers = append(rogueContainers, cut.String())
-				break
 			}
 		}
 	}
@@ -175,7 +174,6 @@ func FindRoguePodsListeningToPorts(pods []*provider.Pod, portsToTest map[int32]b
 			if portsToTest[int32(port.PortNumber)] {
 				tnf.ClaimFilePrintf("%s has one container listening on port %d that has been reserved", put, port.PortNumber)
 				roguePods = append(roguePods, put.String())
-				break
 			}
 		}
 	}

--- a/cnf-certification-test/networking/netcommons/netcommons.go
+++ b/cnf-certification-test/networking/netcommons/netcommons.go
@@ -147,7 +147,7 @@ func FilterIPListByIPVersion(ipList []string, aIPVersion IPVersion) []string {
 	return filteredIPList
 }
 
-func FindRogueContainersListeningToPorts(containers []*provider.Container, portsToTest map[int32]bool) []string {
+func FindRogueContainersDeclaredListeningToPorts(containers []*provider.Container, portsToTest map[int32]bool) []string {
 	var rogueContainers []string
 	for _, cut := range containers {
 		for _, port := range cut.Ports {

--- a/cnf-certification-test/networking/netcommons/netcommons.go
+++ b/cnf-certification-test/networking/netcommons/netcommons.go
@@ -21,7 +21,9 @@ import (
 	"net"
 	"strings"
 
+	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/networking/netutil"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
+	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -143,4 +145,39 @@ func FilterIPListByIPVersion(ipList []string, aIPVersion IPVersion) []string {
 		}
 	}
 	return filteredIPList
+}
+
+func FindRogueContainersListeningToPorts(containers []*provider.Container, portsToTest map[int32]bool) []string {
+	var rogueContainers []string
+	for _, cut := range containers {
+		for _, port := range cut.Ports {
+			if portsToTest[port.ContainerPort] {
+				tnf.ClaimFilePrintf("%s has declared a port (%d) that has been reserved", cut, port.ContainerPort)
+				rogueContainers = append(rogueContainers, cut.String())
+				break
+			}
+		}
+	}
+	return rogueContainers
+}
+
+func FindRoguePodsListeningToPorts(pods []*provider.Pod, portsToTest map[int32]bool) (roguePods []string, failedContainers int) {
+	for _, put := range pods {
+		cut := put.Containers[0]
+
+		listeningPorts, err := netutil.GetListeningPorts(cut)
+		if err != nil {
+			tnf.ClaimFilePrintf("Failed to get the listening ports on %s, err: %s", cut, err)
+			failedContainers++
+			continue
+		}
+		for port := range listeningPorts {
+			if portsToTest[int32(port.PortNumber)] {
+				tnf.ClaimFilePrintf("%s has one container listening on port %d that has been reserved", put, port.PortNumber)
+				roguePods = append(roguePods, put.String())
+				break
+			}
+		}
+	}
+	return roguePods, failedContainers
 }

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -204,7 +204,7 @@ func testOCPReservedPortsUsage(env *provider.TestEnvironment) {
 	// List of all ports reserved by OpenShift
 	OCPReservedPorts := map[int32]bool{22623: true, 22624: true}
 
-	rogueContainers := netcommons.FindRogueContainersListeningToPorts(env.Containers, OCPReservedPorts)
+	rogueContainers := netcommons.FindRogueContainersDeclaredListeningToPorts(env.Containers, OCPReservedPorts)
 	roguePods, failedContainers := netcommons.FindRoguePodsListeningToPorts(env.Pods, OCPReservedPorts)
 
 	if n := len(rogueContainers); n > 0 {
@@ -240,7 +240,7 @@ func testPartnerSpecificTCPPorts(env *provider.TestEnvironment) {
 		15000: true,
 	}
 
-	rogueContainers := netcommons.FindRogueContainersListeningToPorts(env.Containers, ReservedPorts)
+	rogueContainers := netcommons.FindRogueContainersDeclaredListeningToPorts(env.Containers, ReservedPorts)
 	roguePods, failedContainers := netcommons.FindRoguePodsListeningToPorts(env.Pods, ReservedPorts)
 
 	if n := len(rogueContainers); n > 0 {

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -204,7 +204,7 @@ func testOCPReservedPortsUsage(env *provider.TestEnvironment) {
 	// List of all ports reserved by OpenShift
 	OCPReservedPorts := map[int32]bool{22623: true, 22624: true}
 
-	rogueContainers := netcommons.FindRogueContainersDeclaredListeningToPorts(env.Containers, OCPReservedPorts)
+	rogueContainers := netcommons.FindRogueContainersDeclaringPorts(env.Containers, OCPReservedPorts)
 	roguePods, failedContainers := netcommons.FindRoguePodsListeningToPorts(env.Pods, OCPReservedPorts)
 
 	if n := len(rogueContainers); n > 0 {
@@ -240,7 +240,7 @@ func testPartnerSpecificTCPPorts(env *provider.TestEnvironment) {
 		15000: true,
 	}
 
-	rogueContainers := netcommons.FindRogueContainersDeclaredListeningToPorts(env.Containers, ReservedPorts)
+	rogueContainers := netcommons.FindRogueContainersDeclaringPorts(env.Containers, ReservedPorts)
 	roguePods, failedContainers := netcommons.FindRoguePodsListeningToPorts(env.Pods, ReservedPorts)
 
 	if n := len(rogueContainers); n > 0 {

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -116,6 +116,11 @@ var _ = ginkgo.Describe(common.NetworkingTestKey, func() {
 		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
 		testNetworkPolicyDenyAll(&env)
 	})
+	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestReservedExtendedPartnerPorts)
+	ginkgo.It(testID, ginkgo.Label(tags...), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testPartnerSpecificTCPPorts(&env)
+	})
 })
 
 //nolint:funlen
@@ -195,44 +200,12 @@ func testNetworkConnectivity(env *provider.TestEnvironment, aIPVersion netcommon
 	}
 }
 
-//nolint:funlen
 func testOCPReservedPortsUsage(env *provider.TestEnvironment) {
 	// List of all ports reserved by OpenShift
 	OCPReservedPorts := map[int32]bool{22623: true, 22624: true}
 
-	var failedContainers int
-	var rogueContainers []string
-	var roguePods []string
-
-	// First check if any of the containers under test has declared a port reserved by OCP
-	for _, cut := range env.Containers {
-		for _, port := range cut.Ports {
-			if OCPReservedPorts[port.ContainerPort] {
-				tnf.ClaimFilePrintf("%s has declared a port (%d) reserved by OpenShift", cut, port.ContainerPort)
-				rogueContainers = append(rogueContainers, cut.String())
-				break
-			}
-		}
-	}
-
-	// Then verify that no container is listening on the reserved OCP ports
-	for _, put := range env.Pods {
-		cut := put.Containers[0]
-
-		listeningPorts, err := netutil.GetListeningPorts(cut)
-		if err != nil {
-			tnf.ClaimFilePrintf("Failed to get the listening ports on %s, err: %s", cut, err)
-			failedContainers++
-			continue
-		}
-		for port := range listeningPorts {
-			if OCPReservedPorts[int32(port.PortNumber)] {
-				tnf.ClaimFilePrintf("%s has one container listening on port %d reserved by OpenShift", put, port.PortNumber)
-				roguePods = append(roguePods, put.String())
-				break
-			}
-		}
-	}
+	rogueContainers := netcommons.FindRogueContainersListeningToPorts(env.Containers, OCPReservedPorts)
+	roguePods, failedContainers := netcommons.FindRoguePodsListeningToPorts(env.Pods, OCPReservedPorts)
 
 	if n := len(rogueContainers); n > 0 {
 		errMsg := fmt.Sprintf("Number of containers declaring ports reserved by OpenShift: %d", n)
@@ -242,6 +215,42 @@ func testOCPReservedPortsUsage(env *provider.TestEnvironment) {
 
 	if n := len(roguePods); n > 0 {
 		errMsg := fmt.Sprintf("Number of pods having one or more containers listening on ports reserved by OpenShift: %d", n)
+		tnf.ClaimFilePrintf(errMsg)
+		ginkgo.Fail(errMsg)
+	}
+
+	if failedContainers > 0 {
+		errMsg := fmt.Sprintf("Number of containers in which the test could not be performed due to an error: %d", failedContainers)
+		tnf.ClaimFilePrintf(errMsg)
+		ginkgo.Fail(errMsg)
+	}
+}
+
+func testPartnerSpecificTCPPorts(env *provider.TestEnvironment) {
+	// List of all of the ports reserved by partner
+	ReservedPorts := map[int32]bool{
+		15443: true,
+		15090: true,
+		15021: true,
+		15020: true,
+		15014: true,
+		15008: true,
+		15006: true,
+		15001: true,
+		15000: true,
+	}
+
+	rogueContainers := netcommons.FindRogueContainersListeningToPorts(env.Containers, ReservedPorts)
+	roguePods, failedContainers := netcommons.FindRoguePodsListeningToPorts(env.Pods, ReservedPorts)
+
+	if n := len(rogueContainers); n > 0 {
+		errMsg := fmt.Sprintf("Number of containers declaring ports reserved by Partner: %d", n)
+		tnf.ClaimFilePrintf(errMsg)
+		ginkgo.Fail(errMsg)
+	}
+
+	if n := len(roguePods); n > 0 {
+		errMsg := fmt.Sprintf("Number of pods having one or more containers listening on ports reserved by Partner: %d", n)
 		tnf.ClaimFilePrintf(errMsg)
 		ginkgo.Fail(errMsg)
 	}


### PR DESCRIPTION
Utilizes `tagExtended` to designate this test as part of the extended test suite.

I'm open to reworking the "by Partner" strings that appear in the logging.

I took advantage of the existing func `testOCPReservedPortsUsage` which essentially did what we wanted to do for this extended test.  To facilitate this, I created two funcs in the `netcommons` package: `FindRogueContainersListeningToPorts` and `FindRoguePodsListeningToPorts`.

Both the old func and new func use these two new `netcommons` functions to achieve their goals.