### PR TITLE
Add AffinityRequired test to lifecycle

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -338,6 +338,45 @@ Exception Process|There is no documented exception process for this.
 
 ### lifecycle
 
+#### affinity-required-deployments
+
+Property|Description
+---|---
+Test Case Name|affinity-required-deployments
+Test Case Label|lifecycle-affinity-required-deployments
+Unique ID|http://test-network-function.com/testcases/lifecycle/affinity-required-deployments
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/lifecycle/affinity-required-deployments Checks that affinity rules are in place if AffinityRequired: 'true' labels are set on Deployments.
+Result Type|informative
+Suggested Remediation|If a pod/statefulset/deployment is required to use affinity rules, please add AffinityRequired: 'true' as a label
+Best Practice Reference|https://TODO Section 4.6.24
+Exception Process|There is no documented exception process for this.
+#### affinity-required-pods
+
+Property|Description
+---|---
+Test Case Name|affinity-required-pods
+Test Case Label|lifecycle-affinity-required-pods
+Unique ID|http://test-network-function.com/testcases/lifecycle/affinity-required-pods
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/lifecycle/affinity-required-pods Checks that affinity rules are in place if AffinityRequired: 'true' labels are set on Pods.
+Result Type|informative
+Suggested Remediation|If a pod/statefulset/deployment is required to use affinity rules, please add AffinityRequired: 'true' as a label
+Best Practice Reference|https://TODO Section 4.6.24
+Exception Process|There is no documented exception process for this.
+#### affinity-required-statefulsets
+
+Property|Description
+---|---
+Test Case Name|affinity-required-statefulsets
+Test Case Label|lifecycle-affinity-required-statefulsets
+Unique ID|http://test-network-function.com/testcases/lifecycle/affinity-required-statefulsets
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/lifecycle/affinity-required-statefulsets Checks that affinity rules are in place if AffinityRequired: 'true' labels are set on StatefulSets.
+Result Type|informative
+Suggested Remediation|If a pod/statefulset/deployment is required to use affinity rules, please add AffinityRequired: 'true' as a label
+Best Practice Reference|https://TODO Section 4.6.24
+Exception Process|There is no documented exception process for this.
 #### container-shutdown
 
 Property|Description

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ For Network Interfaces:
 The label test-network-function.com/skip_connectivity_tests excludes pods from all connectivity tests. The label value is not important, only its presence.
 The label test-network-function.com/skip_multus_connectivity_tests excludes pods from multus connectivity tests. Tests on default interface are still done. The label value is not important, only its presence.
 
-
+### AffinityRequired
+For CNF workloads that require pods to use Pod or Node Affinity rules, the label `AffinityRequired: true` must be included on either the Deployment, StatefulSet, or Pod YAML.  This will prevent any tests for anti-affinity to fail as well as test your workloads for affinity rules that support your CNF's use-case.
 
 ### certifiedcontainerinfo
 

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -99,6 +99,9 @@ var (
 	TestContainerIsCertifiedDigestIdentifier claim.Identifier
 	TestPodHugePages2M                       claim.Identifier
 	TestReservedExtendedPartnerPorts         claim.Identifier
+	TestAffinityRequiredPods                 claim.Identifier
+	TestAffinityRequiredDeployments          claim.Identifier
+	TestAffinityRequiredStatefulSets         claim.Identifier
 )
 
 //nolint:funlen
@@ -167,6 +170,39 @@ The label value is not important, only its presence.`,
 		common.NetworkingTestKey,
 		`Checks that pods and containers are not consuming ports designated as reserved by partner`,
 		ReservedPartnerPortsRemediation,
+		InformativeResult,
+		NoDocumentedProcess,
+		VersionOne,
+		bestPracticeDocV1dot4URL+" Section 4.6.24",
+		TagExtended)
+
+	TestAffinityRequiredPods = AddCatalogEntry(
+		"affinity-required-pods",
+		common.LifecycleTestKey,
+		`Checks that affinity rules are in place if AffinityRequired: 'true' labels are set on Pods.`,
+		AffinityRequiredRemediation,
+		InformativeResult,
+		NoDocumentedProcess,
+		VersionOne,
+		bestPracticeDocV1dot4URL+" Section 4.6.24",
+		TagExtended)
+
+	TestAffinityRequiredDeployments = AddCatalogEntry(
+		"affinity-required-deployments",
+		common.LifecycleTestKey,
+		`Checks that affinity rules are in place if AffinityRequired: 'true' labels are set on Deployments.`,
+		AffinityRequiredRemediation,
+		InformativeResult,
+		NoDocumentedProcess,
+		VersionOne,
+		bestPracticeDocV1dot4URL+" Section 4.6.24",
+		TagExtended)
+
+	TestAffinityRequiredStatefulSets = AddCatalogEntry(
+		"affinity-required-statefulsets",
+		common.LifecycleTestKey,
+		`Checks that affinity rules are in place if AffinityRequired: 'true' labels are set on StatefulSets.`,
+		AffinityRequiredRemediation,
 		InformativeResult,
 		NoDocumentedProcess,
 		VersionOne,

--- a/cnf-certification-test/identifiers/remediation.go
+++ b/cnf-certification-test/identifiers/remediation.go
@@ -197,4 +197,6 @@ const (
 	UID1337Remediation = `Use another process UID that is not 1337`
 
 	ReservedPartnerPortsRemediation = `Ensure ports are not being used that are reserved by our partner`
+
+	AffinityRequiredRemediation = `If a pod/statefulset/deployment is required to use affinity rules, please add AffinityRequired: 'true' as a label`
 )

--- a/pkg/provider/deployments.go
+++ b/pkg/provider/deployments.go
@@ -18,7 +18,9 @@ package provider
 
 import (
 	"fmt"
+	"strconv"
 
+	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/pkg/autodiscover"
 	appsv1 "k8s.io/api/apps/v1"
 	appv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
@@ -63,6 +65,31 @@ func (d *Deployment) ToString() string {
 		d.Name,
 		d.Namespace,
 	)
+}
+
+func (d *Deployment) AffinityRequired() bool {
+	if val, ok := d.Labels[AffinityRequiredKey]; ok {
+		result, err := strconv.ParseBool(val)
+		if err != nil {
+			logrus.Warnf("failure to parse bool %v", val)
+			return false
+		}
+		return result
+	}
+	return false
+}
+
+func (d *Deployment) IsAffinityCompliant() (bool, error) {
+	if d.Spec.Template.Spec.Affinity == nil {
+		return false, fmt.Errorf("%s has been found with an AffinityRequired flag but is missing corresponding affinity rules", d.String())
+	}
+	if d.Spec.Template.Spec.Affinity.PodAntiAffinity != nil {
+		return false, fmt.Errorf("%s has been found with an AffinityRequired flag but has anti-affinity rules", d.String())
+	}
+	if d.Spec.Template.Spec.Affinity.PodAffinity == nil && d.Spec.Template.Spec.Affinity.NodeAffinity == nil {
+		return false, fmt.Errorf("%s has been found with an AffinityRequired flag but is missing corresponding pod/node affinity rules", d.String())
+	}
+	return true, nil
 }
 
 func GetUpdatedDeployment(ac appv1client.AppsV1Interface, namespace, podName string) (*Deployment, error) {

--- a/pkg/provider/deployments_test.go
+++ b/pkg/provider/deployments_test.go
@@ -15,3 +15,91 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package provider
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+//nolint:funlen
+func TestIsAffinityCompliantDeployments(t *testing.T) {
+	testCases := []struct {
+		testDeployment Deployment
+		resultErrStr   error
+		isCompliant    bool
+	}{
+		{ // Test Case #1 - Affinity is nil, AffinityRequired label is set, fail
+			testDeployment: Deployment{
+				Deployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							AffinityRequiredKey: "true",
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Affinity: nil,
+							},
+						},
+					},
+				},
+			},
+			resultErrStr: errors.New("has been found with an AffinityRequired flag but is missing corresponding affinity rules"),
+			isCompliant:  false,
+		},
+		{ // Test Case #2 - Affinity is not nil, but PodAffinity/NodeAffinity are also not set, fail
+			testDeployment: Deployment{
+				Deployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							AffinityRequiredKey: "true",
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Affinity: &corev1.Affinity{},
+							},
+						},
+					},
+				},
+			},
+			resultErrStr: errors.New("has been found with an AffinityRequired flag but is missing corresponding pod/node affinity rules"),
+			isCompliant:  false,
+		},
+		{ // Test Case #3 - Affinity is not nil, but anti-affinity rule is set which defeats the purpose of the Required flag
+			testDeployment: Deployment{
+				Deployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							AffinityRequiredKey: "true",
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Affinity: &corev1.Affinity{
+									PodAntiAffinity: &corev1.PodAntiAffinity{},
+								},
+							},
+						},
+					},
+				},
+			},
+			resultErrStr: errors.New("has been found with an AffinityRequired flag but has anti-affinity rules"),
+			isCompliant:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		result, testErr := tc.testDeployment.IsAffinityCompliant()
+		assert.Contains(t, testErr.Error(), tc.resultErrStr.Error())
+		assert.Equal(t, tc.isCompliant, result)
+	}
+}

--- a/pkg/provider/statefulsets_test.go
+++ b/pkg/provider/statefulsets_test.go
@@ -15,3 +15,91 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package provider
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+//nolint:funlen
+func TestIsAffinityCompliantStatefulSets(t *testing.T) {
+	testCases := []struct {
+		testStatefulSet StatefulSet
+		resultErrStr    error
+		isCompliant     bool
+	}{
+		{ // Test Case #1 - Affinity is nil, AffinityRequired label is set, fail
+			testStatefulSet: StatefulSet{
+				StatefulSet: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							AffinityRequiredKey: "true",
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Affinity: nil,
+							},
+						},
+					},
+				},
+			},
+			resultErrStr: errors.New("has been found with an AffinityRequired flag but is missing corresponding affinity rules"),
+			isCompliant:  false,
+		},
+		{ // Test Case #2 - Affinity is not nil, but PodAffinity/NodeAffinity are also not set, fail
+			testStatefulSet: StatefulSet{
+				StatefulSet: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							AffinityRequiredKey: "true",
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Affinity: &corev1.Affinity{}, // not nil
+							},
+						},
+					},
+				},
+			},
+			resultErrStr: errors.New("has been found with an AffinityRequired flag but is missing corresponding pod/node affinity rules"),
+			isCompliant:  false,
+		},
+		{ // Test Case #3 - Affinity is not nil, but anti-affinity rule is set which defeats the purpose of the Required flag
+			testStatefulSet: StatefulSet{
+				StatefulSet: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							AffinityRequiredKey: "true",
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Affinity: &corev1.Affinity{
+									PodAntiAffinity: &corev1.PodAntiAffinity{}, // anti-affinity set
+								},
+							},
+						},
+					},
+				},
+			},
+			resultErrStr: errors.New("has been found with an AffinityRequired flag but has anti-affinity rules"),
+			isCompliant:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		result, testErr := tc.testStatefulSet.IsAffinityCompliant()
+		assert.Contains(t, testErr.Error(), tc.resultErrStr.Error())
+		assert.Equal(t, tc.isCompliant, result)
+	}
+}


### PR DESCRIPTION
build-depends: 26152

Adds a test to the `lifecycle` suite that checks for a label `AffinityRequired: true` to be supplied for workloads that require colocation of pods. 

- Tests pods, deployments, and statefulsets.
- Adds "groupings" section(s) into the provider.go.
- Adds `AffinityRequired()` and `IsAffinityCompliant()` funcs to each of the above structs.
- Had to modify `testPodNodeSelectorAndAffinityBestPractices` to avoid pods that have `AffinityRequired` flags.  This func was already looping through NonGuaranteedPods.  Maybe there is a way to do cross-sections of different lists of pods we could implement later.
- The `IsAffinityCompliant` tests are all relatively the same with some copy/pasting.