### PR TITLE
Consolidate into deployment/statefulset structs

### DIFF
--- a/cnf-certification-test/chaostesting/suite.go
+++ b/cnf-certification-test/chaostesting/suite.go
@@ -47,27 +47,26 @@ func testPodDelete(env *provider.TestEnvironment) {
 	ginkgo.Skip("This TC is under construction.")
 
 	for _, dep := range env.Deployments {
-		namespace := dep.Namespace
 		var label string
 		var err error
 		if label, err = poddelete.GetLabelDeploymentValue(env, dep.Spec.Template.Labels); err != nil {
-			logrus.Errorf("didn't find a match label for the deployment %s ", provider.DeploymentToString(dep))
-			ginkgo.Fail(fmt.Sprintf("There is no label for the deployment %s ", provider.DeploymentToString(dep)))
+			logrus.Errorf("didn't find a match label for the deployment %s ", dep.ToString())
+			ginkgo.Fail(fmt.Sprintf("There is no label for the deployment %s ", dep.ToString()))
 		}
-		if err := poddelete.ApplyAndCreatePodDeleteResources(label, deployment, namespace); err != nil {
+		if err := poddelete.ApplyAndCreatePodDeleteResources(label, deployment, dep.Namespace); err != nil {
 			ginkgo.Fail(fmt.Sprintf("test failed while creating the resources err:%s", err))
 		}
 		if completed := poddelete.WaitForTestFinish(testCaseTimeout); !completed {
-			poddelete.DeleteAllResources(namespace)
-			logrus.Errorf("deployment %s timed-out the litmus test", provider.DeploymentToString(dep))
-			ginkgo.Fail(fmt.Sprintf("deployment %s timed-out the litmus test", provider.DeploymentToString(dep)))
+			poddelete.DeleteAllResources(dep.Namespace)
+			logrus.Errorf("deployment %s timed-out the litmus test", dep.ToString())
+			ginkgo.Fail(fmt.Sprintf("deployment %s timed-out the litmus test", dep.ToString()))
 		}
 		if result := poddelete.IsChaosResultVerdictPass(); !result {
 			// delete the chaos engin crd
-			poddelete.DeleteAllResources(namespace)
-			logrus.Errorf("deployment %s failed the litmus test", provider.DeploymentToString(dep))
-			ginkgo.Fail(fmt.Sprintf("deployment %s failed the litmus test", provider.DeploymentToString(dep)))
+			poddelete.DeleteAllResources(dep.Namespace)
+			logrus.Errorf("deployment %s failed the litmus test", dep.ToString())
+			ginkgo.Fail(fmt.Sprintf("deployment %s failed the litmus test", dep.ToString()))
 		}
-		poddelete.DeleteAllResources(namespace)
+		poddelete.DeleteAllResources(dep.Namespace)
 	}
 }

--- a/cnf-certification-test/lifecycle/podsets/podsets.go
+++ b/cnf-certification-test/lifecycle/podsets/podsets.go
@@ -23,7 +23,6 @@ import (
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/pkg/loghelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
-	v1app "k8s.io/api/apps/v1"
 )
 
 const (
@@ -39,10 +38,10 @@ var WaitForDeploymentSetReady = func(ns, name string, timeout time.Duration) boo
 		dp, err := provider.GetUpdatedDeployment(clients.K8sClient.AppsV1(), ns, name)
 		if err != nil {
 			logrus.Errorf("Error while getting deployment %s (ns: %s), err: %s", name, ns, err)
-		} else if !IsDeploymentReady(dp) {
-			logrus.Errorf("%s is not ready yet", provider.DeploymentToString(dp))
+		} else if !dp.IsDeploymentReady() {
+			logrus.Errorf("%s is not ready yet", dp.ToString())
 		} else {
-			logrus.Tracef("%s is ready!", provider.DeploymentToString(dp))
+			logrus.Tracef("%s is ready!", dp.ToString())
 			return true
 		}
 
@@ -52,41 +51,17 @@ var WaitForDeploymentSetReady = func(ns, name string, timeout time.Duration) boo
 	return false
 }
 
-func IsDeploymentReady(deployment *v1app.Deployment) bool {
-	notReady := true
-	for _, condition := range deployment.Status.Conditions {
-		if condition.Type == v1app.DeploymentAvailable {
-			notReady = false
-			break
-		}
-	}
-	var replicas int32
-	if deployment.Spec.Replicas != nil {
-		replicas = *(deployment.Spec.Replicas)
-	} else {
-		replicas = 1
-	}
-	if notReady ||
-		deployment.Status.UnavailableReplicas != 0 ||
-		deployment.Status.ReadyReplicas != replicas ||
-		deployment.Status.AvailableReplicas != replicas ||
-		deployment.Status.UpdatedReplicas != replicas {
-		return false
-	}
-	return true
-}
-
 func WaitForStatefulSetReady(ns, name string, timeout time.Duration) bool {
 	logrus.Trace("check if statefulset ", ns, ":", name, " is ready ")
 	clients := clientsholder.GetClientsHolder()
 	start := time.Now()
 	for time.Since(start) < timeout {
 		ss, err := provider.GetUpdatedStatefulset(clients.K8sClient.AppsV1(), ns, name)
-		if err == nil && IsStatefulSetReady(ss) {
-			logrus.Tracef("%s is ready, err: %s", provider.StatefulsetToString(ss), err)
+		if err == nil && ss.IsStatefulSetReady() {
+			logrus.Tracef("%s is ready, err: %s", ss.ToString(), err)
 			return true
 		} else if err != nil {
-			logrus.Errorf("Error while getting the %s, err: %s", provider.StatefulsetToString(ss), err)
+			logrus.Errorf("Error while getting the %s, err: %s", ss.ToString(), err)
 		}
 		time.Sleep(time.Second)
 	}
@@ -94,38 +69,23 @@ func WaitForStatefulSetReady(ns, name string, timeout time.Duration) bool {
 	return false
 }
 
-func IsStatefulSetReady(statefulset *v1app.StatefulSet) bool {
-	var replicas int32
-	if statefulset.Spec.Replicas != nil {
-		replicas = *(statefulset.Spec.Replicas)
-	} else {
-		replicas = 1
-	}
-	if statefulset.Status.ReadyReplicas != replicas ||
-		statefulset.Status.CurrentReplicas != replicas ||
-		statefulset.Status.UpdatedReplicas != replicas {
-		return false
-	}
-	return true
-}
-
 func WaitForAllPodSetReady(env *provider.TestEnvironment, timeoutPodSetReady time.Duration) (claimsLog loghelper.CuratedLogLines, atLeastOnePodsetNotReady bool) {
 	atLeastOnePodsetNotReady = false
 	for _, dut := range env.Deployments {
 		isReady := WaitForDeploymentSetReady(dut.Namespace, dut.Name, timeoutPodSetReady)
 		if isReady {
-			claimsLog.AddLogLine("%s Status: OK", provider.DeploymentToString(dut))
+			claimsLog.AddLogLine("%s Status: OK", dut.ToString())
 		} else {
-			claimsLog.AddLogLine("%s Status: NOK", provider.DeploymentToString(dut))
+			claimsLog.AddLogLine("%s Status: NOK", dut.ToString())
 			atLeastOnePodsetNotReady = true
 		}
 	}
 	for _, sut := range env.StatetfulSets {
 		isReady := WaitForStatefulSetReady(sut.Namespace, sut.Name, timeoutPodSetReady)
 		if isReady {
-			claimsLog.AddLogLine("%s Status: OK", provider.StatefulsetToString(sut))
+			claimsLog.AddLogLine("%s Status: OK", sut.ToString())
 		} else {
-			claimsLog.AddLogLine("%s Status: NOK", provider.StatefulsetToString(sut))
+			claimsLog.AddLogLine("%s Status: NOK", sut.ToString())
 			atLeastOnePodsetNotReady = true
 		}
 	}

--- a/cnf-certification-test/lifecycle/podsets/podsets_test.go
+++ b/cnf-certification-test/lifecycle/podsets/podsets_test.go
@@ -46,15 +46,25 @@ func TestIsDeploymentReady(t *testing.T) {
 		{v1app.DeploymentAvailable, 10, 10, 10, 0, 10}:    true,
 	}
 	for key, v := range m {
-		dp := v1app.Deployment{}
-		dpCondition := v1app.DeploymentCondition{Type: key.condition}
-		dp.Status.Conditions = append(dp.Status.Conditions, dpCondition)
-		dp.Spec.Replicas = &(key.replicas)
-		dp.Status.ReadyReplicas = key.ready
-		dp.Status.AvailableReplicas = key.available
-		dp.Status.UnavailableReplicas = key.unavailable
-		dp.Status.UpdatedReplicas = key.updated
-		ready := IsDeploymentReady(&dp)
+		dp := provider.Deployment{
+			Deployment: &v1app.Deployment{
+				Status: v1app.DeploymentStatus{
+					Conditions: []v1app.DeploymentCondition{
+						{
+							Type: key.condition,
+						},
+					},
+					ReadyReplicas:       key.ready,
+					AvailableReplicas:   key.available,
+					UnavailableReplicas: key.unavailable,
+					UpdatedReplicas:     key.updated,
+				},
+				Spec: v1app.DeploymentSpec{
+					Replicas: &key.replicas,
+				},
+			},
+		}
+		ready := dp.IsDeploymentReady()
 		assert.Equal(t, v, ready)
 	}
 }
@@ -76,13 +86,20 @@ func TestIsStatefulSetReady(t *testing.T) {
 		{10, 10, 10, 10, 10}: true,
 	}
 	for k, v := range m {
-		statefulset := v1app.StatefulSet{}
-		statefulset.Spec.Replicas = &(k.replicas)
-		statefulset.Status.ReadyReplicas = k.ready
-		statefulset.Status.AvailableReplicas = k.available
-		statefulset.Status.UpdatedReplicas = k.updated
-		statefulset.Status.CurrentReplicas = k.current
-		ready := IsStatefulSetReady(&statefulset)
+		ss := provider.StatefulSet{
+			StatefulSet: &v1app.StatefulSet{
+				Spec: v1app.StatefulSetSpec{
+					Replicas: &k.replicas,
+				},
+				Status: v1app.StatefulSetStatus{
+					ReadyReplicas:     k.ready,
+					AvailableReplicas: k.available,
+					UpdatedReplicas:   k.updated,
+					CurrentReplicas:   k.current,
+				},
+			},
+		}
+		ready := ss.IsStatefulSetReady()
 		if ready != v {
 			fmt.Println(" k= ", k, " should be ", v, " is ", ready)
 		}

--- a/cnf-certification-test/lifecycle/scaling/deployment_scaling.go
+++ b/cnf-certification-test/lifecycle/scaling/deployment_scaling.go
@@ -25,17 +25,18 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/lifecycle/podsets"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
+	"github.com/test-network-function/cnf-certification-test/pkg/provider"
 
-	v1app "k8s.io/api/apps/v1"
 	v1autoscaling "k8s.io/api/autoscaling/v1"
 
 	v1machinery "k8s.io/apimachinery/pkg/apis/meta/v1"
 	retry "k8s.io/client-go/util/retry"
 
+	appsv1 "k8s.io/api/apps/v1"
 	hps "k8s.io/client-go/kubernetes/typed/autoscaling/v1"
 )
 
-func TestScaleDeployment(deployment *v1app.Deployment, timeout time.Duration) bool {
+func TestScaleDeployment(deployment *appsv1.Deployment, timeout time.Duration) bool {
 	clients := clientsholder.GetClientsHolder()
 	logrus.Trace("scale deployment not using HPA ", deployment.Namespace, ":", deployment.Name)
 	var replicas int32
@@ -74,7 +75,7 @@ func TestScaleDeployment(deployment *v1app.Deployment, timeout time.Duration) bo
 	return true
 }
 
-func scaleDeploymentHelper(clients *clientsholder.ClientsHolder, deployment *v1app.Deployment, replicas int32, timeout time.Duration, up bool) bool {
+func scaleDeploymentHelper(clients *clientsholder.ClientsHolder, deployment *appsv1.Deployment, replicas int32, timeout time.Duration, up bool) bool {
 	if up {
 		logrus.Trace("scale UP deployment to ", replicas, " replicas ")
 	} else {
@@ -108,7 +109,7 @@ func scaleDeploymentHelper(clients *clientsholder.ClientsHolder, deployment *v1a
 	return true
 }
 
-func TestScaleHpaDeployment(deployment *v1app.Deployment, hpa *v1autoscaling.HorizontalPodAutoscaler, timeout time.Duration) bool {
+func TestScaleHpaDeployment(deployment *provider.Deployment, hpa *v1autoscaling.HorizontalPodAutoscaler, timeout time.Duration) bool {
 	clients := clientsholder.GetClientsHolder()
 	hpscaler := clients.K8sClient.AutoscalingV1().HorizontalPodAutoscalers(deployment.Namespace)
 	var min int32

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -270,22 +270,21 @@ func testDeploymentScaling(env *provider.TestEnvironment, timeout time.Duration)
 	for i := range env.Deployments {
 		// TestDeploymentScaling test scaling of deployment
 		// This is the entry point for deployment scaling tests
-		deployment := env.Deployments[i]
-		ns, name := deployment.Namespace, deployment.Name
+		ns, name := env.Deployments[i].Namespace, env.Deployments[i].Name
 		key := ns + name
 		if hpa, ok := env.HorizontalScaler[key]; ok {
 			// if the deployment is controller by
 			// horizontal scaler, then test that scaler
 			// can scale the deployment
-			if !scaling.TestScaleHpaDeployment(deployment, hpa, timeout) {
-				failedDeployments = append(failedDeployments, provider.DeploymentToString(deployment))
+			if !scaling.TestScaleHpaDeployment(env.Deployments[i], hpa, timeout) {
+				failedDeployments = append(failedDeployments, env.Deployments[i].ToString())
 			}
 			continue
 		}
 		// if the deployment is not controller by HPA
 		// scale it directly
-		if !scaling.TestScaleDeployment(deployment, timeout) {
-			failedDeployments = append(failedDeployments, provider.DeploymentToString(deployment))
+		if !scaling.TestScaleDeployment(env.Deployments[i].Deployment, timeout) {
+			failedDeployments = append(failedDeployments, env.Deployments[i].ToString())
 		}
 	}
 
@@ -303,22 +302,21 @@ func testStatefulSetScaling(env *provider.TestEnvironment, timeout time.Duration
 	for i := range env.StatetfulSets {
 		// TeststatefulsetScaling test scaling of statefulset
 		// This is the entry point for statefulset scaling tests
-		statefulset := env.StatetfulSets[i]
-		ns, name := statefulset.Namespace, statefulset.Name
+		ns, name := env.StatetfulSets[i].Namespace, env.StatetfulSets[i].Name
 		key := ns + name
 		if hpa, ok := env.HorizontalScaler[key]; ok {
 			// if the statefulset is controller by
 			// horizontal scaler, then test that scaler
 			// can scale the statefulset
-			if !scaling.TestScaleHpaStatefulSet(statefulset, hpa, timeout) {
-				failedStatetfulSets = append(failedStatetfulSets, provider.StatefulsetToString(statefulset))
+			if !scaling.TestScaleHpaStatefulSet(env.StatetfulSets[i].StatefulSet, hpa, timeout) {
+				failedStatetfulSets = append(failedStatetfulSets, env.StatetfulSets[i].ToString())
 			}
 			continue
 		}
 		// if the statefulset is not controller by HPA
 		// scale it directly
-		if !scaling.TestScaleStatefulSet(statefulset, timeout) {
-			failedStatetfulSets = append(failedStatetfulSets, provider.StatefulsetToString(statefulset))
+		if !scaling.TestScaleStatefulSet(env.StatetfulSets[i].StatefulSet, timeout) {
+			failedStatetfulSets = append(failedStatetfulSets, env.StatetfulSets[i].ToString())
 		}
 	}
 
@@ -336,22 +334,22 @@ func testHighAvailability(env *provider.TestEnvironment) {
 	badStatefulSet := []string{}
 	for _, dp := range env.Deployments {
 		if dp.Spec.Replicas == nil || *(dp.Spec.Replicas) <= 1 {
-			badDeployments = append(badDeployments, provider.DeploymentToString(dp))
+			badDeployments = append(badDeployments, dp.ToString())
 			continue
 		}
 		if dp.Spec.Template.Spec.Affinity == nil ||
 			dp.Spec.Template.Spec.Affinity.PodAntiAffinity == nil {
-			badDeployments = append(badDeployments, provider.DeploymentToString(dp))
+			badDeployments = append(badDeployments, dp.ToString())
 		}
 	}
 	for _, st := range env.StatetfulSets {
 		if st.Spec.Replicas == nil || *(st.Spec.Replicas) <= 1 {
-			badStatefulSet = append(badStatefulSet, provider.StatefulsetToString(st))
+			badStatefulSet = append(badStatefulSet, st.ToString())
 			continue
 		}
 		if st.Spec.Template.Spec.Affinity == nil ||
 			st.Spec.Template.Spec.Affinity.PodAntiAffinity == nil {
-			badDeployments = append(badDeployments, provider.StatefulsetToString(st))
+			badDeployments = append(badDeployments, st.ToString())
 		}
 	}
 

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -790,21 +790,29 @@ func TestContainerStringFuncs(t *testing.T) {
 }
 
 func TestDeploymentToString(t *testing.T) {
-	assert.Equal(t, "deployment: test1 ns: testNS", DeploymentToString(&appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test1",
-			Namespace: "testNS",
+	dp := Deployment{
+		Deployment: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test1",
+				Namespace: "testNS",
+			},
 		},
-	}))
+	}
+
+	assert.Equal(t, "deployment: test1 ns: testNS", dp.ToString())
 }
 
 func TestStatefulsetToString(t *testing.T) {
-	assert.Equal(t, "statefulset: test1 ns: testNS", StatefulsetToString(&appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test1",
-			Namespace: "testNS",
+	ss := StatefulSet{
+		StatefulSet: &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test1",
+				Namespace: "testNS",
+			},
 		},
-	}))
+	}
+
+	assert.Equal(t, "statefulset: test1 ns: testNS", ss.ToString())
 }
 
 func TestCsvToString(t *testing.T) {


### PR DESCRIPTION
Created two new structs in provider.go to wrap the `Deployment` and `StatefulSet` k8s objects in our own wrappers.  Utilizing untyped variables to all for direct access to the underlying k8s struct variables in our funcs.

For example, note that no variable name is needed:
```
type Deployment struct {
	*appsv1.Deployment
}
```