### PR TITLE
Switch Pod and Container to nest the k8s structs

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -185,10 +185,10 @@ var _ = ginkgo.Describe(common.AccessControlTestKey, func() {
 func TestSecConCapabilities(env *provider.TestEnvironment) {
 	var badContainers []string
 	for _, cut := range env.Containers {
-		if cut.Data.SecurityContext != nil && cut.Data.SecurityContext.Capabilities != nil {
+		if cut.SecurityContext != nil && cut.SecurityContext.Capabilities != nil {
 			for _, ncc := range nonCompliantCapabilities {
-				if strings.Contains(cut.Data.SecurityContext.Capabilities.String(), ncc) {
-					tnf.ClaimFilePrintf("Non compliant %s capability detected in container %s. All container caps: %s", ncc, cut.String(), cut.Data.SecurityContext.Capabilities.String())
+				if strings.Contains(cut.SecurityContext.Capabilities.String(), ncc) {
+					tnf.ClaimFilePrintf("Non compliant %s capability detected in container %s. All container caps: %s", ncc, cut.String(), cut.SecurityContext.Capabilities.String())
 					badContainers = append(badContainers, cut.String())
 				}
 			}
@@ -205,20 +205,20 @@ func TestSecConCapabilities(env *provider.TestEnvironment) {
 func TestSecConRootUser(env *provider.TestEnvironment) {
 	var badContainers, badPods []string
 	for _, put := range env.Pods {
-		if put.Data.Spec.SecurityContext != nil && put.Data.Spec.SecurityContext.RunAsUser != nil {
+		if put.Spec.SecurityContext != nil && put.Spec.SecurityContext.RunAsUser != nil {
 			// Check the pod level RunAsUser parameter
-			if *(put.Data.Spec.SecurityContext.RunAsUser) == 0 {
-				tnf.ClaimFilePrintf("Non compliant run as Root User detected (RunAsUser uid=0) in pod %s", put.Data.Namespace+"."+put.Data.Name)
-				badPods = append(badPods, put.Data.Namespace+"."+put.Data.Name)
+			if *(put.Spec.SecurityContext.RunAsUser) == 0 {
+				tnf.ClaimFilePrintf("Non compliant run as Root User detected (RunAsUser uid=0) in pod %s", put.Namespace+"."+put.Name)
+				badPods = append(badPods, put.Namespace+"."+put.Name)
 			}
 		}
-		for idx := range put.Data.Spec.Containers {
-			cut := &(put.Data.Spec.Containers[idx])
+		for idx := range put.Spec.Containers {
+			cut := &(put.Spec.Containers[idx])
 			// Check the container level RunAsUser parameter
 			if cut.SecurityContext != nil && cut.SecurityContext.RunAsUser != nil {
 				if *(cut.SecurityContext.RunAsUser) == 0 {
-					tnf.ClaimFilePrintf("Non compliant run as Root User detected (RunAsUser uid=0) in container %s", put.Data.Namespace+"."+put.Data.Name+"."+cut.Name)
-					badContainers = append(badContainers, put.Data.Namespace+"."+put.Data.Name+"."+cut.Name)
+					tnf.ClaimFilePrintf("Non compliant run as Root User detected (RunAsUser uid=0) in container %s", put.Namespace+"."+put.Name+"."+cut.Name)
+					badContainers = append(badContainers, put.Namespace+"."+put.Name+"."+cut.Name)
 				}
 			}
 		}
@@ -239,10 +239,10 @@ func TestSecConRootUser(env *provider.TestEnvironment) {
 func TestSecConPrivilegeEscalation(env *provider.TestEnvironment) {
 	var badContainers []string
 	for _, cut := range env.Containers {
-		if cut.Data.SecurityContext != nil && cut.Data.SecurityContext.AllowPrivilegeEscalation != nil {
-			if *(cut.Data.SecurityContext.AllowPrivilegeEscalation) {
-				tnf.ClaimFilePrintf("AllowPrivilegeEscalation is set to true in container %s.", cut.Podname+"."+cut.Data.Name)
-				badContainers = append(badContainers, cut.Podname+"."+cut.Data.Name)
+		if cut.SecurityContext != nil && cut.SecurityContext.AllowPrivilegeEscalation != nil {
+			if *(cut.SecurityContext.AllowPrivilegeEscalation) {
+				tnf.ClaimFilePrintf("AllowPrivilegeEscalation is set to true in container %s.", cut.Podname+"."+cut.Name)
+				badContainers = append(badContainers, cut.Podname+"."+cut.Name)
 			}
 		}
 	}
@@ -257,7 +257,7 @@ func TestSecConPrivilegeEscalation(env *provider.TestEnvironment) {
 func TestContainerHostPort(env *provider.TestEnvironment) {
 	var badContainers []string
 	for _, cut := range env.Containers {
-		for _, aPort := range cut.Data.Ports {
+		for _, aPort := range cut.Ports {
 			if aPort.HostPort != 0 {
 				tnf.ClaimFilePrintf("Host port %d is configured in container %s.", aPort.HostPort, cut.String())
 				badContainers = append(badContainers, cut.String())
@@ -275,9 +275,9 @@ func TestContainerHostPort(env *provider.TestEnvironment) {
 func TestPodHostNetwork(env *provider.TestEnvironment) {
 	var badPods []string
 	for _, put := range env.Pods {
-		if put.Data.Spec.HostNetwork {
-			tnf.ClaimFilePrintf("Host network is set to true in pod %s.", put.Data.Namespace+"."+put.Data.Name)
-			badPods = append(badPods, put.Data.Namespace+"."+put.Data.Name)
+		if put.Spec.HostNetwork {
+			tnf.ClaimFilePrintf("Host network is set to true in pod %s.", put.Namespace+"."+put.Name)
+			badPods = append(badPods, put.Namespace+"."+put.Name)
 		}
 	}
 
@@ -291,11 +291,11 @@ func TestPodHostNetwork(env *provider.TestEnvironment) {
 func TestPodHostPath(env *provider.TestEnvironment) {
 	var badPods []string
 	for _, put := range env.Pods {
-		for idx := range put.Data.Spec.Volumes {
-			vol := &put.Data.Spec.Volumes[idx]
+		for idx := range put.Spec.Volumes {
+			vol := &put.Spec.Volumes[idx]
 			if vol.HostPath != nil && vol.HostPath.Path != "" {
-				tnf.ClaimFilePrintf("Hostpath path: %s is set in pod %s.", vol.HostPath.Path, put.Data.Namespace+"."+put.Data.Name)
-				badPods = append(badPods, put.Data.Namespace+"."+put.Data.Name)
+				tnf.ClaimFilePrintf("Hostpath path: %s is set in pod %s.", vol.HostPath.Path, put.Namespace+"."+put.Name)
+				badPods = append(badPods, put.Namespace+"."+put.Name)
 			}
 		}
 	}
@@ -310,9 +310,9 @@ func TestPodHostPath(env *provider.TestEnvironment) {
 func TestPodHostIPC(env *provider.TestEnvironment) {
 	var badPods []string
 	for _, put := range env.Pods {
-		if put.Data.Spec.HostIPC {
-			tnf.ClaimFilePrintf("HostIpc is set in pod %s.", put.Data.Namespace+"."+put.Data.Name)
-			badPods = append(badPods, put.Data.Namespace+"."+put.Data.Name)
+		if put.Spec.HostIPC {
+			tnf.ClaimFilePrintf("HostIpc is set in pod %s.", put.Namespace+"."+put.Name)
+			badPods = append(badPods, put.Namespace+"."+put.Name)
 		}
 	}
 
@@ -326,9 +326,9 @@ func TestPodHostIPC(env *provider.TestEnvironment) {
 func TestPodHostPID(env *provider.TestEnvironment) {
 	var badPods []string
 	for _, put := range env.Pods {
-		if put.Data.Spec.HostPID {
-			tnf.ClaimFilePrintf("HostPid is set in pod %s.", put.Data.Namespace+"."+put.Data.Name)
-			badPods = append(badPods, put.Data.Namespace+"."+put.Data.Name)
+		if put.Spec.HostPID {
+			tnf.ClaimFilePrintf("HostPid is set in pod %s.", put.Namespace+"."+put.Name)
+			badPods = append(badPods, put.Namespace+"."+put.Name)
 		}
 	}
 
@@ -373,10 +373,10 @@ func TestPodServiceAccount(env *provider.TestEnvironment) {
 	ginkgo.By("Tests that each pod utilizes a valid service account")
 	failedPods := []string{}
 	for _, put := range env.Pods {
-		ginkgo.By(fmt.Sprintf("Testing service account for pod %s (ns: %s)", put.Data.Name, put.Data.Namespace))
-		if put.Data.Spec.ServiceAccountName == "" {
-			tnf.ClaimFilePrintf("Pod %s (ns: %s) doesn't have a service account name.", put.Data.Name, put.Data.Namespace)
-			failedPods = append(failedPods, put.Data.Name)
+		ginkgo.By(fmt.Sprintf("Testing service account for pod %s (ns: %s)", put.Name, put.Namespace))
+		if put.Spec.ServiceAccountName == "" {
+			tnf.ClaimFilePrintf("Pod %s (ns: %s) doesn't have a service account name.", put.Name, put.Namespace)
+			failedPods = append(failedPods, put.Name)
 		}
 	}
 	if n := len(failedPods); n > 0 {
@@ -393,21 +393,21 @@ func TestPodRoleBindings(env *provider.TestEnvironment) {
 	failedPods := []string{}
 
 	for _, put := range env.Pods {
-		ginkgo.By(fmt.Sprintf("Testing role binding for pod: %s namespace: %s", put.Data.Name, put.Data.Namespace))
-		if put.Data.Spec.ServiceAccountName == "" {
+		ginkgo.By(fmt.Sprintf("Testing role binding for pod: %s namespace: %s", put.Name, put.Namespace))
+		if put.Spec.ServiceAccountName == "" {
 			ginkgo.Skip("Can not test when serviceAccountName is empty. Please check previous tests for failures")
 		}
 
 		// Get any rolebindings that do not belong to the pod namespace.
-		roleBindings, err := rbac.GetRoleBindings(put.Data.Namespace, put.Data.Spec.ServiceAccountName)
+		roleBindings, err := rbac.GetRoleBindings(put.Namespace, put.Spec.ServiceAccountName)
 		if err != nil {
-			failedPods = append(failedPods, put.Data.Name)
+			failedPods = append(failedPods, put.Name)
 		}
 
 		if len(roleBindings) > 0 {
-			logrus.Warnf("Pod: %s/%s has the following role bindings: %s", put.Data.Namespace, put.Data.Name, roleBindings)
-			tnf.ClaimFilePrintf("Pod: %s/%s has the following role bindings: %s", put.Data.Namespace, put.Data.Name, roleBindings)
-			failedPods = append(failedPods, put.Data.Name)
+			logrus.Warnf("Pod: %s/%s has the following role bindings: %s", put.Namespace, put.Name, roleBindings)
+			tnf.ClaimFilePrintf("Pod: %s/%s has the following role bindings: %s", put.Namespace, put.Name, roleBindings)
+			failedPods = append(failedPods, put.Name)
 		}
 	}
 	if n := len(failedPods); n > 0 {
@@ -424,21 +424,21 @@ func TestPodClusterRoleBindings(env *provider.TestEnvironment) {
 	failedPods := []string{}
 
 	for _, put := range env.Pods {
-		ginkgo.By(fmt.Sprintf("Testing cluster role binding for pod: %s namespace: %s", put.Data.Name, put.Data.Namespace))
-		if put.Data.Spec.ServiceAccountName == "" {
+		ginkgo.By(fmt.Sprintf("Testing cluster role binding for pod: %s namespace: %s", put.Name, put.Namespace))
+		if put.Spec.ServiceAccountName == "" {
 			ginkgo.Skip("Can not test when serviceAccountName is empty. Please check previous tests for failures")
 		}
 
 		// Get any clusterrolebindings that do not belong to the pod namespace.
-		clusterRoleBindings, err := rbac.GetClusterRoleBindings(put.Data.Namespace, put.Data.Spec.ServiceAccountName)
+		clusterRoleBindings, err := rbac.GetClusterRoleBindings(put.Namespace, put.Spec.ServiceAccountName)
 		if err != nil {
-			failedPods = append(failedPods, put.Data.Name)
+			failedPods = append(failedPods, put.Name)
 		}
 
 		if len(clusterRoleBindings) > 0 {
-			logrus.Warnf("Pod: %s/%s has the following cluster role bindings: %s", put.Data.Namespace, put.Data.Name, clusterRoleBindings)
-			tnf.ClaimFilePrintf("Pod: %s/%s has the following cluster role bindings: %s", put.Data.Namespace, put.Data.Name, clusterRoleBindings)
-			failedPods = append(failedPods, put.Data.Name)
+			logrus.Warnf("Pod: %s/%s has the following cluster role bindings: %s", put.Namespace, put.Name, clusterRoleBindings)
+			tnf.ClaimFilePrintf("Pod: %s/%s has the following cluster role bindings: %s", put.Namespace, put.Name, clusterRoleBindings)
+			failedPods = append(failedPods, put.Name)
 		}
 	}
 	if n := len(failedPods); n > 0 {
@@ -453,16 +453,16 @@ func TestAutomountServiceToken(env *provider.TestEnvironment) {
 	msg := []string{}
 	failedPods := []string{}
 	for _, put := range env.Pods {
-		ginkgo.By(fmt.Sprintf("check the existence of pod service account %s (ns= %s )", put.Data.Namespace, put.Data.Name))
-		if put.Data.Spec.ServiceAccountName == "" {
-			tnf.ClaimFilePrintf("Pod %s has been found with an empty service account name.", put.Data.Name)
+		ginkgo.By(fmt.Sprintf("check the existence of pod service account %s (ns= %s )", put.Namespace, put.Name))
+		if put.Spec.ServiceAccountName == "" {
+			tnf.ClaimFilePrintf("Pod %s has been found with an empty service account name.", put.Name)
 			ginkgo.Fail("Pod has been found with an empty service account name.")
 		}
 
 		// Evaluate the pod's automount service tokens and any attached service accounts
-		podPassed, newMsg := rbac.EvaluateAutomountTokens(put.Data)
+		podPassed, newMsg := rbac.EvaluateAutomountTokens(put.Pod)
 		if !podPassed {
-			failedPods = append(failedPods, put.Data.Name)
+			failedPods = append(failedPods, put.Name)
 			msg = append(msg, newMsg)
 		}
 	}
@@ -525,7 +525,7 @@ func TestSYSNiceRealtimeCapability(env *provider.TestEnvironment) {
 	// or not the node's kernel is realtime enabled.
 	for _, cut := range env.Containers {
 		n := env.Nodes[cut.NodeName]
-		if n.IsRTKernel() && !strings.Contains(cut.Data.SecurityContext.Capabilities.String(), "SYS_NICE") {
+		if n.IsRTKernel() && !strings.Contains(cut.SecurityContext.Capabilities.String(), "SYS_NICE") {
 			tnf.ClaimFilePrintf("Container: %s has been found running on a realtime kernel enabled node without SYS_NICE capability.", cut.String())
 			containersWithoutSysNice = append(containersWithoutSysNice, cut.String())
 		}
@@ -543,9 +543,9 @@ func TestSysPtraceCapability(env *provider.TestEnvironment) {
 
 	for _, put := range env.Pods {
 		sysPtraceEnabled := false
-		if put.Data.Spec.ShareProcessNamespace != nil && *put.Data.Spec.ShareProcessNamespace {
+		if put.Spec.ShareProcessNamespace != nil && *put.Spec.ShareProcessNamespace {
 			for _, cut := range put.Containers {
-				if strings.Contains(cut.Data.SecurityContext.Capabilities.String(), "SYS_PTRACE") {
+				if strings.Contains(cut.SecurityContext.Capabilities.String(), "SYS_PTRACE") {
 					sysPtraceEnabled = true
 					break
 				}
@@ -576,7 +576,7 @@ func TestNamespaceResourceQuota(env *provider.TestEnvironment) {
 			// We are just checking for the existence of the resource quota as of right now.
 			// Read more about the resource quota object here:
 			// https://kubernetes.io/docs/concepts/policy/resource-quotas/
-			if put.Data.Namespace == env.ResourceQuotas[index].Namespace {
+			if put.Namespace == env.ResourceQuotas[index].Namespace {
 				foundPodNamespaceRQ = true
 				break
 			}
@@ -599,10 +599,10 @@ func TestPodTolerationBypass(env *provider.TestEnvironment) {
 	var podsWithRestrictedTolerationsNotDefault []string
 
 	for _, put := range env.Pods {
-		for _, t := range put.Data.Spec.Tolerations {
+		for _, t := range put.Spec.Tolerations {
 			// Check if the tolerations fall outside the 'default' and are modified versions
 			// Take also into account the qosClass applied to the pod
-			if tolerations.IsTolerationModified(t, put.Data.Status.QOSClass) {
+			if tolerations.IsTolerationModified(t, put.Status.QOSClass) {
 				podsWithRestrictedTolerationsNotDefault = append(podsWithRestrictedTolerationsNotDefault, put.String())
 				tnf.ClaimFilePrintf("%s has been found with non-default toleration %s which is not allowed.", put.String(), t.Effect)
 			}
@@ -629,7 +629,7 @@ func TestNoSSHDaemonsAllowed(env *provider.TestEnvironment) {
 	r := regexp.MustCompile(sshDaemonProcessName)
 
 	for _, cut := range env.Containers {
-		ctx := clientsholder.Context{Namespace: cut.Namespace, Podname: cut.Podname, Containername: cut.Data.Name}
+		ctx := clientsholder.Context{Namespace: cut.Namespace, Podname: cut.Podname, Containername: cut.Name}
 		stdout, stderr, err := o.ExecCommandContainer(ctx, listProcessesCmd)
 		if err != nil || stderr != "" {
 			tnf.ClaimFilePrintf("Could not list processes on: %s, error: %s", cut, err)
@@ -665,32 +665,32 @@ func testPodRequestsAndLimits(env *provider.TestEnvironment) {
 	for _, cut := range env.Containers {
 		badContainer := false
 		// Parse the limits.
-		if len(cut.Data.Resources.Limits) == 0 {
+		if len(cut.Resources.Limits) == 0 {
 			tnf.ClaimFilePrintf("Container has been found missing resource limits: %s", cut.String())
 			badContainer = true
 		} else {
-			if cut.Data.Resources.Limits.Cpu() == nil {
+			if cut.Resources.Limits.Cpu() == nil {
 				tnf.ClaimFilePrintf("Container has been found missing CPU limits: %s", cut.String())
 				badContainer = true
 			}
 
-			if cut.Data.Resources.Limits.Memory() == nil {
+			if cut.Resources.Limits.Memory() == nil {
 				tnf.ClaimFilePrintf("Container has been found missing memory limits: %s", cut.String())
 				badContainer = true
 			}
 		}
 
 		// Parse the requests.
-		if len(cut.Data.Resources.Requests) == 0 {
+		if len(cut.Resources.Requests) == 0 {
 			tnf.ClaimFilePrintf("Container has been found missing resource requests: %s", cut.String())
 			badContainer = true
 		} else {
-			if cut.Data.Resources.Requests.Cpu() == nil {
+			if cut.Resources.Requests.Cpu() == nil {
 				tnf.ClaimFilePrintf("Container has been found missing CPU requests: %s", cut.String())
 				badContainer = true
 			}
 
-			if cut.Data.Resources.Requests.Memory() == nil {
+			if cut.Resources.Requests.Memory() == nil {
 				tnf.ClaimFilePrintf("Container has been found missing memory requests: %s", cut.String())
 				badContainer = true
 			}
@@ -714,10 +714,10 @@ func Test1337UIDs(env *provider.TestEnvironment) {
 	const leetNum = 1337
 	var badPods []string
 	for _, put := range env.Pods {
-		ginkgo.By(fmt.Sprintf("checking if pod %s has a securityContext RunAsUser 1337 (ns= %s)", put.Data.Name, put.Data.Namespace))
-		if put.Data.Spec.SecurityContext.RunAsUser != nil && *put.Data.Spec.SecurityContext.RunAsUser == int64(leetNum) {
-			tnf.ClaimFilePrintf("Pod: %s/%s is found to use securityContext RunAsUser 1337", put.Data.Namespace, put.Data.Name)
-			badPods = append(badPods, put.Data.Name)
+		ginkgo.By(fmt.Sprintf("checking if pod %s has a securityContext RunAsUser 1337 (ns= %s)", put.Name, put.Namespace))
+		if put.Spec.SecurityContext.RunAsUser != nil && *put.Spec.SecurityContext.RunAsUser == int64(leetNum) {
+			tnf.ClaimFilePrintf("Pod: %s/%s is found to use securityContext RunAsUser 1337", put.Namespace, put.Name)
+			badPods = append(badPods, put.Name)
 		}
 	}
 

--- a/cnf-certification-test/lifecycle/podsets/podsets.go
+++ b/cnf-certification-test/lifecycle/podsets/podsets.go
@@ -95,11 +95,11 @@ func WaitForAllPodSetReady(env *provider.TestEnvironment, timeoutPodSetReady tim
 func GetAllNodesForAllPodSets(pods []*provider.Pod) (nodes map[string]bool) {
 	nodes = make(map[string]bool)
 	for _, put := range pods {
-		for _, or := range put.Data.OwnerReferences {
+		for _, or := range put.OwnerReferences {
 			if or.Kind != ReplicaSetString && or.Kind != StatefulsetString {
 				continue
 			}
-			nodes[put.Data.Spec.NodeName] = true
+			nodes[put.Spec.NodeName] = true
 			break
 		}
 	}

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -155,8 +155,8 @@ func testContainersPreStop(env *provider.TestEnvironment) {
 	for _, cut := range env.Containers {
 		logrus.Debugln("check container ", cut.String(), " pre stop lifecycle ")
 
-		if cut.Data.Lifecycle == nil || (cut.Data.Lifecycle != nil && cut.Data.Lifecycle.PreStop == nil) {
-			badcontainers = append(badcontainers, cut.Data.Name)
+		if cut.Lifecycle == nil || (cut.Lifecycle != nil && cut.Lifecycle.PreStop == nil) {
+			badcontainers = append(badcontainers, cut.Name)
 			tnf.ClaimFilePrintf("%s does not have preStop defined", cut)
 		}
 	}
@@ -171,9 +171,9 @@ func testContainersImagePolicy(env *provider.TestEnvironment) {
 	badcontainers := []string{}
 	for _, cut := range env.Containers {
 		logrus.Debugln("check container ", cut.String(), " pull policy, should be ", corev1.PullIfNotPresent)
-		if cut.Data.ImagePullPolicy != corev1.PullIfNotPresent {
-			badcontainers = append(badcontainers, "{"+cut.String()+": is using"+string(cut.Data.ImagePullPolicy)+"}")
-			logrus.Errorln("container ", cut.Data.Name, " is using ", cut.Data.ImagePullPolicy, " as image policy")
+		if cut.ImagePullPolicy != corev1.PullIfNotPresent {
+			badcontainers = append(badcontainers, "{"+cut.String()+": is using"+string(cut.ImagePullPolicy)+"}")
+			logrus.Errorln("container ", cut.Name, " is using ", cut.ImagePullPolicy, " as image policy")
 		}
 	}
 	if len(badcontainers) > 0 {
@@ -186,9 +186,9 @@ func testContainersReadinessProbe(env *provider.TestEnvironment) {
 	badcontainers := []string{}
 	for _, cut := range env.Containers {
 		logrus.Debugln("check container ", cut.String(), " readiness probe ")
-		if cut.Data.ReadinessProbe == nil {
+		if cut.ReadinessProbe == nil {
 			badcontainers = append(badcontainers, cut.String())
-			logrus.Errorln("container ", cut.Data.Name, " does not have ReadinessProbe defined")
+			logrus.Errorln("container ", cut.Name, " does not have ReadinessProbe defined")
 		}
 	}
 	if len(badcontainers) > 0 {
@@ -201,9 +201,9 @@ func testContainersLivenessProbe(env *provider.TestEnvironment) {
 	badcontainers := []string{}
 	for _, cut := range env.Containers {
 		logrus.Debugln("check container ", cut.String(), " liveness probe ")
-		if cut.Data.LivenessProbe == nil {
+		if cut.LivenessProbe == nil {
 			badcontainers = append(badcontainers, cut.String())
-			logrus.Errorln("container ", cut.Data.Name, " does not have livenessProbe defined")
+			logrus.Errorln("container ", cut.Name, " does not have livenessProbe defined")
 		}
 	}
 	if len(badcontainers) > 0 {
@@ -216,9 +216,9 @@ func testContainersStartupProbe(env *provider.TestEnvironment) {
 	badcontainers := []string{}
 	for _, cut := range env.Containers {
 		logrus.Debugln("check container ", cut.String(), " startup probe ")
-		if cut.Data.StartupProbe == nil {
+		if cut.StartupProbe == nil {
 			badcontainers = append(badcontainers, cut.String())
-			logrus.Errorln("container ", cut.Data.Name, " does not have startupProbe defined")
+			logrus.Errorln("container ", cut.Name, " does not have startupProbe defined")
 		}
 	}
 	if len(badcontainers) > 0 {
@@ -231,8 +231,8 @@ func testPodsOwnerReference(env *provider.TestEnvironment) {
 	ginkgo.By("Testing owners of CNF pod, should be replicas Set")
 	badPods := []string{}
 	for _, put := range env.Pods {
-		logrus.Debugln("check pod ", put.Data.Namespace, " ", put.Data.Name, " owner reference")
-		o := ownerreference.NewOwnerReference(put.Data)
+		logrus.Debugln("check pod ", put.Namespace, " ", put.Name, " owner reference")
+		o := ownerreference.NewOwnerReference(put.Pod)
 		o.RunTest()
 		if o.GetResults() != testhelper.SUCCESS {
 			badPods = append(badPods, put.String())
@@ -247,13 +247,13 @@ func testPodsOwnerReference(env *provider.TestEnvironment) {
 func testPodNodeSelectorAndAffinityBestPractices(env *provider.TestEnvironment) {
 	var badPods []*corev1.Pod
 	for _, put := range env.NonGuaranteedPods {
-		if len(put.Data.Spec.NodeSelector) != 0 {
-			tnf.ClaimFilePrintf("ERROR: %s has a node selector clause. Node selector: %v", put, &put.Data.Spec.NodeSelector)
-			badPods = append(badPods, put.Data)
+		if len(put.Spec.NodeSelector) != 0 {
+			tnf.ClaimFilePrintf("ERROR: %s has a node selector clause. Node selector: %v", put, &put.Spec.NodeSelector)
+			badPods = append(badPods, put.Pod)
 		}
-		if put.Data.Spec.Affinity != nil && put.Data.Spec.Affinity.NodeAffinity != nil {
-			tnf.ClaimFilePrintf("ERROR: %s has a node affinity clause. Node affinity: %v", put, put.Data.Spec.Affinity.NodeAffinity)
-			badPods = append(badPods, put.Data)
+		if put.Spec.Affinity != nil && put.Spec.Affinity.NodeAffinity != nil {
+			tnf.ClaimFilePrintf("ERROR: %s has a node affinity clause. Node affinity: %v", put, put.Spec.Affinity.NodeAffinity)
+			badPods = append(badPods, put.Pod)
 		}
 	}
 	if n := len(badPods); n > 0 {
@@ -415,8 +415,8 @@ func testPodPersistentVolumeReclaimPolicy(env *provider.TestEnvironment) {
 	// Look through all of the pods, matching their persistent volumes to the list of overall cluster PVs and checking their reclaim status.
 	for _, put := range env.Pods {
 		for index := range env.PersistentVolumes {
-			for pvIndex := range put.Data.Spec.Volumes {
-				if put.Data.Spec.Volumes[pvIndex].Name == env.PersistentVolumes[index].Name && env.PersistentVolumes[index].Spec.PersistentVolumeReclaimPolicy != corev1.PersistentVolumeReclaimDelete {
+			for pvIndex := range put.Spec.Volumes {
+				if put.Spec.Volumes[pvIndex].Name == env.PersistentVolumes[index].Name && env.PersistentVolumes[index].Spec.PersistentVolumeReclaimPolicy != corev1.PersistentVolumeReclaimDelete {
 					persistentVolumesBadReclaim = append(persistentVolumesBadReclaim, env.PersistentVolumes[index].Name)
 					tnf.ClaimFilePrintf("Persistent Volume: %s in namespace %s has been found without a reclaim policy of DELETE.", env.PersistentVolumes[index].Name, env.PersistentVolumes[index].Namespace)
 				}
@@ -446,7 +446,7 @@ func testCPUIsolation(env *provider.TestEnvironment) {
 
 	for _, put := range env.GuaranteedPods {
 		if !put.IsCPUIsolationCompliant() {
-			podsMissingIsolationRequirements[put.Data.Name] = true
+			podsMissingIsolationRequirements[put.Name] = true
 		}
 	}
 

--- a/cnf-certification-test/manageability/suite.go
+++ b/cnf-certification-test/manageability/suite.go
@@ -49,7 +49,7 @@ func testContainersImageTag(env *provider.TestEnvironment) {
 		logrus.Debugln("check container ", cut.String(), " image should be tagged ")
 		if cut.ContainerImageIdentifier.Tag == "" {
 			badcontainers = append(badcontainers, cut.String())
-			logrus.Debugf("Container %s is missing image tag(s)", cut.Data.Name)
+			logrus.Debugf("Container %s is missing image tag(s)", cut.Name)
 		}
 	}
 	if len(badcontainers) > 0 {

--- a/cnf-certification-test/networking/icmp/icmp.go
+++ b/cnf-certification-test/networking/icmp/icmp.go
@@ -58,7 +58,7 @@ func BuildNetTestContext(pods []*provider.Pod, aIPVersion netcommons.IPVersion, 
 
 		if aType == netcommons.MULTUS {
 			if put.SkipMultusNetTests {
-				claimsLog.AddLogLine("Skipping pod %s because it is excluded from %s connectivity tests only", put.Data.Name, aType)
+				claimsLog.AddLogLine("Skipping pod %s because it is excluded from %s connectivity tests only", put.Name, aType)
 				continue
 			}
 			for netKey, multusIPAddress := range put.MultusIPs {
@@ -69,7 +69,7 @@ func BuildNetTestContext(pods []*provider.Pod, aIPVersion netcommons.IPVersion, 
 		}
 
 		const defaultNetKey = "default"
-		defaultIPAddress := put.Data.Status.PodIPs
+		defaultIPAddress := put.Status.PodIPs
 		// The first container is used to get the network namespace
 		ProcessContainerIpsPerNet(put.Containers[0], defaultNetKey, netcommons.PodIPsToStringList(defaultIPAddress), netsUnderTest, aIPVersion)
 	}

--- a/cnf-certification-test/networking/icmp/icmp_test.go
+++ b/cnf-certification-test/networking/icmp/icmp_test.go
@@ -206,7 +206,7 @@ func TestProcessContainerIpsPerNet(t *testing.T) { //nolint:funlen
 			name: "ok",
 			args: args{
 				containerID: &provider.Container{
-					Data:      &corev1.Container{},
+					Container: &corev1.Container{},
 					Status:    corev1.ContainerStatus{},
 					Namespace: "namespace1",
 					Podname:   "pod1",
@@ -224,7 +224,7 @@ func TestProcessContainerIpsPerNet(t *testing.T) { //nolint:funlen
 						TesterSource: netcommons.ContainerIP{
 							IP: "1.1.1.1",
 							ContainerIdentifier: &provider.Container{
-								Data:      &corev1.Container{},
+								Container: &corev1.Container{},
 								Status:    corev1.ContainerStatus{},
 								Namespace: "namespace1",
 								Podname:   "pod1",
@@ -236,7 +236,7 @@ func TestProcessContainerIpsPerNet(t *testing.T) { //nolint:funlen
 						DestTargets: []netcommons.ContainerIP{{
 							IP: "2.2.2.2",
 							ContainerIdentifier: &provider.Container{
-								Data:      &corev1.Container{},
+								Container: &corev1.Container{},
 								Status:    corev1.ContainerStatus{},
 								Namespace: "namespace1",
 								Podname:   "pod1",
@@ -247,7 +247,7 @@ func TestProcessContainerIpsPerNet(t *testing.T) { //nolint:funlen
 						}, {
 							IP: "3.3.3.3",
 							ContainerIdentifier: &provider.Container{
-								Data:      &corev1.Container{},
+								Container: &corev1.Container{},
 								Status:    corev1.ContainerStatus{},
 								Namespace: "namespace1",
 								Podname:   "pod1",
@@ -296,7 +296,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 					TesterSource: netcommons.ContainerIP{
 						IP: "10.244.195.231",
 						ContainerIdentifier: &provider.Container{
-							Data: &corev1.Container{
+							Container: &corev1.Container{
 								Name: "test1",
 							},
 							Namespace: "tnf",
@@ -309,7 +309,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 					DestTargets: []netcommons.ContainerIP{{
 						IP: "10.244.195.232",
 						ContainerIdentifier: &provider.Container{
-							Data: &corev1.Container{
+							Container: &corev1.Container{
 								Name: "test2",
 							},
 							Namespace: "tnf",
@@ -335,7 +335,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 					TesterSource: netcommons.ContainerIP{
 						IP: "10.244.195.231",
 						ContainerIdentifier: &provider.Container{
-							Data: &corev1.Container{
+							Container: &corev1.Container{
 								Name: "test1",
 							},
 							Namespace: "tnf",
@@ -363,7 +363,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 					TesterSource: netcommons.ContainerIP{
 						IP: "192.168.0.3",
 						ContainerIdentifier: &provider.Container{
-							Data: &corev1.Container{
+							Container: &corev1.Container{
 								Name: "test1",
 							},
 							Namespace: "tnf",
@@ -377,7 +377,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 						{
 							IP: "192.168.0.4",
 							ContainerIdentifier: &provider.Container{
-								Data: &corev1.Container{
+								Container: &corev1.Container{
 									Name: "test2",
 								},
 								Namespace: "tnf",
@@ -394,7 +394,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 					TesterSource: netcommons.ContainerIP{
 						IP: "192.168.1.3",
 						ContainerIdentifier: &provider.Container{
-							Data: &corev1.Container{
+							Container: &corev1.Container{
 								Name: "test1",
 							},
 							Namespace: "tnf",
@@ -408,7 +408,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 						{
 							IP: "192.168.1.4",
 							ContainerIdentifier: &provider.Container{
-								Data: &corev1.Container{
+								Container: &corev1.Container{
 									Name: "test2",
 								},
 								Namespace: "tnf",
@@ -433,7 +433,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 					TesterSource: netcommons.ContainerIP{
 						IP: "192.168.0.3",
 						ContainerIdentifier: &provider.Container{
-							Data: &corev1.Container{
+							Container: &corev1.Container{
 								Name: "test1",
 							},
 							Namespace: "tnf",
@@ -450,7 +450,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 					TesterSource: netcommons.ContainerIP{
 						IP: "192.168.1.3",
 						ContainerIdentifier: &provider.Container{
-							Data: &corev1.Container{
+							Container: &corev1.Container{
 								Name: "test1",
 							},
 							Namespace: "tnf",
@@ -472,7 +472,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 			for idx := range tt.args.pods {
 				tt.args.pods[idx].MultusIPs = make(map[string][]string)
 				var err error
-				tt.args.pods[idx].MultusIPs, err = provider.GetPodIPsPerNet(tt.args.pods[idx].Data.GetAnnotations()[provider.CniNetworksStatusKey])
+				tt.args.pods[idx].MultusIPs, err = provider.GetPodIPsPerNet(tt.args.pods[idx].GetAnnotations()[provider.CniNetworksStatusKey])
 				if err != nil {
 					fmt.Printf("Could not decode networks-status annotation")
 				}
@@ -500,7 +500,7 @@ func TestBuildNetTestContext(t *testing.T) { //nolint:funlen
 
 var (
 	pod1 = provider.Pod{ //nolint:dupl
-		Data: &corev1.Pod{
+		Pod: &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod1",
 				Namespace: "ns1",
@@ -526,7 +526,7 @@ var (
 		SkipMultusNetTests: false,
 		Containers: []*provider.Container{
 			{
-				Data: &corev1.Container{
+				Container: &corev1.Container{
 					Name: "test1",
 				},
 				Namespace: "tnf",
@@ -538,7 +538,7 @@ var (
 		},
 	}
 	pod2 = provider.Pod{ //nolint:dupl
-		Data: &corev1.Pod{
+		Pod: &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod2",
 				Namespace: "ns1",
@@ -564,7 +564,7 @@ var (
 		SkipMultusNetTests: false,
 		Containers: []*provider.Container{
 			{
-				Data: &corev1.Container{
+				Container: &corev1.Container{
 					Name: "test2",
 				},
 				Namespace: "tnf",
@@ -576,7 +576,7 @@ var (
 		},
 	}
 	pod3 = provider.Pod{ //nolint:dupl
-		Data: &corev1.Pod{
+		Pod: &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod2",
 				Namespace: "ns1",
@@ -602,7 +602,7 @@ var (
 		SkipMultusNetTests: false,
 		Containers: []*provider.Container{
 			{
-				Data: &corev1.Container{
+				Container: &corev1.Container{
 					Name: "test2",
 				},
 				Namespace: "tnf",
@@ -614,7 +614,7 @@ var (
 		},
 	}
 	pod4 = provider.Pod{ //nolint:dupl
-		Data: &corev1.Pod{
+		Pod: &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod2",
 				Namespace: "ns1",
@@ -640,7 +640,7 @@ var (
 		SkipMultusNetTests: true,
 		Containers: []*provider.Container{
 			{
-				Data: &corev1.Container{
+				Container: &corev1.Container{
 					Name: "test2",
 				},
 				Namespace: "tnf",
@@ -672,7 +672,7 @@ func TestRunNetworkingTests(t *testing.T) { //nolint:funlen
 				TesterSource: netcommons.ContainerIP{
 					IP: "10.244.195.231",
 					ContainerIdentifier: &provider.Container{
-						Data: &corev1.Container{
+						Container: &corev1.Container{
 							Name: "test1",
 						},
 						Namespace: "tnf",
@@ -685,7 +685,7 @@ func TestRunNetworkingTests(t *testing.T) { //nolint:funlen
 				DestTargets: []netcommons.ContainerIP{{
 					IP: "10.244.195.232",
 					ContainerIdentifier: &provider.Container{
-						Data: &corev1.Container{
+						Container: &corev1.Container{
 							Name: "test2",
 						},
 						Namespace: "tnf",
@@ -716,7 +716,7 @@ func TestRunNetworkingTests(t *testing.T) { //nolint:funlen
 				TesterSource: netcommons.ContainerIP{
 					IP: "10.244.195.231",
 					ContainerIdentifier: &provider.Container{
-						Data: &corev1.Container{
+						Container: &corev1.Container{
 							Name: "test1",
 						},
 						Namespace: "tnf",
@@ -739,7 +739,7 @@ func TestRunNetworkingTests(t *testing.T) { //nolint:funlen
 				TesterSource: netcommons.ContainerIP{
 					IP: "10.244.195.231",
 					ContainerIdentifier: &provider.Container{
-						Data: &corev1.Container{
+						Container: &corev1.Container{
 							Name: "test1",
 						},
 						Namespace: "tnf",
@@ -752,7 +752,7 @@ func TestRunNetworkingTests(t *testing.T) { //nolint:funlen
 				DestTargets: []netcommons.ContainerIP{{
 					IP: "10.244.195.232",
 					ContainerIdentifier: &provider.Container{
-						Data: &corev1.Container{
+						Container: &corev1.Container{
 							Name: "test2",
 						},
 						Namespace: "tnf",
@@ -765,7 +765,7 @@ func TestRunNetworkingTests(t *testing.T) { //nolint:funlen
 					{
 						IP: "10.244.195.233",
 						ContainerIdentifier: &provider.Container{
-							Data: &corev1.Container{
+							Container: &corev1.Container{
 								Name: "test3",
 							},
 							Namespace: "tnf",

--- a/cnf-certification-test/networking/netcommons/netcommons_test.go
+++ b/cnf-certification-test/networking/netcommons/netcommons_test.go
@@ -148,7 +148,7 @@ func TestContainerIPString(t *testing.T) {
 			IP: IP,
 			ContainerIdentifier: &provider.Container{
 				UID: ID,
-				Data: &corev1.Container{
+				Container: &corev1.Container{
 					Name: "test-" + ID,
 				},
 			},
@@ -185,7 +185,7 @@ func TestNetTestContextString(t *testing.T) {
 			TesterSource: ContainerIP{
 				IP: IP,
 				ContainerIdentifier: &provider.Container{
-					Data: &corev1.Container{
+					Container: &corev1.Container{
 						Name: containerName,
 					},
 				},
@@ -194,7 +194,7 @@ func TestNetTestContextString(t *testing.T) {
 				{
 					IP: IP,
 					ContainerIdentifier: &provider.Container{
-						Data: &corev1.Container{
+						Container: &corev1.Container{
 							Name: containerName,
 						},
 					},
@@ -233,7 +233,7 @@ func TestNetTestContextMapString(t *testing.T) {
 			TesterSource: ContainerIP{
 				IP: IP,
 				ContainerIdentifier: &provider.Container{
-					Data: &corev1.Container{
+					Container: &corev1.Container{
 						Name: containerName,
 					},
 				},
@@ -242,7 +242,7 @@ func TestNetTestContextMapString(t *testing.T) {
 				{
 					IP: IP,
 					ContainerIdentifier: &provider.Container{
-						Data: &corev1.Container{
+						Container: &corev1.Container{
 							Name: containerName,
 						},
 					},

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -126,7 +126,7 @@ func testUndeclaredContainerPortsUsage(env *provider.TestEnvironment) {
 		// First get the ports declared in the Pod's containers spec
 		declaredPorts := make(map[netutil.PortInfo]bool)
 		for _, cut := range put.Containers {
-			for _, port := range cut.Data.Ports {
+			for _, port := range cut.Ports {
 				portInfo.PortNumber = int(port.ContainerPort)
 				portInfo.Protocol = string(port.Protocol)
 				declaredPorts[portInfo] = true
@@ -206,7 +206,7 @@ func testOCPReservedPortsUsage(env *provider.TestEnvironment) {
 
 	// First check if any of the containers under test has declared a port reserved by OCP
 	for _, cut := range env.Containers {
-		for _, port := range cut.Data.Ports {
+		for _, port := range cut.Ports {
 			if OCPReservedPorts[port.ContainerPort] {
 				tnf.ClaimFilePrintf("%s has declared a port (%d) reserved by OpenShift", cut, port.ContainerPort)
 				rogueContainers = append(rogueContainers, cut.String())
@@ -337,12 +337,12 @@ func testNetworkPolicyDenyAll(env *provider.TestEnvironment) {
 			logrus.Debugf("Testing network policy %s against pod %s", env.NetworkPolicies[index].Name, put.String())
 
 			// Skip any network policies that don't match the namespace of the pod we are testing.
-			if env.NetworkPolicies[index].Namespace != put.Data.Namespace {
+			if env.NetworkPolicies[index].Namespace != put.Namespace {
 				continue
 			}
 
 			// Match the pod namespace with the network policy namespace.
-			if policies.LabelsMatch(env.NetworkPolicies[index].Spec.PodSelector, put.Data.Labels) {
+			if policies.LabelsMatch(env.NetworkPolicies[index].Spec.PodSelector, put.Labels) {
 				if !denyAllEgressFound {
 					denyAllEgressFound = policies.IsNetworkPolicyCompliant(&env.NetworkPolicies[index], networkingv1.PolicyTypeEgress)
 				}
@@ -354,13 +354,13 @@ func testNetworkPolicyDenyAll(env *provider.TestEnvironment) {
 
 		// Network policy has not been found that contains a deny-all rule for both ingress and egress.
 		if !denyAllIngressFound {
-			podsMissingDenyAllDefaultPolicies = append(podsMissingDenyAllDefaultPolicies, put.Data.Name)
-			tnf.ClaimFilePrintf("%s was found to not have a default ingress deny-all network policy.", put.Data.Name)
+			podsMissingDenyAllDefaultPolicies = append(podsMissingDenyAllDefaultPolicies, put.Name)
+			tnf.ClaimFilePrintf("%s was found to not have a default ingress deny-all network policy.", put.Name)
 		}
 
 		if !denyAllEgressFound {
-			podsMissingDenyAllDefaultPolicies = append(podsMissingDenyAllDefaultPolicies, put.Data.Name)
-			tnf.ClaimFilePrintf("%s was found to not have a default egress deny-all network policy.", put.Data.Name)
+			podsMissingDenyAllDefaultPolicies = append(podsMissingDenyAllDefaultPolicies, put.Name)
+			tnf.ClaimFilePrintf("%s was found to not have a default egress deny-all network policy.", put.Name)
 		}
 	}
 

--- a/cnf-certification-test/observability/suite.go
+++ b/cnf-certification-test/observability/suite.go
@@ -77,7 +77,7 @@ func containerHasLoggingOutput(cut *provider.Container) (bool, error) {
 	// We need to ask for the last two lines.
 	const tailLogLines = 2
 	numLogLines := int64(tailLogLines)
-	podLogOptions := corev1.PodLogOptions{TailLines: &numLogLines, Container: cut.Data.Name}
+	podLogOptions := corev1.PodLogOptions{TailLines: &numLogLines, Container: cut.Name}
 	req := ocpClient.K8sClient.CoreV1().Pods(cut.Namespace).GetLogs(cut.Podname, &podLogOptions)
 
 	podLogsReaderCloser, err := req.Stream(context.TODO())
@@ -145,9 +145,9 @@ func testTerminationMessagePolicy(env *provider.TestEnvironment) {
 	failedContainers := []string{}
 	for _, cut := range env.Containers {
 		ginkgo.By("Testing for terminationMessagePolicy: " + cut.String())
-		if cut.Data.TerminationMessagePolicy != corev1.TerminationMessageFallbackToLogsOnError {
+		if cut.TerminationMessagePolicy != corev1.TerminationMessageFallbackToLogsOnError {
 			tnf.ClaimFilePrintf("FAILURE: %s does not have a TerminationMessagePolicy: FallbackToLogsOnError", cut)
-			failedContainers = append(failedContainers, cut.Data.Name)
+			failedContainers = append(failedContainers, cut.Name)
 		}
 	}
 	if n := len(failedContainers); n > 0 {

--- a/cnf-certification-test/platform/bootparams/bootparams.go
+++ b/cnf-certification-test/platform/bootparams/bootparams.go
@@ -100,7 +100,7 @@ func getCurrentKernelCmdlineArgs(cut *provider.Container) (aMap map[string]strin
 	o := clientsholder.GetClientsHolder()
 	ctx := clientsholder.Context{Namespace: cut.Namespace,
 		Podname:       cut.Podname,
-		Containername: cut.Data.Name}
+		Containername: cut.Name}
 	currnetKernelCmdlineArgs, errStr, err := o.ExecCommandContainer(ctx, kernelArgscommand)
 	if err != nil || errStr != "" {
 		return aMap, fmt.Errorf("cannot execute %s on container %s, err=%s, stderr=%s", grubKernelArgsCommand, cut, err, errStr)

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -189,10 +189,10 @@ func testContainersFsDiff(env *provider.TestEnvironment) {
 			continue
 		case testhelper.FAILURE:
 			tnf.ClaimFilePrintf("%s - changed folders: %v, deleted folders: %v", cut, fsDiffTester.ChangedFolders, fsDiffTester.DeletedFolders)
-			badContainers = append(badContainers, cut.Data.Name)
+			badContainers = append(badContainers, cut.Name)
 		case testhelper.ERROR:
 			tnf.ClaimFilePrintf("%s - error while running fs-diff: %v: ", cut, fsDiffTester.Error)
-			errContainers = append(errContainers, cut.Data.Name)
+			errContainers = append(errContainers, cut.Name)
 		}
 	}
 
@@ -317,7 +317,7 @@ func testIsRedHatRelease(env *provider.TestEnvironment) {
 		baseImageTester := isredhat.NewBaseImageTester(clientsholder.GetClientsHolder(), clientsholder.Context{
 			Namespace:     cut.Namespace,
 			Podname:       cut.Podname,
-			Containername: cut.Data.Name,
+			Containername: cut.Name,
 		})
 
 		result, err := baseImageTester.TestContainerIsRedHatRelease()
@@ -325,7 +325,7 @@ func testIsRedHatRelease(env *provider.TestEnvironment) {
 			logrus.Error("failed to collect release information from container: ", err)
 		}
 		if !result {
-			failedContainers = append(failedContainers, cut.Namespace+"/"+cut.Podname+"/"+cut.Data.Name)
+			failedContainers = append(failedContainers, cut.Namespace+"/"+cut.Podname+"/"+cut.Name)
 			tnf.ClaimFilePrintf("%s has failed the RHEL release check", cut)
 		}
 	}

--- a/internal/crclient/crclient.go
+++ b/internal/crclient/crclient.go
@@ -61,7 +61,7 @@ func ExecCommandContainerNSEnter(command string,
 	// Getting the debug pod corresponding to the container's node
 	debugPod := env.DebugPods[aContainer.NodeName]
 	if debugPod == nil {
-		err = fmt.Errorf("debug pod not found on Node: %s trying to run command: \" %s \" Namespace: %s Pod: %s container %s err:%s", aContainer.NodeName, command, aContainer.Namespace, aContainer.Podname, aContainer.Data.Name, err)
+		err = fmt.Errorf("debug pod not found on Node: %s trying to run command: \" %s \" Namespace: %s Pod: %s container %s err:%s", aContainer.NodeName, command, aContainer.Namespace, aContainer.Podname, aContainer.Name, err)
 		return "", "", err
 	}
 	o := clientsholder.GetClientsHolder()

--- a/pkg/provider/isolation.go
+++ b/pkg/provider/isolation.go
@@ -24,16 +24,16 @@ func AreResourcesIdentical(p *Pod) bool {
 	// Pods may contain more than one container.  All containers must conform to the CPU isolation requirements.
 	for _, cut := range p.Containers {
 		// Resources must be specified
-		if len(cut.Data.Resources.Requests) == 0 || len(cut.Data.Resources.Limits) == 0 {
+		if len(cut.Resources.Requests) == 0 || len(cut.Resources.Limits) == 0 {
 			logrus.Debugf("%s has been found with undefined requests or limits.", cut.String())
 			return false
 		}
 
 		// Gather the values
-		cpuRequests := cut.Data.Resources.Requests.Cpu()
-		cpuLimits := cut.Data.Resources.Limits.Cpu()
-		memoryRequests := cut.Data.Resources.Requests.Memory()
-		memoryLimits := cut.Data.Resources.Limits.Memory()
+		cpuRequests := cut.Resources.Requests.Cpu()
+		cpuLimits := cut.Resources.Limits.Cpu()
+		memoryRequests := cut.Resources.Requests.Memory()
+		memoryLimits := cut.Resources.Limits.Memory()
 
 		// Check for mismatches
 		if cpuRequests.Value() != cpuLimits.Value() {
@@ -58,14 +58,14 @@ func AreCPUResourcesWholeUnits(p *Pod) bool {
 	// Pods may contain more than one container.  All containers must conform to the CPU isolation requirements.
 	for _, cut := range p.Containers {
 		// Resources must be specified
-		if len(cut.Data.Resources.Requests) == 0 || len(cut.Data.Resources.Limits) == 0 {
+		if len(cut.Resources.Requests) == 0 || len(cut.Resources.Limits) == 0 {
 			logrus.Debugf("%s has been found with undefined requests or limits.", cut.String())
 			return false
 		}
 
 		// Gather the values
-		cpuRequests := cut.Data.Resources.Requests.Cpu().MilliValue()
-		cpuLimits := cut.Data.Resources.Limits.Cpu().MilliValue()
+		cpuRequests := cut.Resources.Requests.Cpu().MilliValue()
+		cpuLimits := cut.Resources.Limits.Cpu().MilliValue()
 
 		if !isInteger(cpuRequests) {
 			logrus.Debugf("%s has CPU requests %d (milli) that has to be a whole unit.", cut.String(), cpuRequests)
@@ -81,7 +81,7 @@ func AreCPUResourcesWholeUnits(p *Pod) bool {
 }
 
 func IsRuntimeClassNameSpecified(p *Pod) bool {
-	return p.Data.Spec.RuntimeClassName != nil
+	return p.Spec.RuntimeClassName != nil
 }
 
 func LoadBalancingDisabled(p *Pod) bool {
@@ -92,7 +92,7 @@ func LoadBalancingDisabled(p *Pod) bool {
 	cpuLoadBalancingDisabled := false
 	irqLoadBalancingDisabled := false
 
-	if v, ok := p.Data.ObjectMeta.Annotations["cpu-load-balancing.crio.io"]; ok {
+	if v, ok := p.ObjectMeta.Annotations["cpu-load-balancing.crio.io"]; ok {
 		if v == disableVar {
 			cpuLoadBalancingDisabled = true
 		} else {
@@ -102,7 +102,7 @@ func LoadBalancingDisabled(p *Pod) bool {
 		logrus.Debugf("Annotation cpu-load-balancing.crio.io is missing.")
 	}
 
-	if v, ok := p.Data.ObjectMeta.Annotations["irq-load-balancing.crio.io"]; ok {
+	if v, ok := p.ObjectMeta.Annotations["irq-load-balancing.crio.io"]; ok {
 		if v == disableVar {
 			irqLoadBalancingDisabled = true
 		} else {

--- a/pkg/provider/isolation_test.go
+++ b/pkg/provider/isolation_test.go
@@ -48,7 +48,7 @@ func TestCPUIsolation(t *testing.T) {
 			testPod: &Pod{
 				Containers: []*Container{
 					{
-						Data: &v1.Container{
+						Container: &v1.Container{
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
 									"cpu":    resource.MustParse(validCPULimit),
@@ -62,7 +62,7 @@ func TestCPUIsolation(t *testing.T) {
 						},
 					},
 				},
-				Data: &v1.Pod{
+				Pod: &v1.Pod{
 					Spec: v1.PodSpec{
 						RuntimeClassName: &testClassName,
 					},
@@ -83,7 +83,7 @@ func TestCPUIsolation(t *testing.T) {
 			testPod: &Pod{
 				Containers: []*Container{
 					{
-						Data: &v1.Container{
+						Container: &v1.Container{
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
 									"cpu":    resource.MustParse(validCPULimit),
@@ -97,7 +97,7 @@ func TestCPUIsolation(t *testing.T) {
 						},
 					},
 				},
-				Data: &v1.Pod{
+				Pod: &v1.Pod{
 					Spec: v1.PodSpec{
 						RuntimeClassName: &testClassName,
 					},
@@ -118,7 +118,7 @@ func TestCPUIsolation(t *testing.T) {
 			testPod: &Pod{
 				Containers: []*Container{
 					{
-						Data: &v1.Container{
+						Container: &v1.Container{
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
 									"cpu":    resource.MustParse(invalidCPULimit1),
@@ -132,7 +132,7 @@ func TestCPUIsolation(t *testing.T) {
 						},
 					},
 				},
-				Data: &v1.Pod{
+				Pod: &v1.Pod{
 					Spec: v1.PodSpec{
 						RuntimeClassName: &testClassName,
 					},
@@ -153,7 +153,7 @@ func TestCPUIsolation(t *testing.T) {
 			testPod: &Pod{
 				Containers: []*Container{
 					{
-						Data: &v1.Container{
+						Container: &v1.Container{
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
 									"cpu":    resource.MustParse(validCPULimit),
@@ -167,7 +167,7 @@ func TestCPUIsolation(t *testing.T) {
 						},
 					},
 				},
-				Data: &v1.Pod{
+				Pod: &v1.Pod{
 					Spec: v1.PodSpec{
 						RuntimeClassName: nil,
 					},
@@ -188,7 +188,7 @@ func TestCPUIsolation(t *testing.T) {
 			testPod: &Pod{
 				Containers: []*Container{
 					{
-						Data: &v1.Container{
+						Container: &v1.Container{
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
 									"cpu":    resource.MustParse(validCPULimit),
@@ -202,7 +202,7 @@ func TestCPUIsolation(t *testing.T) {
 						},
 					},
 				},
-				Data: &v1.Pod{
+				Pod: &v1.Pod{
 					Spec: v1.PodSpec{
 						RuntimeClassName: &testClassName,
 					},

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -69,7 +69,7 @@ var (
 )
 
 type Pod struct {
-	Data               *corev1.Pod
+	*corev1.Pod
 	Containers         []*Container
 	MultusIPs          map[string][]string
 	SkipNetTests       bool
@@ -86,7 +86,7 @@ type StatefulSet struct {
 
 func NewPod(aPod *corev1.Pod) (out Pod) {
 	var err error
-	out.Data = aPod
+	out.Pod = aPod
 	out.MultusIPs = make(map[string][]string)
 	out.MultusIPs, err = GetPodIPsPerNet(aPod.GetAnnotations()[CniNetworksStatusKey])
 	if err != nil {
@@ -159,7 +159,7 @@ type Operator struct {
 	Channel          string                            `yaml:"channel" json:"channel"`
 }
 type Container struct {
-	Data                     *corev1.Container
+	*corev1.Container
 	Status                   corev1.ContainerStatus
 	Namespace                string
 	Podname                  string
@@ -413,7 +413,7 @@ func getPodContainers(aPod *corev1.Pod) (containerList []*Container) {
 		}
 		aRuntime, uid := GetRuntimeUID(&state)
 		container := Container{Podname: aPod.Name, Namespace: aPod.Namespace,
-			NodeName: aPod.Spec.NodeName, Data: cut, Status: state, Runtime: aRuntime, UID: uid,
+			NodeName: aPod.Spec.NodeName, Container: cut, Status: state, Runtime: aRuntime, UID: uid,
 			ContainerImageIdentifier: buildContainerImageSource(aPod.Spec.Containers[j].Image)}
 		containerList = append(containerList, &container)
 	}
@@ -506,10 +506,10 @@ func (c *Container) GetUID() (string, error) {
 		uid = split[len(split)-1]
 	}
 	if uid == "" {
-		logrus.Debugln(fmt.Sprintf("could not find uid of %s/%s/%s\n", c.Namespace, c.Podname, c.Data.Name))
+		logrus.Debugln(fmt.Sprintf("could not find uid of %s/%s/%s\n", c.Namespace, c.Podname, c.Name))
 		return "", errors.New("cannot determine container UID")
 	}
-	logrus.Debugln(fmt.Sprintf("uid of %s/%s/%s=%s\n", c.Namespace, c.Podname, c.Data.Name, uid))
+	logrus.Debugln(fmt.Sprintf("uid of %s/%s/%s=%s\n", c.Namespace, c.Podname, c.Name, uid))
 	return uid, nil
 }
 
@@ -549,14 +549,14 @@ func (c *Container) StringLong() string {
 		c.NodeName,
 		c.Namespace,
 		c.Podname,
-		c.Data.Name,
+		c.Name,
 		c.Status.ContainerID,
 		c.Runtime,
 	)
 }
 func (c *Container) String() string {
 	return fmt.Sprintf("container: %s pod: %s ns: %s",
-		c.Data.Name,
+		c.Name,
 		c.Podname,
 		c.Namespace,
 	)
@@ -564,8 +564,8 @@ func (c *Container) String() string {
 
 func (p *Pod) String() string {
 	return fmt.Sprintf("pod: %s ns: %s",
-		p.Data.Name,
-		p.Data.Namespace,
+		p.Name,
+		p.Namespace,
 	)
 }
 

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -159,7 +159,7 @@ func TestGetUID(t *testing.T) {
 
 	for _, tc := range testCases {
 		c := GetContainer()
-		c.Data = &corev1.Container{}
+		c.Container = &corev1.Container{}
 		c.Status.ContainerID = tc.testCID
 		uid, err := c.GetUID()
 		assert.Equal(t, tc.expectedErr, err)
@@ -632,7 +632,7 @@ func TestConvertArrayPods(t *testing.T) {
 			},
 			expectedPods: []*Pod{
 				{
-					Data: &corev1.Pod{
+					Pod: &corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "testpod1",
 							Namespace: "testnamespace1",
@@ -659,7 +659,7 @@ func TestConvertArrayPods(t *testing.T) {
 			},
 			expectedPods: []*Pod{
 				{
-					Data: &corev1.Pod{
+					Pod: &corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "testpod1",
 							Namespace: "testnamespace1",
@@ -667,7 +667,7 @@ func TestConvertArrayPods(t *testing.T) {
 					},
 					Containers: []*Container{
 						{
-							Data: &corev1.Container{
+							Container: &corev1.Container{
 								Name: "testcontainer1",
 							},
 							Namespace: "testnamespace1",
@@ -682,8 +682,8 @@ func TestConvertArrayPods(t *testing.T) {
 	for _, tc := range testCases {
 		convertedArray := ConvertArrayPods(tc.testPods)
 		assert.Equal(t, tc.expectedPods[0].Containers, convertedArray[0].Containers)
-		assert.Equal(t, tc.expectedPods[0].Data.Name, convertedArray[0].Data.Name)
-		assert.Equal(t, tc.expectedPods[0].Data.Namespace, convertedArray[0].Data.Namespace)
+		assert.Equal(t, tc.expectedPods[0].Name, convertedArray[0].Name)
+		assert.Equal(t, tc.expectedPods[0].Namespace, convertedArray[0].Namespace)
 	}
 }
 
@@ -776,7 +776,7 @@ func TestContainerStringFuncs(t *testing.T) {
 			NodeName:  tc.nodename,
 			Namespace: tc.namespace,
 			Podname:   tc.podname,
-			Data: &corev1.Container{
+			Container: &corev1.Container{
 				Name: tc.name,
 			},
 			Status: corev1.ContainerStatus{
@@ -826,7 +826,7 @@ func TestCsvToString(t *testing.T) {
 
 func TestPodString(t *testing.T) {
 	p := Pod{
-		Data: &corev1.Pod{
+		Pod: &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test1",
 				Namespace: "testNS",


### PR DESCRIPTION
Similar to #501 that did the same for `Deployment` and `StatefulSet`.  This removes the "Data" variable from the struct that wraps the k8s structs themselves.