### PR TITLE
add postmortem information to claims file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters-settings:
     local-prefixes: github.com/golangci/golangci-lint
   goconst:
     min-len: 4
-    min-occurrences: 1
+    min-occurrences: 2
   gocritic:
     enabled-tags:
       - diagnostic

--- a/cnf-certification-test/platform/nodetainted/nodetainted.go
+++ b/cnf-certification-test/platform/nodetainted/nodetainted.go
@@ -74,7 +74,6 @@ func (nt *NodeTainted) GetKernelTaintInfo(ctx clientsholder.Context) (string, er
 func (nt *NodeTainted) GetModulesFromNode(ctx clientsholder.Context) []string {
 	// Get the 1st column list of the modules running on the node.
 	// Split on the return/newline and get the list of the modules back.
-	//nolint:goconst // used only once
 	command := `chroot /host lsmod | awk '{ print $1 }' | grep -v Module`
 	output, _ := nt.runCommand(ctx, command)
 	output = strings.ReplaceAll(output, "\t", "")

--- a/internal/crclient/crclient.go
+++ b/internal/crclient/crclient.go
@@ -30,11 +30,11 @@ func GetPidFromContainer(cut *provider.Container, ctx clientsholder.Context) (in
 	var pidCmd string
 
 	switch cut.Runtime {
-	case "docker": //nolint:goconst // used only once
+	case "docker":
 		pidCmd = "chroot /host docker inspect -f '{{.State.Pid}}' " + cut.UID + " 2>/dev/null"
-	case "docker-pullable": //nolint:goconst // used only once
+	case "docker-pullable":
 		pidCmd = "chroot /host docker inspect -f '{{.State.Pid}}' " + cut.UID + " 2>/dev/null"
-	case "cri-o", "containerd": //nolint:goconst // used only once
+	case "cri-o", "containerd":
 		pidCmd = "chroot /host crictl inspect --output go-template --template '{{.info.pid}}' " + cut.UID + " 2>/dev/null"
 	default:
 		logrus.Debugf("Container runtime %s not supported yet for this test, skipping", cut.Runtime)

--- a/pkg/autodiscover/autodiscover_events.go
+++ b/pkg/autodiscover/autodiscover_events.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package autodiscover
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type Event struct {
+	*corev1.Event
+}
+
+func findAbnormalEvents(oc corev1client.CoreV1Interface, namespaces []string) (abnormalEvents []corev1.Event) {
+	abnormalEvents = []corev1.Event{}
+	for _, ns := range namespaces {
+		someAbnormalEvents, err := oc.Events(ns).List(context.TODO(), metav1.ListOptions{FieldSelector: "type!=Normal"})
+		if err != nil {
+			logrus.Errorf("failed to get event list for namespace %s, err:%s", ns, err)
+			continue
+		}
+		abnormalEvents = append(abnormalEvents, someAbnormalEvents.Items...)
+	}
+	return abnormalEvents
+}

--- a/pkg/autodiscover/autodiscover_events_test.go
+++ b/pkg/autodiscover/autodiscover_events_test.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package autodiscover

--- a/pkg/autodiscover/autodiscover_pods_test.go
+++ b/pkg/autodiscover/autodiscover_pods_test.go
@@ -39,6 +39,9 @@ func TestFindPodsByLabel(t *testing.T) {
 					"testLabel": label,
 				},
 			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+			},
 		}
 	}
 
@@ -64,6 +67,9 @@ func TestFindPodsByLabel(t *testing.T) {
 						Labels: map[string]string{
 							"testLabel": "mylabel",
 						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
 					},
 				},
 			},
@@ -92,7 +98,7 @@ func TestFindPodsByLabel(t *testing.T) {
 		testRuntimeObjects = append(testRuntimeObjects, generatePod(tc.testPodName, tc.testPodNamespace, tc.queryLabel))
 		oc := clientsholder.GetTestClientsHolder(testRuntimeObjects)
 
-		podResult := findPodsByLabel(oc.K8sClient.CoreV1(), testLabel, testNamespaces)
+		podResult, _ := findPodsByLabel(oc.K8sClient.CoreV1(), testLabel, testNamespaces)
 		assert.Equal(t, tc.expectedResults, podResult)
 	}
 }

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -184,11 +184,11 @@ func GetVersionK8s() (out string) {
 func GetVersionOcp() (out string) {
 	env := provider.GetTestEnvironment()
 	if env.OpenshiftVersion == "" {
-		return "n/a, (non-OpenShift cluster)" //nolint:goconst
+		return "n/a, (non-OpenShift cluster)"
 	}
 	return env.OpenshiftVersion
 }
 
 func GetVersionOcClient() (out string) {
-	return "n/a, (not using oc or kubectl client)" //nolint:goconst
+	return "n/a, (not using oc or kubectl client)"
 }

--- a/pkg/junit/convert.go
+++ b/pkg/junit/convert.go
@@ -96,7 +96,7 @@ func determineFailureReason(failure interface{}) string {
 		if derivedFailureReason, ok := failureReasonObject[junitContentKey]; ok {
 			failureReason = "Failed due to line: " + derivedFailureReason.(string)
 		} else {
-			failureReason = "Failed due to line: No error line found in JUnit" //nolint:goconst // only instance
+			failureReason = "Failed due to line: No error line found in JUnit"
 		}
 		if derivedFailureReason, ok := failureReasonObject[junitMessageKey]; ok {
 			failureReason = failureReason + "\n" + "Error message: " + derivedFailureReason.(string)

--- a/pkg/postmortem/postmortem.go
+++ b/pkg/postmortem/postmortem.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package postmortem
+
+import (
+	"fmt"
+
+	"github.com/test-network-function/cnf-certification-test/pkg/provider"
+	v1 "k8s.io/api/core/v1"
+)
+
+func PrintPostMortemInfo() (out string) {
+	// Get current environment
+	env := provider.GetTestEnvironment()
+
+	// Set refresh
+	env.SetNeedsRefresh()
+
+	// Get up-to-date environment
+	env = provider.GetTestEnvironment()
+
+	out += "\nNode Status:\n"
+	for _, n := range env.Nodes {
+		out += fmt.Sprintf("node name=%s taints=%+v", n.Data.Name, n.Data.Spec.Taints) + "\n"
+	}
+	out += "\nPending Pods:\n"
+	for _, p := range env.AllPods {
+		if p.Status.Phase != v1.PodSucceeded && p.Status.Phase != v1.PodRunning {
+			out += p.String() + "\n"
+		}
+	}
+	out += "\nAbnormal events:\n"
+	for _, e := range env.AbnormalEvents {
+		out += e.String() + "\n"
+	}
+	return out
+}

--- a/pkg/postmortem/postmortem.go
+++ b/pkg/postmortem/postmortem.go
@@ -23,7 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func PrintPostMortemInfo() (out string) {
+func Log() (out string) {
 	// Get current environment
 	env := provider.GetTestEnvironment()
 

--- a/pkg/postmortem/postmortem_test.go
+++ b/pkg/postmortem/postmortem_test.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package postmortem

--- a/pkg/provider/events.go
+++ b/pkg/provider/events.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package provider
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+type Event struct {
+	*corev1.Event
+}
+
+func NewEvent(aEvent *corev1.Event) (out Event) {
+	out.Event = aEvent
+	return out
+}
+func (e *Event) String() string {
+	return fmt.Sprintf("timestamp=%s involved object=%s reason=%s message=%s", e.CreationTimestamp.Time, e.InvolvedObject, e.Reason, e.Message)
+}

--- a/pkg/provider/events_test.go
+++ b/pkg/provider/events_test.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package provider

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -66,6 +66,7 @@ var (
 type TestEnvironment struct { // rename this with testTarget
 	Namespaces           []string     `json:"testNamespaces"`
 	Pods                 []*Pod       `json:"testPods"`
+	AllPods              []*Pod       `json:"AllPods"`
 	Containers           []*Container `json:"testContainers"`
 	Operators            []Operator   `json:"testOperators"`
 	PersistentVolumes    []corev1.PersistentVolume
@@ -73,6 +74,7 @@ type TestEnvironment struct { // rename this with testTarget
 	GuaranteedPods       []*Pod
 	NonGuaranteedPods    []*Pod
 	HugepagesPods        []*Pod
+	AbnormalEvents       []*Event
 	Config               configuration.TestConfiguration
 	variables            configuration.TestParameters
 	Crds                 []*apiextv1.CustomResourceDefinition          `json:"testCrds"`
@@ -152,8 +154,11 @@ func buildTestEnvironment() { //nolint:funlen
 	env.variables = data.Env
 	env.Nodes = createNodes(data.Nodes.Items)
 	env.IstioServiceMesh = data.Istio
+	for i := range data.AbnormalEvents {
+		aEvent := NewEvent(&data.AbnormalEvents[i])
+		env.AbnormalEvents = append(env.AbnormalEvents, &aEvent)
+	}
 	pods := data.Pods
-
 	for i := 0; i < len(pods); i++ {
 		aNewPod := NewPod(&pods[i])
 		env.Pods = append(env.Pods, &aNewPod)
@@ -169,7 +174,11 @@ func buildTestEnvironment() { //nolint:funlen
 		}
 		env.Containers = append(env.Containers, getPodContainers(&pods[i])...)
 	}
-
+	pods = data.AllPods
+	for i := 0; i < len(pods); i++ {
+		aNewPod := NewPod(&pods[i])
+		env.AllPods = append(env.AllPods, &aNewPod)
+	}
 	env.DebugPods = make(map[string]*corev1.Pod)
 	for i := 0; i < len(data.DebugPods); i++ {
 		nodeName := data.DebugPods[i].Spec.NodeName

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -30,11 +30,11 @@ const (
 func ResultToString(result int) (str string) {
 	switch result {
 	case SUCCESS:
-		return "SUCCESS" //nolint:goconst
+		return "SUCCESS"
 	case FAILURE:
-		return "FAILURE" //nolint:goconst
+		return "FAILURE"
 	case ERROR:
-		return "ERROR" //nolint:goconst
+		return "ERROR"
 	}
 	return ""
 }


### PR DESCRIPTION
This PR is to add post-mortem information during the pod-recreation test similar to how it was implemented in previous project:
- collects the pending pods
- collects the node status (taints)
- collects the non-normal events in the namespaces under test
- Adding a AllPods list to record pods that are pending or in other error states

Also tweaks the min-occurrences in golint to 2 instead of 1 (e.g. make a constant if a string is used more than once)