### PR TITLE
Add control-plane toleration to daemonset.

### DIFF
--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -139,6 +139,10 @@ func CreateDaemonSetsTemplate(dsName, namespace, containerName, imageWithVersion
 							Effect: "NoSchedule",
 							Key:    "node-role.kubernetes.io/master",
 						},
+						{
+							Effect: "NoSchedule",
+							Key:    "node-role.kubernetes.io/control-plane",
+						},
 					},
 					Volumes: []corev1.Volume{
 						{


### PR DESCRIPTION
Nodes with k8s version v1.24 in kind have a new toleration for the control-plane+worker nodes. We need to add it here, otherwise the pod won't run on that node, making CI to fail.

Signed-off-by: Gonzalo Reyero Ferreras <greyerof@redhat.com>