### PR TITLE
Add extended test for UID 1337

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -59,6 +59,19 @@ Result Type|informative
 Suggested Remediation|Apply a ResourceQuota to the namespace your CNF is running in
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 4.6.8
 Exception Process|There is no documented exception process for this.
+#### no-1337-uid
+
+Property|Description
+---|---
+Test Case Name|no-1337-uid
+Test Case Label|access-control-no-1337-uid
+Unique ID|http://test-network-function.com/testcases/access-control/no-1337-uid
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/access-control/no-1337-uid Checks that all pods are not using the securityContext UID 1337
+Result Type|informative
+Suggested Remediation|Use another process UID that is not 1337
+Best Practice Reference|https://TODO Section 4.6.24
+Exception Process|There is no documented exception process for this.
 #### one-process-per-container
 
 Property|Description

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -95,6 +95,7 @@ func AddCatalogEntry(testID, suiteName, description, remediation, testType, exce
 var (
 	TestICMPv4ConnectivityIdentifier   claim.Identifier
 	TestNetworkPolicyDenyAllIdentifier claim.Identifier
+	Test1337UIDIdentifier              claim.Identifier
 )
 
 func InitCatalog() map[claim.Identifier]TestCaseDescription {
@@ -123,6 +124,17 @@ The label value is not important, only its presence.`,
 		versionOne,
 		bestPracticeDocV1dot3URL+" Section 10.6",
 		tagCommon)
+
+	Test1337UIDIdentifier = AddCatalogEntry(
+		"no-1337-uid",
+		common.AccessControlTestKey,
+		`Checks that all pods are not using the securityContext UID 1337`,
+		UID1337Remediation,
+		informativeResult,
+		NoDocumentedProcess,
+		versionOne,
+		bestPracticeDocV1dot4URL+" Section 4.6.24",
+		tagExtended)
 
 	return Catalog
 }

--- a/cnf-certification-test/identifiers/remediation.go
+++ b/cnf-certification-test/identifiers/remediation.go
@@ -193,4 +193,6 @@ const (
 	NetworkPolicyDenyAllRemediation = `Ensure that a NetworkPolicy with a default deny-all is applied. After the default is applied, apply a network policy to allow the traffic your application requires.`
 
 	CPUIsolationRemediation = `CPU isolation testing is enabled.  Please ensure that all pods adhere to the CPU isolation requirements`
+
+	UID1337Remediation = `Use another process UID that is not 1337`
 )


### PR DESCRIPTION
Utilizes `tagExtended` to make this run as part of the extended test suite.

Similar to #493 as they are part of the same issue.

Previous PR: #136 

Marked WIP until I can test this.