### PR TITLE
Turn groupings into env funcs

### DIFF
--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -141,7 +141,7 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestPodHugePages2M)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
 		if provider.IsOCPCluster() {
-			testhelper.SkipIfEmptyAny(ginkgo.Skip, env.HugepagesPods)
+			testhelper.SkipIfEmptyAny(ginkgo.Skip, env.GetHugepagesPods())
 			testPodHugePages2M(&env)
 		}
 	})
@@ -570,7 +570,7 @@ func testNodeOperatingSystemStatus(env *provider.TestEnvironment) {
 
 func testPodHugePages2M(env *provider.TestEnvironment) {
 	var badPods []*provider.Pod
-	for _, put := range env.HugepagesPods {
+	for _, put := range env.GetHugepagesPods() {
 		result := put.CheckResourceOnly2MiHugePages()
 		if !result {
 			badPods = append(badPods, put)

--- a/pkg/provider/filters.go
+++ b/pkg/provider/filters.go
@@ -1,0 +1,107 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package provider
+
+func (env *TestEnvironment) GetGuaranteedPods() []*Pod {
+	var filteredPods []*Pod
+	for _, p := range env.Pods {
+		if p.IsPodGuaranteed() {
+			filteredPods = append(filteredPods, p)
+		}
+	}
+	return filteredPods
+}
+
+func (env *TestEnvironment) GetNonGuaranteedPods() []*Pod {
+	var filteredPods []*Pod
+	for _, p := range env.Pods {
+		if !p.IsPodGuaranteed() {
+			filteredPods = append(filteredPods, p)
+		}
+	}
+	return filteredPods
+}
+
+func (env *TestEnvironment) GetNonGuaranteedPodsWithAntiAffinity() []*Pod {
+	var filteredPods []*Pod
+	for _, p := range env.Pods {
+		if !p.IsPodGuaranteed() && !p.AffinityRequired() {
+			filteredPods = append(filteredPods, p)
+		}
+	}
+	return filteredPods
+}
+
+func (env *TestEnvironment) GetAffinityRequiredPods() []*Pod {
+	var filteredPods []*Pod
+	for _, p := range env.Pods {
+		if p.AffinityRequired() {
+			filteredPods = append(filteredPods, p)
+		}
+	}
+	return filteredPods
+}
+
+func (env *TestEnvironment) GetAntiAffinityRequiredPods() []*Pod {
+	var filteredPods []*Pod
+	for _, p := range env.Pods {
+		if !p.AffinityRequired() {
+			filteredPods = append(filteredPods, p)
+		}
+	}
+	return filteredPods
+}
+
+func (env *TestEnvironment) GetAffinityRequiredDeployments() []*Deployment {
+	var filteredDeployments []*Deployment
+	for _, d := range env.Deployments {
+		if d.AffinityRequired() {
+			filteredDeployments = append(filteredDeployments, d)
+		}
+	}
+	return filteredDeployments
+}
+
+func (env *TestEnvironment) GetAntiAffinityRequiredDeployments() []*Deployment {
+	var filteredDeployments []*Deployment
+	for _, d := range env.Deployments {
+		if !d.AffinityRequired() {
+			filteredDeployments = append(filteredDeployments, d)
+		}
+	}
+	return filteredDeployments
+}
+
+func (env *TestEnvironment) GetAffinityRequiredStatefulSets() []*StatefulSet {
+	var filteredStatefulSets []*StatefulSet
+	for _, d := range env.StatefulSets {
+		if d.AffinityRequired() {
+			filteredStatefulSets = append(filteredStatefulSets, d)
+		}
+	}
+	return filteredStatefulSets
+}
+
+func (env *TestEnvironment) GetAntiAffinityRequiredStatefulSets() []*StatefulSet {
+	var filteredStatefulSets []*StatefulSet
+	for _, d := range env.StatefulSets {
+		if !d.AffinityRequired() {
+			filteredStatefulSets = append(filteredStatefulSets, d)
+		}
+	}
+	return filteredStatefulSets
+}

--- a/pkg/provider/filters.go
+++ b/pkg/provider/filters.go
@@ -105,3 +105,13 @@ func (env *TestEnvironment) GetAntiAffinityRequiredStatefulSets() []*StatefulSet
 	}
 	return filteredStatefulSets
 }
+
+func (env *TestEnvironment) GetHugepagesPods() []*Pod {
+	var filteredPods []*Pod
+	for _, p := range env.Pods {
+		if p.HasHugepages() {
+			filteredPods = append(filteredPods, p)
+		}
+	}
+	return filteredPods
+}

--- a/pkg/provider/filters_test.go
+++ b/pkg/provider/filters_test.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package provider

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -68,10 +68,9 @@ type TestEnvironment struct { // rename this with testTarget
 	AbnormalEvents []*Event
 
 	// Pod Groupings
-	Pods          []*Pod                 `json:"testPods"`
-	DebugPods     map[string]*corev1.Pod // map from nodename to debugPod
-	HugepagesPods []*Pod
-	AllPods       []*Pod `json:"AllPods"`
+	Pods      []*Pod                 `json:"testPods"`
+	DebugPods map[string]*corev1.Pod // map from nodename to debugPod
+	AllPods   []*Pod                 `json:"AllPods"`
 
 	// Deployment Groupings
 	Deployments []*Deployment `json:"testDeployments"`
@@ -170,11 +169,6 @@ func buildTestEnvironment() { //nolint:funlen
 	for i := 0; i < len(pods); i++ {
 		aNewPod := NewPod(&pods[i])
 		env.Pods = append(env.Pods, &aNewPod)
-
-		// Build slices of guaranteed and non guaranteed pods
-		if aNewPod.HasHugepages() {
-			env.HugepagesPods = append(env.HugepagesPods, &aNewPod)
-		}
 		env.Containers = append(env.Containers, getPodContainers(&pods[i])...)
 	}
 	pods = data.AllPods

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -68,24 +68,16 @@ type TestEnvironment struct { // rename this with testTarget
 	AbnormalEvents []*Event
 
 	// Pod Groupings
-	Pods                     []*Pod                 `json:"testPods"`
-	DebugPods                map[string]*corev1.Pod // map from nodename to debugPod
-	GuaranteedPods           []*Pod
-	NonGuaranteedPods        []*Pod
-	AffinityRequiredPods     []*Pod
-	AntiAffinityRequiredPods []*Pod
-	HugepagesPods            []*Pod
-	AllPods                  []*Pod `json:"AllPods"`
+	Pods          []*Pod                 `json:"testPods"`
+	DebugPods     map[string]*corev1.Pod // map from nodename to debugPod
+	HugepagesPods []*Pod
+	AllPods       []*Pod `json:"AllPods"`
 
 	// Deployment Groupings
-	Deployments                     []*Deployment `json:"testDeployments"`
-	AffinityRequiredDeployments     []*Deployment
-	AntiAffinityRequiredDeployments []*Deployment
+	Deployments []*Deployment `json:"testDeployments"`
 
 	// StatefulSet Groupings
-	StatefulSets                     []*StatefulSet `json:"testStatefulSets"`
-	AffinityRequiredStatefulSets     []*StatefulSet
-	AntiAffinityRequiredStatefulSets []*StatefulSet
+	StatefulSets []*StatefulSet `json:"testStatefulSets"`
 
 	Containers             []*Container `json:"testContainers"`
 	Operators              []Operator   `json:"testOperators"`
@@ -155,7 +147,7 @@ var (
 	loaded = false
 )
 
-func buildTestEnvironment() { //nolint:funlen,gocyclo
+func buildTestEnvironment() { //nolint:funlen
 	// Wait for the debug pods to be ready before the autodiscovery starts.
 	err := WaitDebugPodsReady()
 	if err != nil {
@@ -180,20 +172,8 @@ func buildTestEnvironment() { //nolint:funlen,gocyclo
 		env.Pods = append(env.Pods, &aNewPod)
 
 		// Build slices of guaranteed and non guaranteed pods
-		if aNewPod.IsPodGuaranteed() {
-			env.GuaranteedPods = append(env.GuaranteedPods, &aNewPod)
-		} else {
-			env.NonGuaranteedPods = append(env.NonGuaranteedPods, &aNewPod)
-		}
 		if aNewPod.HasHugepages() {
 			env.HugepagesPods = append(env.HugepagesPods, &aNewPod)
-		}
-
-		// Build slices of AffinityRequired and non AffinityRequired pods
-		if aNewPod.AffinityRequired() {
-			env.AffinityRequiredPods = append(env.AffinityRequiredPods, &aNewPod)
-		} else {
-			env.AntiAffinityRequiredPods = append(env.AntiAffinityRequiredPods, &aNewPod)
 		}
 		env.Containers = append(env.Containers, getPodContainers(&pods[i])...)
 	}
@@ -229,26 +209,12 @@ func buildTestEnvironment() { //nolint:funlen,gocyclo
 			&data.Deployments[i],
 		}
 		env.Deployments = append(env.Deployments, aNewDeployment)
-
-		// Create slices of affinity required and affinity not required deployments
-		if aNewDeployment.AffinityRequired() {
-			env.AffinityRequiredDeployments = append(env.AffinityRequiredDeployments, aNewDeployment)
-		} else {
-			env.AntiAffinityRequiredDeployments = append(env.AntiAffinityRequiredDeployments, aNewDeployment)
-		}
 	}
 	for i := range data.StatefulSet {
 		aNewStatefulSet := &StatefulSet{
 			&data.StatefulSet[i],
 		}
 		env.StatefulSets = append(env.StatefulSets, aNewStatefulSet)
-
-		// Create slices of affinity required and affinity not required statefulsets
-		if aNewStatefulSet.AffinityRequired() {
-			env.AffinityRequiredStatefulSets = append(env.AffinityRequiredStatefulSets, aNewStatefulSet)
-		} else {
-			env.AntiAffinityRequiredStatefulSets = append(env.AntiAffinityRequiredStatefulSets, aNewStatefulSet)
-		}
 	}
 	env.HorizontalScaler = data.Hpas
 


### PR DESCRIPTION
I created `pkg/provider/filters.go` to house all of these environment funcs to filter Pods, Deployments, StatefulSets on the fly versus once during the autodiscover.  I can see where this might be problematic as far as running the filtering multiple times however I think it will help clean up the code in the long run.

For example, see `lifecycle/suite.go`.  Instead of using our slice of NonGuaranteedPods and then filtering, I'm combining all of the logic into `GetNonGuaranteedPodsWithAntiAffinity()`.  This can help get all of the _filtering_ out of the way prior to running the test.

![image](https://user-images.githubusercontent.com/4563082/192613340-82c179b7-6cad-4b44-a82b-49923eeb37c9.png)
