### PR TITLE
Break down provider into multiple files

### DIFF
--- a/pkg/provider/containers.go
+++ b/pkg/provider/containers.go
@@ -1,0 +1,74 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type Container struct {
+	*corev1.Container
+	Status                   corev1.ContainerStatus
+	Namespace                string
+	Podname                  string
+	NodeName                 string
+	Runtime                  string
+	UID                      string
+	ContainerImageIdentifier configuration.ContainerImageIdentifier
+}
+
+func GetContainer() *Container {
+	return &Container{}
+}
+
+func (c *Container) GetUID() (string, error) {
+	split := strings.Split(c.Status.ContainerID, "://")
+	uid := ""
+	if len(split) > 0 {
+		uid = split[len(split)-1]
+	}
+	if uid == "" {
+		logrus.Debugln(fmt.Sprintf("could not find uid of %s/%s/%s\n", c.Namespace, c.Podname, c.Name))
+		return "", errors.New("cannot determine container UID")
+	}
+	logrus.Debugln(fmt.Sprintf("uid of %s/%s/%s=%s\n", c.Namespace, c.Podname, c.Name, uid))
+	return uid, nil
+}
+
+func (c *Container) StringLong() string {
+	return fmt.Sprintf("node: %s ns: %s podName: %s containerName: %s containerUID: %s containerRuntime: %s",
+		c.NodeName,
+		c.Namespace,
+		c.Podname,
+		c.Name,
+		c.Status.ContainerID,
+		c.Runtime,
+	)
+}
+func (c *Container) String() string {
+	return fmt.Sprintf("container: %s pod: %s ns: %s",
+		c.Name,
+		c.Podname,
+		c.Namespace,
+	)
+}

--- a/pkg/provider/containers_test.go
+++ b/pkg/provider/containers_test.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package provider

--- a/pkg/provider/deployments.go
+++ b/pkg/provider/deployments.go
@@ -1,0 +1,73 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package provider
+
+import (
+	"fmt"
+
+	"github.com/test-network-function/cnf-certification-test/pkg/autodiscover"
+	appsv1 "k8s.io/api/apps/v1"
+	appv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
+)
+
+type Deployment struct {
+	*appsv1.Deployment
+}
+
+func (d *Deployment) IsDeploymentReady() bool {
+	notReady := true
+
+	// Check the deployment's conditions for deploymentAvailable.
+	for _, condition := range d.Status.Conditions {
+		if condition.Type == appsv1.DeploymentAvailable {
+			notReady = false // Deployment is ready
+			break
+		}
+	}
+
+	// Find the number of expected replicas
+	var replicas int32
+	if d.Spec.Replicas != nil {
+		replicas = *(d.Spec.Replicas)
+	} else {
+		replicas = 1
+	}
+
+	// If condition says that the deployment is not ready or replicas do not match totals specified in spec.replicas.
+	if notReady ||
+		d.Status.UnavailableReplicas != 0 || //
+		d.Status.ReadyReplicas != replicas || // eg. 10 ready replicas == 10 total replicas
+		d.Status.AvailableReplicas != replicas ||
+		d.Status.UpdatedReplicas != replicas {
+		return false
+	}
+	return true
+}
+
+func (d *Deployment) ToString() string {
+	return fmt.Sprintf("deployment: %s ns: %s",
+		d.Name,
+		d.Namespace,
+	)
+}
+
+func GetUpdatedDeployment(ac appv1client.AppsV1Interface, namespace, podName string) (*Deployment, error) {
+	result, err := autodiscover.FindDeploymentByNameByNamespace(ac, namespace, podName)
+	return &Deployment{
+		result,
+	}, err
+}

--- a/pkg/provider/deployments_test.go
+++ b/pkg/provider/deployments_test.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package provider

--- a/pkg/provider/nodes.go
+++ b/pkg/provider/nodes.go
@@ -1,0 +1,107 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/platform/operatingsystem"
+	"github.com/test-network-function/cnf-certification-test/pkg/stringhelper"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type Node struct {
+	Data *corev1.Node
+	Mc   MachineConfig `json:"-"`
+}
+
+func (node Node) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&node.Data)
+}
+
+func (node *Node) IsWorkerNode() bool {
+	for nodeLabel := range node.Data.Labels {
+		if stringhelper.StringInSlice(WorkerLabels, nodeLabel, true) {
+			return true
+		}
+	}
+	return false
+}
+
+func (node *Node) IsMasterNode() bool {
+	for nodeLabel := range node.Data.Labels {
+		if stringhelper.StringInSlice(MasterLabels, nodeLabel, true) {
+			return true
+		}
+	}
+	return false
+}
+
+func (node *Node) IsRHCOS() bool {
+	return strings.Contains(strings.TrimSpace(node.Data.Status.NodeInfo.OSImage), rhcosName)
+}
+
+func (node *Node) IsRHEL() bool {
+	return strings.Contains(strings.TrimSpace(node.Data.Status.NodeInfo.OSImage), rhelName)
+}
+
+func (node *Node) IsRTKernel() bool {
+	// More information: https://www.redhat.com/sysadmin/real-time-kernel
+	return strings.Contains(strings.TrimSpace(node.Data.Status.NodeInfo.KernelVersion), "rt")
+}
+
+func (node *Node) GetRHCOSVersion() (string, error) {
+	// Check if the node is running CoreOS or not
+	if !node.IsRHCOS() {
+		return "", fmt.Errorf("invalid OS type: %s", node.Data.Status.NodeInfo.OSImage)
+	}
+
+	path, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	filePath := fmt.Sprintf(rhcosRelativePath, path)
+
+	// Red Hat Enterprise Linux CoreOS 410.84.202205031645-0 (Ootpa) --> 410.84.202205031645-0
+	splitStr := strings.Split(node.Data.Status.NodeInfo.OSImage, rhcosName)
+	longVersionSplit := strings.Split(strings.TrimSpace(splitStr[1]), " ")
+
+	// Get the short version string from the long version string
+	shortVersion, err := operatingsystem.GetShortVersionFromLong(longVersionSplit[0], filePath)
+	if err != nil {
+		return "", err
+	}
+
+	return shortVersion, nil
+}
+
+func (node *Node) GetRHELVersion() (string, error) {
+	// Check if the node is running RHEL or not
+	if !node.IsRHEL() {
+		return "", fmt.Errorf("invalid OS type: %s", node.Data.Status.NodeInfo.OSImage)
+	}
+
+	// Red Hat Enterprise Linux 8.5 (Ootpa) --> 8.5
+	splitStr := strings.Split(node.Data.Status.NodeInfo.OSImage, rhelName)
+	longVersionSplit := strings.Split(strings.TrimSpace(splitStr[1]), " ")
+
+	return longVersionSplit[0], nil
+}

--- a/pkg/provider/nodes_test.go
+++ b/pkg/provider/nodes_test.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package provider

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -1,0 +1,103 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package provider
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/sirupsen/logrus"
+	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type Pod struct {
+	*corev1.Pod
+	Containers         []*Container
+	MultusIPs          map[string][]string
+	SkipNetTests       bool
+	SkipMultusNetTests bool
+}
+
+func NewPod(aPod *corev1.Pod) (out Pod) {
+	var err error
+	out.Pod = aPod
+	out.MultusIPs = make(map[string][]string)
+	out.MultusIPs, err = GetPodIPsPerNet(aPod.GetAnnotations()[CniNetworksStatusKey])
+	if err != nil {
+		logrus.Errorf("Could not decode networks-status annotation, error: %s", err)
+	}
+
+	if _, ok := aPod.GetLabels()[skipConnectivityTestsLabel]; ok {
+		out.SkipNetTests = true
+	}
+	if _, ok := aPod.GetLabels()[skipMultusConnectivityTestsLabel]; ok {
+		out.SkipMultusNetTests = true
+	}
+	out.Containers = append(out.Containers, getPodContainers(aPod)...)
+	return out
+}
+
+func ConvertArrayPods(pods []*corev1.Pod) (out []*Pod) {
+	for i := range pods {
+		aPodWrapper := NewPod(pods[i])
+		out = append(out, &aPodWrapper)
+	}
+	return out
+}
+
+func (p *Pod) IsPodGuaranteed() bool {
+	return AreCPUResourcesWholeUnits(p) && AreResourcesIdentical(p)
+}
+
+func (p *Pod) IsCPUIsolationCompliant() bool {
+	isCPUIsolated := true
+
+	if !LoadBalancingDisabled(p) {
+		errMsg := fmt.Sprintf("%s has been found to not have annotations set correctly for CPU isolation.", p.String())
+		logrus.Debugf(errMsg)
+		tnf.ClaimFilePrintf(errMsg)
+		isCPUIsolated = false
+	}
+
+	if !IsRuntimeClassNameSpecified(p) {
+		errMsg := fmt.Sprintf("%s has been found to not have runtimeClassName specified.", p.String())
+		logrus.Debugf(errMsg)
+		tnf.ClaimFilePrintf(errMsg)
+		isCPUIsolated = false
+	}
+
+	return isCPUIsolated
+}
+
+func (p *Pod) String() string {
+	return fmt.Sprintf("pod: %s ns: %s",
+		p.Name,
+		p.Namespace,
+	)
+}
+
+func (p *Pod) ColocationEnabled() bool {
+	if val, ok := p.Labels[AffinityAllowedKey]; ok {
+		result, err := strconv.ParseBool(val)
+		if err != nil {
+			return false
+		}
+		return result
+	}
+	return false
+}

--- a/pkg/provider/pods_test.go
+++ b/pkg/provider/pods_test.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package provider

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -18,7 +18,6 @@ package provider
 
 import (
 	"context"
-	"os"
 	"time"
 
 	"errors"
@@ -30,12 +29,9 @@ import (
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	olmv1Alpha "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/sirupsen/logrus"
-	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/platform/operatingsystem"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/pkg/autodiscover"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
-	"github.com/test-network-function/cnf-certification-test/pkg/stringhelper"
-	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
 	"helm.sh/helm/v3/pkg/release"
 	appsv1 "k8s.io/api/apps/v1"
 	scalingv1 "k8s.io/api/autoscaling/v1"
@@ -44,11 +40,10 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	appv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 )
 
 const (
-	colocationEnabledKey             = "colocation"
+	AffinityAllowedKey               = "AffinityAllowed"
 	DaemonSetNamespace               = "default"
 	DaemonSetName                    = "debug"
 	debugPodsTimeout                 = 5 * time.Minute
@@ -67,49 +62,6 @@ var (
 	MasterLabels      = []string{"node-role.kubernetes.io/master", "node-role.kubernetes.io/control-plane"}
 	rhcosRelativePath = "%s/platform/operatingsystem/files/rhcos_version_map"
 )
-
-type Pod struct {
-	*corev1.Pod
-	Containers         []*Container
-	MultusIPs          map[string][]string
-	SkipNetTests       bool
-	SkipMultusNetTests bool
-}
-
-type Deployment struct {
-	*appsv1.Deployment
-}
-
-type StatefulSet struct {
-	*appsv1.StatefulSet
-}
-
-func NewPod(aPod *corev1.Pod) (out Pod) {
-	var err error
-	out.Pod = aPod
-	out.MultusIPs = make(map[string][]string)
-	out.MultusIPs, err = GetPodIPsPerNet(aPod.GetAnnotations()[CniNetworksStatusKey])
-	if err != nil {
-		logrus.Errorf("Could not decode networks-status annotation, error: %s", err)
-	}
-
-	if _, ok := aPod.GetLabels()[skipConnectivityTestsLabel]; ok {
-		out.SkipNetTests = true
-	}
-	if _, ok := aPod.GetLabels()[skipMultusConnectivityTestsLabel]; ok {
-		out.SkipMultusNetTests = true
-	}
-	out.Containers = append(out.Containers, getPodContainers(aPod)...)
-	return out
-}
-
-func ConvertArrayPods(pods []*corev1.Pod) (out []*Pod) {
-	for i := range pods {
-		aPodWrapper := NewPod(pods[i])
-		out = append(out, &aPodWrapper)
-	}
-	return out
-}
 
 type TestEnvironment struct { // rename this with testTarget
 	Namespaces           []string     `json:"testNamespaces"`
@@ -158,16 +110,6 @@ type Operator struct {
 	Version          string                            `yaml:"version" json:"version"`
 	Channel          string                            `yaml:"channel" json:"channel"`
 }
-type Container struct {
-	*corev1.Container
-	Status                   corev1.ContainerStatus
-	Namespace                string
-	Podname                  string
-	NodeName                 string
-	Runtime                  string
-	UID                      string
-	ContainerImageIdentifier configuration.ContainerImageIdentifier
-}
 
 type MachineConfig struct {
 	*mcv1.MachineConfig
@@ -179,85 +121,6 @@ type MachineConfig struct {
 			} `json:"units"`
 		} `json:"systemd"`
 	} `json:"config"`
-}
-
-type Node struct {
-	Data *corev1.Node
-	Mc   MachineConfig `json:"-"`
-}
-
-func (node Node) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&node.Data)
-}
-
-func (node *Node) IsWorkerNode() bool {
-	for nodeLabel := range node.Data.Labels {
-		if stringhelper.StringInSlice(WorkerLabels, nodeLabel, true) {
-			return true
-		}
-	}
-	return false
-}
-
-func (node *Node) IsMasterNode() bool {
-	for nodeLabel := range node.Data.Labels {
-		if stringhelper.StringInSlice(MasterLabels, nodeLabel, true) {
-			return true
-		}
-	}
-	return false
-}
-
-func (node *Node) IsRHCOS() bool {
-	return strings.Contains(strings.TrimSpace(node.Data.Status.NodeInfo.OSImage), rhcosName)
-}
-
-func (node *Node) IsRHEL() bool {
-	return strings.Contains(strings.TrimSpace(node.Data.Status.NodeInfo.OSImage), rhelName)
-}
-
-func (node *Node) IsRTKernel() bool {
-	// More information: https://www.redhat.com/sysadmin/real-time-kernel
-	return strings.Contains(strings.TrimSpace(node.Data.Status.NodeInfo.KernelVersion), "rt")
-}
-
-func (node *Node) GetRHCOSVersion() (string, error) {
-	// Check if the node is running CoreOS or not
-	if !node.IsRHCOS() {
-		return "", fmt.Errorf("invalid OS type: %s", node.Data.Status.NodeInfo.OSImage)
-	}
-
-	path, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-
-	filePath := fmt.Sprintf(rhcosRelativePath, path)
-
-	// Red Hat Enterprise Linux CoreOS 410.84.202205031645-0 (Ootpa) --> 410.84.202205031645-0
-	splitStr := strings.Split(node.Data.Status.NodeInfo.OSImage, rhcosName)
-	longVersionSplit := strings.Split(strings.TrimSpace(splitStr[1]), " ")
-
-	// Get the short version string from the long version string
-	shortVersion, err := operatingsystem.GetShortVersionFromLong(longVersionSplit[0], filePath)
-	if err != nil {
-		return "", err
-	}
-
-	return shortVersion, nil
-}
-
-func (node *Node) GetRHELVersion() (string, error) {
-	// Check if the node is running RHEL or not
-	if !node.IsRHEL() {
-		return "", fmt.Errorf("invalid OS type: %s", node.Data.Status.NodeInfo.OSImage)
-	}
-
-	// Red Hat Enterprise Linux 8.5 (Ootpa) --> 8.5
-	splitStr := strings.Split(node.Data.Status.NodeInfo.OSImage, rhelName)
-	longVersionSplit := strings.Split(strings.TrimSpace(splitStr[1]), " ")
-
-	return longVersionSplit[0], nil
 }
 
 type cniNetworkInterface struct {
@@ -272,62 +135,6 @@ var (
 	env    = TestEnvironment{}
 	loaded = false
 )
-
-func GetContainer() *Container {
-	return &Container{}
-}
-
-func (d *Deployment) IsDeploymentReady() bool {
-	notReady := true
-	for _, condition := range d.Status.Conditions {
-		if condition.Type == appsv1.DeploymentAvailable {
-			notReady = false
-			break
-		}
-	}
-	var replicas int32
-	if d.Spec.Replicas != nil {
-		replicas = *(d.Spec.Replicas)
-	} else {
-		replicas = 1
-	}
-	if notReady ||
-		d.Status.UnavailableReplicas != 0 ||
-		d.Status.ReadyReplicas != replicas ||
-		d.Status.AvailableReplicas != replicas ||
-		d.Status.UpdatedReplicas != replicas {
-		return false
-	}
-	return true
-}
-
-func (ss *StatefulSet) IsStatefulSetReady() bool {
-	var replicas int32
-	if ss.Spec.Replicas != nil {
-		replicas = *(ss.Spec.Replicas)
-	} else {
-		replicas = 1
-	}
-	if ss.Status.ReadyReplicas != replicas ||
-		ss.Status.CurrentReplicas != replicas ||
-		ss.Status.UpdatedReplicas != replicas {
-		return false
-	}
-	return true
-}
-
-func GetUpdatedDeployment(ac appv1client.AppsV1Interface, namespace, podName string) (*Deployment, error) {
-	result, err := autodiscover.FindDeploymentByNameByNamespace(ac, namespace, podName)
-	return &Deployment{
-		result,
-	}, err
-}
-func GetUpdatedStatefulset(ac appv1client.AppsV1Interface, namespace, podName string) (*StatefulSet, error) {
-	result, err := autodiscover.FindStatefulsetByNameByNamespace(ac, namespace, podName)
-	return &StatefulSet{
-		result,
-	}, err
-}
 
 func buildTestEnvironment() { //nolint:funlen
 	// Wait for the debug pods to be ready before the autodiscovery starts.
@@ -499,20 +306,6 @@ func isDaemonSetReady(status *appsv1.DaemonSetStatus) bool {
 		status.NumberMisscheduled == 0
 }
 
-func (c *Container) GetUID() (string, error) {
-	split := strings.Split(c.Status.ContainerID, "://")
-	uid := ""
-	if len(split) > 0 {
-		uid = split[len(split)-1]
-	}
-	if uid == "" {
-		logrus.Debugln(fmt.Sprintf("could not find uid of %s/%s/%s\n", c.Namespace, c.Podname, c.Name))
-		return "", errors.New("cannot determine container UID")
-	}
-	logrus.Debugln(fmt.Sprintf("uid of %s/%s/%s=%s\n", c.Namespace, c.Podname, c.Name, uid))
-	return uid, nil
-}
-
 func buildContainerImageSource(url string) configuration.ContainerImageIdentifier {
 	source := configuration.ContainerImageIdentifier{}
 	urlSegments := strings.Split(url, "/")
@@ -535,6 +328,7 @@ func buildContainerImageSource(url string) configuration.ContainerImageIdentifie
 	}
 	return source
 }
+
 func GetRuntimeUID(cs *corev1.ContainerStatus) (runtime, uid string) {
 	split := strings.Split(cs.ContainerID, "://")
 	if len(split) > 0 {
@@ -542,69 +336,6 @@ func GetRuntimeUID(cs *corev1.ContainerStatus) (runtime, uid string) {
 		runtime = split[0]
 	}
 	return runtime, uid
-}
-
-func (c *Container) StringLong() string {
-	return fmt.Sprintf("node: %s ns: %s podName: %s containerName: %s containerUID: %s containerRuntime: %s",
-		c.NodeName,
-		c.Namespace,
-		c.Podname,
-		c.Name,
-		c.Status.ContainerID,
-		c.Runtime,
-	)
-}
-func (c *Container) String() string {
-	return fmt.Sprintf("container: %s pod: %s ns: %s",
-		c.Name,
-		c.Podname,
-		c.Namespace,
-	)
-}
-
-func (p *Pod) String() string {
-	return fmt.Sprintf("pod: %s ns: %s",
-		p.Name,
-		p.Namespace,
-	)
-}
-
-func (p *Pod) IsPodGuaranteed() bool {
-	return AreCPUResourcesWholeUnits(p) && AreResourcesIdentical(p)
-}
-
-func (p *Pod) IsCPUIsolationCompliant() bool {
-	isCPUIsolated := true
-
-	if !LoadBalancingDisabled(p) {
-		errMsg := fmt.Sprintf("%s has been found to not have annotations set correctly for CPU isolation.", p.String())
-		logrus.Debugf(errMsg)
-		tnf.ClaimFilePrintf(errMsg)
-		isCPUIsolated = false
-	}
-
-	if !IsRuntimeClassNameSpecified(p) {
-		errMsg := fmt.Sprintf("%s has been found to not have runtimeClassName specified.", p.String())
-		logrus.Debugf(errMsg)
-		tnf.ClaimFilePrintf(errMsg)
-		isCPUIsolated = false
-	}
-
-	return isCPUIsolated
-}
-
-func (d *Deployment) ToString() string {
-	return fmt.Sprintf("deployment: %s ns: %s",
-		d.Name,
-		d.Namespace,
-	)
-}
-
-func (ss *StatefulSet) ToString() string {
-	return fmt.Sprintf("statefulset: %s ns: %s",
-		ss.Name,
-		ss.Namespace,
-	)
 }
 
 func CsvToString(csv *olmv1Alpha.ClusterServiceVersion) string {

--- a/pkg/provider/statefulsets.go
+++ b/pkg/provider/statefulsets.go
@@ -1,0 +1,58 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package provider
+
+import (
+	"fmt"
+
+	"github.com/test-network-function/cnf-certification-test/pkg/autodiscover"
+	appsv1 "k8s.io/api/apps/v1"
+	appv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
+)
+
+type StatefulSet struct {
+	*appsv1.StatefulSet
+}
+
+func (ss *StatefulSet) IsStatefulSetReady() bool {
+	var replicas int32
+	if ss.Spec.Replicas != nil {
+		replicas = *(ss.Spec.Replicas)
+	} else {
+		replicas = 1
+	}
+	if ss.Status.ReadyReplicas != replicas ||
+		ss.Status.CurrentReplicas != replicas ||
+		ss.Status.UpdatedReplicas != replicas {
+		return false
+	}
+	return true
+}
+
+func (ss *StatefulSet) ToString() string {
+	return fmt.Sprintf("statefulset: %s ns: %s",
+		ss.Name,
+		ss.Namespace,
+	)
+}
+
+func GetUpdatedStatefulset(ac appv1client.AppsV1Interface, namespace, podName string) (*StatefulSet, error) {
+	result, err := autodiscover.FindStatefulsetByNameByNamespace(ac, namespace, podName)
+	return &StatefulSet{
+		result,
+	}, err
+}

--- a/pkg/provider/statefulsets_test.go
+++ b/pkg/provider/statefulsets_test.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package provider


### PR DESCRIPTION
Take the existing provider.go and break it down into files specific to whatever objects they are dealing with:
- containers.go
- pods.go
- deployments.go
- nodes.go
- pods.go
- statefulsets.go

I plan on going back after this PR and adding more unit testing (if needed) for some of these files and their corresponding funcs.