### PR TITLE
Clean up reporting

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -465,7 +465,7 @@ func TestOneProcessPerContainer(env *provider.TestEnvironment) {
 			continue
 		}
 		if nbProcesses > 1 {
-			tnf.ClaimFilePrintf("Container %s has more than one process running", cut.String())
+			tnf.ClaimFilePrintf("%s has more than one process running", cut.String())
 			badContainers = append(badContainers, cut.String())
 		}
 	}
@@ -481,7 +481,7 @@ func TestSYSNiceRealtimeCapability(env *provider.TestEnvironment) {
 	for _, cut := range env.Containers {
 		n := env.Nodes[cut.NodeName]
 		if n.IsRTKernel() && !strings.Contains(cut.SecurityContext.Capabilities.String(), "SYS_NICE") {
-			tnf.ClaimFilePrintf("Container: %s has been found running on a realtime kernel enabled node without SYS_NICE capability.", cut.String())
+			tnf.ClaimFilePrintf("%s has been found running on a realtime kernel enabled node without SYS_NICE capability.", cut.String())
 			containersWithoutSysNice = append(containersWithoutSysNice, cut.String())
 		}
 	}

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -282,6 +282,7 @@ func testDeploymentScaling(env *provider.TestEnvironment, timeout time.Duration)
 			// can scale the deployment
 			if !scaling.TestScaleHpaDeployment(env.Deployments[i], hpa, timeout) {
 				failedDeployments = append(failedDeployments, env.Deployments[i].ToString())
+				tnf.ClaimFilePrintf("Deployment has failed the HPA scale test: %s", env.Deployments[i].ToString())
 			}
 			continue
 		}
@@ -289,6 +290,7 @@ func testDeploymentScaling(env *provider.TestEnvironment, timeout time.Duration)
 		// scale it directly
 		if !scaling.TestScaleDeployment(env.Deployments[i].Deployment, timeout) {
 			failedDeployments = append(failedDeployments, env.Deployments[i].ToString())
+			tnf.ClaimFilePrintf("Deployment has failed the non-HPA scale test: %s", env.Deployments[i].ToString())
 		}
 	}
 

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -153,9 +153,11 @@ func testUndeclaredContainerPortsUsage(env *provider.TestEnvironment) {
 
 		// Verify that all the listening ports have been declared in the container spec
 		failedPod := false
+		var listeningPortsAlreadyReported []netutil.PortInfo // short circuit to not report the same port more than once
 		for listeningPort := range listeningPorts {
-			if !declaredPorts[listeningPort] {
-				tnf.ClaimFilePrintf("%s is listening on port %d protocol %d, but that port was not declared in any container spec.", put, portInfo.PortNumber, portInfo.Protocol)
+			if !declaredPorts[listeningPort] && !netcommons.ExistsInPortInfoSlice(listeningPort, listeningPortsAlreadyReported) {
+				listeningPortsAlreadyReported = append(listeningPortsAlreadyReported, listeningPort)
+				tnf.ClaimFilePrintf("%s is listening on port %d protocol %s, but that port was not declared in any container spec.", put, portInfo.PortNumber, portInfo.Protocol)
 				failedPod = true
 			}
 		}


### PR DESCRIPTION
Changes: 
- Removed extraneous `Container: %s` strings when all is needed is `%s`.
- Added claim file prints for the `testDeploymentScaling` func.
- Fixed `FindRogueContainersDeclaringPorts` and `testUndeclaredContainerPortsUsage` to only report a port once to avoid output like:

```
pod: test-0 ns: production-cnf is listening on port 15090 protocol %!d(string=TCP), but that port was not declared in any container spec.
pod: test-0 ns: production-cnf is listening on port 15090 protocol %!d(string=TCP), but that port was not declared in any container spec.
pod: test-0 ns: production-cnf is listening on port 15090 protocol %!d(string=TCP), but that port was not declared in any container spec.
pod: test-1 ns: production-cnf is listening on port 15090 protocol %!d(string=TCP), but that port was not declared in any container spec.
pod: test-1 ns: production-cnf is listening on port 15090 protocol %!d(string=TCP), but that port was not declared in any container spec.
pod: test-1 ns: production-cnf is listening on port 15090 protocol %!d(string=TCP), but that port was not declared in any container spec.
pod: test-1 ns: production-cnf is listening on port 15090 protocol %!d(string=TCP), but that port was not declared in any container spec.
pod: test-1 ns: production-cnf is listening on port 15090 protocol %!d(string=TCP), but that port was not declared in any container spec.
pod: test-1 ns: production-cnf is listening on port 15090 protocol %!d(string=TCP), but that port was not declared in any container spec.
```