### PR TITLE
Drain only pods under test

### DIFF
--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -384,13 +384,13 @@ func testPodsRecreation(env *provider.TestEnvironment) { //nolint:funlen
 		}
 		ginkgo.By(fmt.Sprintf("Draining and Cordoning node %s: ", n))
 		logrus.Debugf("node: %s cordoned", n)
-		count, err := podrecreation.CountPodsWithDelete(n, podrecreation.NoDelete)
+		count, err := podrecreation.CountPodsWithDelete(env.Pods, n, podrecreation.NoDelete)
 		if err != nil {
 			ginkgo.Fail(fmt.Sprintf("Getting pods list to drain in node %s failed with err: %s. Test inconclusive.", n, err))
 		}
 		nodeTimeout := timeoutPodSetReady + timeoutPodRecreationPerPod*time.Duration(count)
 		logrus.Debugf("draining node: %s with timeout: %s", n, nodeTimeout.String())
-		_, err = podrecreation.CountPodsWithDelete(n, podrecreation.DeleteForeground)
+		_, err = podrecreation.CountPodsWithDelete(env.Pods, n, podrecreation.DeleteForeground)
 		if err != nil {
 			ginkgo.Fail(fmt.Sprintf("Draining node %s failed with err: %s. Test inconclusive", n, err))
 		}


### PR DESCRIPTION
This PR enables limiting the scope of draining a particular node by just deleting the pods that are:
- under test and 
- controlled by a statefulset or deployment 
- running on the node being drained
Previous behavior drained all pods belonging to deployments running on the node being drained