### PR TITLE
Skip known container names

### DIFF
--- a/pkg/provider/containers.go
+++ b/pkg/provider/containers.go
@@ -26,6 +26,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+var (
+	// Certain tests that have been known to fail because of injected containers (such as Istio) that fail certain tests.
+	ignoredContainerNames = []string{"istio-proxy"}
+)
+
 type Container struct {
 	*corev1.Container
 	Status                   corev1.ContainerStatus
@@ -71,4 +76,13 @@ func (c *Container) String() string {
 		c.Podname,
 		c.Namespace,
 	)
+}
+
+func (c *Container) HasIgnoredContainerName() bool {
+	for _, ign := range ignoredContainerNames {
+		if strings.Contains(c.Name, ign) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -55,7 +55,7 @@ func NewPod(aPod *corev1.Pod) (out Pod) {
 	if _, ok := aPod.GetLabels()[skipMultusConnectivityTestsLabel]; ok {
 		out.SkipMultusNetTests = true
 	}
-	out.Containers = append(out.Containers, getPodContainers(aPod)...)
+	out.Containers = append(out.Containers, getPodContainers(aPod, false)...)
 	return out
 }
 


### PR DESCRIPTION
build-depends: 26082

In some recent tests where a partner is actually using Istio, there are a number container related tests that are failing/flagging istio-proxy containers.  The tests are:
```
networking-undeclared-container-ports-usage
observability-termination-policy
lifecycle-liveness
lifecycle-image-pull-policy
lifecycle-container-shutdown
```

So what I did was add a check function on the `Container` object that will allow us to ignore any containers that have a known container name that causes failures.