### PR TITLE
Exclude guaranteed pods from node selector check

### DIFF
--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -100,7 +100,7 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 		if env.GetWorkerCount() < minWorkerNodesForLifecycle {
 			ginkgo.Skip("Skipping pod scheduling test because invalid number of available workers.")
 		}
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.NonGuaranteedPods)
 		testPodNodeSelectorAndAffinityBestPractices(&env)
 	})
 
@@ -246,7 +246,7 @@ func testPodsOwnerReference(env *provider.TestEnvironment) {
 
 func testPodNodeSelectorAndAffinityBestPractices(env *provider.TestEnvironment) {
 	var badPods []*corev1.Pod
-	for _, put := range env.Pods {
+	for _, put := range env.NonGuaranteedPods {
 		if len(put.Data.Spec.NodeSelector) != 0 {
 			tnf.ClaimFilePrintf("ERROR: %s has a node selector clause. Node selector: %v", put, &put.Data.Spec.NodeSelector)
 			badPods = append(badPods, put.Data)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -110,6 +110,7 @@ type TestEnvironment struct { // rename this with testTarget
 	PersistentVolumes    []corev1.PersistentVolume
 	DebugPods            map[string]*corev1.Pod // map from nodename to debugPod
 	GuaranteedPods       []*Pod
+	NonGuaranteedPods    []*Pod
 	Config               configuration.TestConfiguration
 	variables            configuration.TestParameters
 	Crds                 []*apiextv1.CustomResourceDefinition          `json:"testCrds"`
@@ -295,9 +296,11 @@ func buildTestEnvironment() { //nolint:funlen
 		aNewPod := NewPod(&pods[i])
 		env.Pods = append(env.Pods, &aNewPod)
 
-		// Build slice of guaranteed pods (if any)
+		// Build slices of guaranteed and non guaranteed pods
 		if aNewPod.IsPodGuaranteed() {
 			env.GuaranteedPods = append(env.GuaranteedPods, &aNewPod)
+		} else {
+			env.NonGuaranteedPods = append(env.NonGuaranteedPods, &aNewPod)
 		}
 		env.Containers = append(env.Containers, getPodContainers(&pods[i])...)
 	}


### PR DESCRIPTION
Resolves #497 

Creates a list of `NonGuaranteedPods` then change `testPodNodeSelectorAndAffinityBestPractices` func to only parse through the list of `NonGuaranteedPods` to avoid any problems with runtimeClasses potentially having node selectors.