### PR TITLE
Add tags to the catalog entries

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -20,7 +20,7 @@ Result Type|normative
 Suggested Remediation|In most cases, Pod's should not have ClusterRoleBindings.  The suggested remediation is to remove the need for 	ClusterRoleBindings, if possible.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.10 and 5.3.6
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### container-host-port
 
 Property|Description
@@ -34,7 +34,7 @@ Result Type|informative
 Suggested Remediation|Remove hostPort configuration from the container
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.3.6
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### namespace
 
 Property|Description
@@ -48,7 +48,7 @@ Result Type|normative
 Suggested Remediation|Ensure that your CNF utilizes namespaces declared in the yaml config file. Additionally, 	the namespaces should not start with "default, openshift-, istio- or aspenmesh-", except in rare cases.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2, 16.3.8 and 16.3.9
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### namespace-resource-quota
 
 Property|Description
@@ -62,7 +62,7 @@ Result Type|informative
 Suggested Remediation|Apply a ResourceQuota to the namespace your CNF is running in
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 4.6.8
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### no-1337-uid
 
 Property|Description
@@ -90,7 +90,7 @@ Result Type|informative
 Suggested Remediation|Launch only one process per container
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 10.8.3
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### pod-automount-service-account-token
 
 Property|Description
@@ -104,7 +104,7 @@ Result Type|normative
 Suggested Remediation|Check that pod has automountServiceAccountToken set to false or pod is attached to service account which has automountServiceAccountToken set to false
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 12.7
 Exception Process|Identify which Kubernetes APIs are required if you need to utilize automount service tokens.  Depending on 												which APIs are utilized, Red Hat possibly might make those APIs available to use via OpenShift.
-Tags|
+Tags|common
 #### pod-host-ipc
 
 Property|Description
@@ -118,7 +118,7 @@ Result Type|informative
 Suggested Remediation|Set the spec.HostIpc parameter to false in the pod configuration
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.3.6
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### pod-host-network
 
 Property|Description
@@ -132,7 +132,7 @@ Result Type|informative
 Suggested Remediation|Set the spec.HostNetwork parameter to false in the pod configuration
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.3.6
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### pod-host-path
 
 Property|Description
@@ -146,7 +146,7 @@ Result Type|informative
 Suggested Remediation|Set the spec.HostNetwork parameter to false in the pod configuration
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.3.6
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### pod-host-pid
 
 Property|Description
@@ -160,7 +160,7 @@ Result Type|informative
 Suggested Remediation|Set the spec.HostPid parameter to false in the pod configuration
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.3.6
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### pod-role-bindings
 
 Property|Description
@@ -174,7 +174,7 @@ Result Type|normative
 Suggested Remediation|Ensure the CNF is not configured to use RoleBinding(s) in a non-CNF Namespace.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.3.3 and 5.3.5
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### pod-service-account
 
 Property|Description
@@ -188,7 +188,7 @@ Result Type|normative
 Suggested Remediation|Ensure that the each CNF Pod is configured to use a valid Service Account
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.3 and 5.2.7
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### pod-toleration-bypass
 
 Property|Description
@@ -202,7 +202,7 @@ Result Type|informative
 Suggested Remediation|Do not allow pods to bypass the NoExecute, PreferNoSchedule, or NoSchedule tolerations that are default applied by Kubernetes.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 10.6
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### requests-and-limits
 
 Property|Description
@@ -216,7 +216,7 @@ Result Type|informative
 Suggested Remediation|Add requests and limits to your container spec.  See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
 Best Practice Reference|https://TODO Section 4.6.11
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### security-context-capabilities-check
 
 Property|Description
@@ -230,7 +230,7 @@ Result Type|normative
 Suggested Remediation|Remove the following capabilities from the container/pod definitions: NET_ADMIN SCC, SYS_ADMIN SCC, NET_RAW SCC, IPC_LOCK SCC
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|Identify the pod that is needing special capabilities and document why  
-Tags|
+Tags|common
 #### security-context-non-root-user-check
 
 Property|Description
@@ -244,7 +244,7 @@ Result Type|normative
 Suggested Remediation|Change the pod and containers "runAsUser" uid to something other than root(0)
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|If your application needs root user access, please document why your application cannot be ran as 											non-root and supply the reasoning for exception.
-Tags|
+Tags|common
 #### security-context-privilege-escalation
 
 Property|Description
@@ -258,7 +258,7 @@ Result Type|normative
 Suggested Remediation|Configure privilege escalation to false
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### ssh-daemons
 
 Property|Description
@@ -272,7 +272,7 @@ Result Type|normative
 Suggested Remediation|Ensure that no SSH daemons are running inside a pod
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 4.6.12
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### sys-nice-realtime-capability
 
 Property|Description
@@ -286,7 +286,7 @@ Result Type|informative
 Suggested Remediation|If pods are scheduled to realtime kernel nodes, they must add SYS_NICE capability to their spec.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 2.7.4
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### sys-ptrace-capability
 
 Property|Description
@@ -300,7 +300,7 @@ Result Type|informative
 Suggested Remediation|Allow the SYS_PTRACE capability when enabling process namespace sharing for a Pod
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 2.7.5
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 
 ### affiliated-certification
 
@@ -345,7 +345,7 @@ Result Type|normative
 Suggested Remediation|Ensure that the helm charts under test passed the Red Hat's helm Certification Program (e.g. listed in https://charts.openshift.io/index.yaml).
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.12 and 5.3.3
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common,online
 #### operator-is-certified
 
 Property|Description
@@ -359,7 +359,7 @@ Result Type|normative
 Suggested Remediation|Ensure that your Operator has passed Red Hat's Operator Certification Program (OCP).
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.12 and 5.3.3
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common,online
 
 ### lifecycle
 
@@ -418,7 +418,7 @@ Result Type|normative
 Suggested Remediation| 	It's considered best-practices to define prestop for proper management of container lifecycle. 	The prestop can be used to gracefully stop the container and clean resources (e.g., DB connection). 	 	The prestop can be configured using : 	 1) Exec : executes the supplied command inside the container 	 2) HTTP : executes HTTP request against the specified endpoint. 	 	When defined. K8s will handle shutdown of the container using the following: 	1) K8s first execute the preStop hook inside the container. 	2) K8s will wait for a grace period. 	3) K8s will clean the remaining processes using KILL signal.		 		
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.1.3, 12.2 and 12.5
 Exception Process|Identify which pod is not conforming to the process and submit information as to why it cannot  									use a prestop shutdown specification.
-Tags|
+Tags|common
 #### cpu-isolation
 
 Property|Description
@@ -432,7 +432,7 @@ Result Type|informative
 Suggested Remediation|CPU isolation testing is enabled.  Please ensure that all pods adhere to the CPU isolation requirements
 Best Practice Reference|https://TODO Section 3.5.5
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### deployment-scaling
 
 Property|Description
@@ -446,7 +446,7 @@ Result Type|normative
 Suggested Remediation|Ensure CNF deployments/replica sets can scale in/out successfully.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### image-pull-policy
 
 Property|Description
@@ -460,7 +460,7 @@ Result Type|normative
 Suggested Remediation|Ensure that the containers under test are using IfNotPresent as Image Pull Policy.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf  Section 12.6
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### liveness-probe
 
 Property|Description
@@ -474,7 +474,7 @@ Result Type|normative
 Suggested Remediation|Add a liveness probe to deployed containers
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.16, 12.1 and 12.5
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### persistent-volume-reclaim-policy
 
 Property|Description
@@ -488,7 +488,7 @@ Result Type|informative
 Suggested Remediation|Ensure that all persistent volumes are using the reclaim policy: delete
 Best Practice Reference|https://TODO Section 3.3.4
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### pod-high-availability
 
 Property|Description
@@ -502,7 +502,7 @@ Result Type|informative
 Suggested Remediation|In high availability cases, Pod podAntiAffinity rule should be specified for pod scheduling and pod replica value is set to more than 1 .
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### pod-owner-type
 
 Property|Description
@@ -516,7 +516,7 @@ Result Type|normative
 Suggested Remediation|Deploy the CNF using ReplicaSet/StatefulSet.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.3.3 and 5.3.8
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### pod-recreation
 
 Property|Description
@@ -530,7 +530,7 @@ Result Type|normative
 Suggested Remediation|Ensure that CNF Pod(s) utilize a configuration that supports High Availability.   	Additionally, ensure that there are available Nodes in the OpenShift cluster that can be utilized in the event that a host Node fails.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### pod-scheduling
 
 Property|Description
@@ -544,7 +544,7 @@ Result Type|informative
 Suggested Remediation|In most cases, Pod's should not specify their host Nodes through nodeSelector or nodeAffinity.  However, there are 	cases in which CNFs require specialized hardware specific to a particular class of Node.  As such, this test is purely 	informative, and will not prevent a CNF from being certified. However, one should have an appropriate justification as 	to why nodeSelector and/or nodeAffinity is utilized by a CNF.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### readiness-probe
 
 Property|Description
@@ -558,7 +558,7 @@ Result Type|normative
 Suggested Remediation|Add a readiness probe to deployed containers
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.16, 12.1 and 12.5
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### scaling
 
 Property|Description
@@ -572,7 +572,7 @@ Result Type|normative
 Suggested Remediation|Ensure CNF deployments/replica sets can scale in/out successfully.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### startup-probe
 
 Property|Description
@@ -586,7 +586,7 @@ Result Type|normative
 Suggested Remediation|Add a startup probe to deployed containers
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 4.6.12
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### statefulset-scaling
 
 Property|Description
@@ -600,7 +600,7 @@ Result Type|normative
 Suggested Remediation|Ensure CNF statefulsets/replica sets can scale in/out successfully.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 
 ### manageability
 
@@ -617,7 +617,7 @@ Result Type|normative
 Suggested Remediation|Ensure that the container's ports name follow our partner naming conventions
 Best Practice Reference|https://TODO Section 4.6.20
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|extended
 #### containers-image-tag
 
 Property|Description
@@ -631,7 +631,7 @@ Result Type|informative
 Suggested Remediation|Ensure that all the container images are tagged
 Best Practice Reference|https://TODO Section 4.6.12
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|extended
 
 ### networking
 
@@ -648,7 +648,7 @@ Result Type|normative
 Suggested Remediation|Configure every CNF services with either a single stack ipv6 or dual stack (ipv4/ipv6) load balancer
 Best Practice Reference|https://TODO Section 3.5.7
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### icmpv4-connectivity
 
 Property|Description
@@ -690,7 +690,7 @@ Result Type|normative
 Suggested Remediation|Ensure that the CNF is able to communicate via the Default OpenShift network. In some rare cases, 	CNFs may require routing table changes in order to communicate over the Default network. To exclude a particular pod 	from ICMPv6 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### icmpv6-connectivity-multus
 
 Property|Description
@@ -704,7 +704,7 @@ Result Type|normative
 Suggested Remediation|Ensure that the CNF is able to communicate via the Multus network(s). In some rare cases, 	CNFs may require routing table changes in order to communicate over the Multus network(s). To exclude a particular pod 	from ICMPv6 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it.The label value is not important, only its presence.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### iptables
 
 Property|Description
@@ -718,7 +718,7 @@ Result Type|normative
 Suggested Remediation|Do not configure iptables on any CNF container.
 Best Practice Reference|https://TODO Section 4.6.23
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### network-policy-deny-all
 
 Property|Description
@@ -746,7 +746,7 @@ Result Type|normative
 Suggested Remediation|Do not configure nftables on any CNF container.
 Best Practice Reference|https://TODO Section 4.6.23
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### ocp-reserved-ports-usage
 
 Property|Description
@@ -760,7 +760,7 @@ Result Type|normative
 Suggested Remediation|Ensure that CNF apps do not listen on ports that are reserved by OpenShift
 Best Practice Reference|https://TODO Section 3.5.9
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### reserved-partner-ports
 
 Property|Description
@@ -788,7 +788,7 @@ Result Type|normative
 Suggested Remediation|Ensure Services are not configured to use NodePort(s).
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.3.1
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### undeclared-container-ports-usage
 
 Property|Description
@@ -802,7 +802,7 @@ Result Type|normative
 Suggested Remediation|Ensure the CNF apps do not listen on undeclared containers' ports
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 16.3.1.1
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 
 ### observability
 
@@ -819,7 +819,7 @@ Result Type|informative
 Suggested Remediation|Ensure containers are not redirecting stdout/stderr
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 10.1
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### crd-status
 
 Property|Description
@@ -833,7 +833,7 @@ Result Type|informative
 Suggested Remediation|Ensure that all the CRDs have a meaningful status specification (Spec.versions[].Schema.OpenAPIV3Schema.Properties["status"]).
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### pod-disruption-budget
 
 Property|Description
@@ -847,7 +847,7 @@ Result Type|normative
 Suggested Remediation|Ensure minAvailable is not zero and maxUnavailable does not equal the number of pods in the replica
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 4.6.20
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### termination-policy
 
 Property|Description
@@ -861,7 +861,7 @@ Result Type|informative
 Suggested Remediation|Ensure containers are all using FallbackToLogsOnError in terminationMessagePolicy
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 12.1
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 
 ### operator
 
@@ -878,7 +878,7 @@ Result Type|normative
 Suggested Remediation|Ensure that your Operator is installed via OLM.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.12 and 5.3.3
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### install-status-no-privileges
 
 Property|Description
@@ -892,7 +892,7 @@ Result Type|normative
 Suggested Remediation|Ensure all the CNF operators have no privileges on cluster resources.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.12 and 5.3.3
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### install-status-succeeded
 
 Property|Description
@@ -906,7 +906,7 @@ Result Type|normative
 Suggested Remediation|Ensure all the CNF operators have been successfully installed by OLM.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.12 and 5.3.3
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 
 ### platform-alteration
 
@@ -923,7 +923,7 @@ Result Type|normative
 Suggested Remediation|Ensure that Container applications do not modify the Container Base Image.  In particular, ensure that the following 	directories are not modified: 	1) /var/lib/rpm 	2) /var/lib/dpkg 	3) /bin 	4) /sbin 	5) /lib 	6) /lib64 	7) /usr/bin 	8) /usr/sbin 	9) /usr/lib 	10) /usr/lib64 	Ensure that all required binaries are built directly into the container image, and are not installed post startup.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.1.4
 Exception Process|Images should not be changed during runtime.  There is no exception process for this.
-Tags|
+Tags|common
 #### boot-params
 
 Property|Description
@@ -937,7 +937,7 @@ Result Type|normative
 Suggested Remediation|Ensure that boot parameters are set directly through the MachineConfigOperator, or indirectly through the PerformanceAddonOperator.   	Boot parameters should not be changed directly through the Node, as OpenShift should manage the changes for you.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.13 and 5.2.14
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### hugepages-2m-only
 
 Property|Description
@@ -965,7 +965,7 @@ Result Type|normative
 Suggested Remediation|HugePage settings should be configured either directly through the MachineConfigOperator or indirectly using the 	PerformanceAddonOperator.  This ensures that OpenShift is aware of the special MachineConfig requirements, and can 	provision your CNF on a Node that is part of the corresponding MachineConfigSet.  Avoid making changes directly to an 	underlying Node, and let OpenShift handle the heavy lifting of configuring advanced settings.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### is-selinux-enforcing
 
 Property|Description
@@ -979,7 +979,7 @@ Result Type|normative
 Suggested Remediation|Configure selinux and enable enforcing mode.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 10.3 Pod Security
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### isredhat-release
 
 Property|Description
@@ -993,7 +993,7 @@ Result Type|normative
 Suggested Remediation|Build a new container image that is based on UBI (Red Hat Universal Base Image).
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|Document which containers are not able to meet the RHEL-based container  											requirement and if/when the base image can be updated.
-Tags|
+Tags|common
 #### ocp-lifecycle
 
 Property|Description
@@ -1007,7 +1007,7 @@ Result Type|normative
 Suggested Remediation|Please update your cluster to a version that is generally available.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 7.9
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### ocp-node-os-lifecycle
 
 Property|Description
@@ -1021,7 +1021,7 @@ Result Type|normative
 Suggested Remediation|Please update your workers to a version that is supported by your version of OpenShift
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 7.9
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### service-mesh-usage
 
 Property|Description
@@ -1035,7 +1035,7 @@ Result Type|normative
 Suggested Remediation|Ensure all the CNF pods are using service mesh if the cluster provides it.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### sysctl-config
 
 Property|Description
@@ -1049,7 +1049,7 @@ Result Type|normative
 Suggested Remediation|You should recreate the node or change the sysctls, recreating is recommended because there might be other unknown changes
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 #### tainted-node-kernel
 
 Property|Description
@@ -1063,5 +1063,5 @@ Result Type|normative
 Suggested Remediation|Test failure indicates that the underlying Node's kernel is tainted.  Ensure that you have not altered underlying 	Node(s) kernels in order to run the CNF.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.14
 Exception Process|There is no documented exception process for this.
-Tags|
+Tags|common
 

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -20,6 +20,7 @@ Result Type|normative
 Suggested Remediation|In most cases, Pod's should not have ClusterRoleBindings.  The suggested remediation is to remove the need for 	ClusterRoleBindings, if possible.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.10 and 5.3.6
 Exception Process|There is no documented exception process for this.
+Tags|
 #### container-host-port
 
 Property|Description
@@ -33,6 +34,7 @@ Result Type|informative
 Suggested Remediation|Remove hostPort configuration from the container
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.3.6
 Exception Process|There is no documented exception process for this.
+Tags|
 #### namespace
 
 Property|Description
@@ -46,6 +48,7 @@ Result Type|normative
 Suggested Remediation|Ensure that your CNF utilizes namespaces declared in the yaml config file. Additionally, 	the namespaces should not start with "default, openshift-, istio- or aspenmesh-", except in rare cases.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2, 16.3.8 and 16.3.9
 Exception Process|There is no documented exception process for this.
+Tags|
 #### namespace-resource-quota
 
 Property|Description
@@ -59,6 +62,7 @@ Result Type|informative
 Suggested Remediation|Apply a ResourceQuota to the namespace your CNF is running in
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 4.6.8
 Exception Process|There is no documented exception process for this.
+Tags|
 #### no-1337-uid
 
 Property|Description
@@ -72,6 +76,7 @@ Result Type|informative
 Suggested Remediation|Use another process UID that is not 1337
 Best Practice Reference|https://TODO Section 4.6.24
 Exception Process|There is no documented exception process for this.
+Tags|extended
 #### one-process-per-container
 
 Property|Description
@@ -85,6 +90,7 @@ Result Type|informative
 Suggested Remediation|Launch only one process per container
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 10.8.3
 Exception Process|There is no documented exception process for this.
+Tags|
 #### pod-automount-service-account-token
 
 Property|Description
@@ -98,6 +104,7 @@ Result Type|normative
 Suggested Remediation|Check that pod has automountServiceAccountToken set to false or pod is attached to service account which has automountServiceAccountToken set to false
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 12.7
 Exception Process|Identify which Kubernetes APIs are required if you need to utilize automount service tokens.  Depending on 												which APIs are utilized, Red Hat possibly might make those APIs available to use via OpenShift.
+Tags|
 #### pod-host-ipc
 
 Property|Description
@@ -111,6 +118,7 @@ Result Type|informative
 Suggested Remediation|Set the spec.HostIpc parameter to false in the pod configuration
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.3.6
 Exception Process|There is no documented exception process for this.
+Tags|
 #### pod-host-network
 
 Property|Description
@@ -124,6 +132,7 @@ Result Type|informative
 Suggested Remediation|Set the spec.HostNetwork parameter to false in the pod configuration
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.3.6
 Exception Process|There is no documented exception process for this.
+Tags|
 #### pod-host-path
 
 Property|Description
@@ -137,6 +146,7 @@ Result Type|informative
 Suggested Remediation|Set the spec.HostNetwork parameter to false in the pod configuration
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.3.6
 Exception Process|There is no documented exception process for this.
+Tags|
 #### pod-host-pid
 
 Property|Description
@@ -150,6 +160,7 @@ Result Type|informative
 Suggested Remediation|Set the spec.HostPid parameter to false in the pod configuration
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.3.6
 Exception Process|There is no documented exception process for this.
+Tags|
 #### pod-role-bindings
 
 Property|Description
@@ -163,6 +174,7 @@ Result Type|normative
 Suggested Remediation|Ensure the CNF is not configured to use RoleBinding(s) in a non-CNF Namespace.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.3.3 and 5.3.5
 Exception Process|There is no documented exception process for this.
+Tags|
 #### pod-service-account
 
 Property|Description
@@ -176,6 +188,7 @@ Result Type|normative
 Suggested Remediation|Ensure that the each CNF Pod is configured to use a valid Service Account
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.3 and 5.2.7
 Exception Process|There is no documented exception process for this.
+Tags|
 #### pod-toleration-bypass
 
 Property|Description
@@ -189,6 +202,7 @@ Result Type|informative
 Suggested Remediation|Do not allow pods to bypass the NoExecute, PreferNoSchedule, or NoSchedule tolerations that are default applied by Kubernetes.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 10.6
 Exception Process|There is no documented exception process for this.
+Tags|
 #### requests-and-limits
 
 Property|Description
@@ -202,6 +216,7 @@ Result Type|informative
 Suggested Remediation|Add requests and limits to your container spec.  See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
 Best Practice Reference|https://TODO Section 4.6.11
 Exception Process|There is no documented exception process for this.
+Tags|
 #### security-context-capabilities-check
 
 Property|Description
@@ -215,6 +230,7 @@ Result Type|normative
 Suggested Remediation|Remove the following capabilities from the container/pod definitions: NET_ADMIN SCC, SYS_ADMIN SCC, NET_RAW SCC, IPC_LOCK SCC
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|Identify the pod that is needing special capabilities and document why  
+Tags|
 #### security-context-non-root-user-check
 
 Property|Description
@@ -228,6 +244,7 @@ Result Type|normative
 Suggested Remediation|Change the pod and containers "runAsUser" uid to something other than root(0)
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|If your application needs root user access, please document why your application cannot be ran as 											non-root and supply the reasoning for exception.
+Tags|
 #### security-context-privilege-escalation
 
 Property|Description
@@ -241,6 +258,7 @@ Result Type|normative
 Suggested Remediation|Configure privilege escalation to false
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
+Tags|
 #### ssh-daemons
 
 Property|Description
@@ -254,6 +272,7 @@ Result Type|normative
 Suggested Remediation|Ensure that no SSH daemons are running inside a pod
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 4.6.12
 Exception Process|There is no documented exception process for this.
+Tags|
 #### sys-nice-realtime-capability
 
 Property|Description
@@ -267,6 +286,7 @@ Result Type|informative
 Suggested Remediation|If pods are scheduled to realtime kernel nodes, they must add SYS_NICE capability to their spec.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 2.7.4
 Exception Process|There is no documented exception process for this.
+Tags|
 #### sys-ptrace-capability
 
 Property|Description
@@ -280,6 +300,7 @@ Result Type|informative
 Suggested Remediation|Allow the SYS_PTRACE capability when enabling process namespace sharing for a Pod
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 2.7.5
 Exception Process|There is no documented exception process for this.
+Tags|
 
 ### affiliated-certification
 
@@ -296,6 +317,7 @@ Result Type|normative
 Suggested Remediation|Ensure that your container has passed the Red Hat Container Certification Program (CCP).
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.3.7
 Exception Process|There is no documented exception process for this.
+Tags|
 #### container-is-certified-digest
 
 Property|Description
@@ -309,6 +331,7 @@ Result Type|normative
 Suggested Remediation|Ensure that your container has passed the Red Hat Container Certification Program (CCP).
 Best Practice Reference|https://TODO Section 5.3.7
 Exception Process|There is no documented exception process for this.
+Tags|extended
 #### helmchart-is-certified
 
 Property|Description
@@ -322,6 +345,7 @@ Result Type|normative
 Suggested Remediation|Ensure that the helm charts under test passed the Red Hat's helm Certification Program (e.g. listed in https://charts.openshift.io/index.yaml).
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.12 and 5.3.3
 Exception Process|There is no documented exception process for this.
+Tags|
 #### operator-is-certified
 
 Property|Description
@@ -335,6 +359,7 @@ Result Type|normative
 Suggested Remediation|Ensure that your Operator has passed Red Hat's Operator Certification Program (OCP).
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.12 and 5.3.3
 Exception Process|There is no documented exception process for this.
+Tags|
 
 ### lifecycle
 
@@ -351,6 +376,7 @@ Result Type|informative
 Suggested Remediation|If a pod/statefulset/deployment is required to use affinity rules, please add AffinityRequired: 'true' as a label
 Best Practice Reference|https://TODO Section 4.6.24
 Exception Process|There is no documented exception process for this.
+Tags|extended
 #### affinity-required-pods
 
 Property|Description
@@ -364,6 +390,7 @@ Result Type|informative
 Suggested Remediation|If a pod/statefulset/deployment is required to use affinity rules, please add AffinityRequired: 'true' as a label
 Best Practice Reference|https://TODO Section 4.6.24
 Exception Process|There is no documented exception process for this.
+Tags|extended
 #### affinity-required-statefulsets
 
 Property|Description
@@ -377,6 +404,7 @@ Result Type|informative
 Suggested Remediation|If a pod/statefulset/deployment is required to use affinity rules, please add AffinityRequired: 'true' as a label
 Best Practice Reference|https://TODO Section 4.6.24
 Exception Process|There is no documented exception process for this.
+Tags|extended
 #### container-shutdown
 
 Property|Description
@@ -390,6 +418,7 @@ Result Type|normative
 Suggested Remediation| 	It's considered best-practices to define prestop for proper management of container lifecycle. 	The prestop can be used to gracefully stop the container and clean resources (e.g., DB connection). 	 	The prestop can be configured using : 	 1) Exec : executes the supplied command inside the container 	 2) HTTP : executes HTTP request against the specified endpoint. 	 	When defined. K8s will handle shutdown of the container using the following: 	1) K8s first execute the preStop hook inside the container. 	2) K8s will wait for a grace period. 	3) K8s will clean the remaining processes using KILL signal.		 		
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.1.3, 12.2 and 12.5
 Exception Process|Identify which pod is not conforming to the process and submit information as to why it cannot  									use a prestop shutdown specification.
+Tags|
 #### cpu-isolation
 
 Property|Description
@@ -403,6 +432,7 @@ Result Type|informative
 Suggested Remediation|CPU isolation testing is enabled.  Please ensure that all pods adhere to the CPU isolation requirements
 Best Practice Reference|https://TODO Section 3.5.5
 Exception Process|There is no documented exception process for this.
+Tags|
 #### deployment-scaling
 
 Property|Description
@@ -416,6 +446,7 @@ Result Type|normative
 Suggested Remediation|Ensure CNF deployments/replica sets can scale in/out successfully.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
+Tags|
 #### image-pull-policy
 
 Property|Description
@@ -429,6 +460,7 @@ Result Type|normative
 Suggested Remediation|Ensure that the containers under test are using IfNotPresent as Image Pull Policy.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf  Section 12.6
 Exception Process|There is no documented exception process for this.
+Tags|
 #### liveness-probe
 
 Property|Description
@@ -442,6 +474,7 @@ Result Type|normative
 Suggested Remediation|Add a liveness probe to deployed containers
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.16, 12.1 and 12.5
 Exception Process|There is no documented exception process for this.
+Tags|
 #### persistent-volume-reclaim-policy
 
 Property|Description
@@ -455,6 +488,7 @@ Result Type|informative
 Suggested Remediation|Ensure that all persistent volumes are using the reclaim policy: delete
 Best Practice Reference|https://TODO Section 3.3.4
 Exception Process|There is no documented exception process for this.
+Tags|
 #### pod-high-availability
 
 Property|Description
@@ -468,6 +502,7 @@ Result Type|informative
 Suggested Remediation|In high availability cases, Pod podAntiAffinity rule should be specified for pod scheduling and pod replica value is set to more than 1 .
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
+Tags|
 #### pod-owner-type
 
 Property|Description
@@ -481,6 +516,7 @@ Result Type|normative
 Suggested Remediation|Deploy the CNF using ReplicaSet/StatefulSet.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.3.3 and 5.3.8
 Exception Process|There is no documented exception process for this.
+Tags|
 #### pod-recreation
 
 Property|Description
@@ -494,6 +530,7 @@ Result Type|normative
 Suggested Remediation|Ensure that CNF Pod(s) utilize a configuration that supports High Availability.   	Additionally, ensure that there are available Nodes in the OpenShift cluster that can be utilized in the event that a host Node fails.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
+Tags|
 #### pod-scheduling
 
 Property|Description
@@ -507,6 +544,7 @@ Result Type|informative
 Suggested Remediation|In most cases, Pod's should not specify their host Nodes through nodeSelector or nodeAffinity.  However, there are 	cases in which CNFs require specialized hardware specific to a particular class of Node.  As such, this test is purely 	informative, and will not prevent a CNF from being certified. However, one should have an appropriate justification as 	to why nodeSelector and/or nodeAffinity is utilized by a CNF.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
+Tags|
 #### readiness-probe
 
 Property|Description
@@ -520,6 +558,7 @@ Result Type|normative
 Suggested Remediation|Add a readiness probe to deployed containers
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.16, 12.1 and 12.5
 Exception Process|There is no documented exception process for this.
+Tags|
 #### scaling
 
 Property|Description
@@ -533,6 +572,7 @@ Result Type|normative
 Suggested Remediation|Ensure CNF deployments/replica sets can scale in/out successfully.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
+Tags|
 #### startup-probe
 
 Property|Description
@@ -546,6 +586,7 @@ Result Type|normative
 Suggested Remediation|Add a startup probe to deployed containers
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 4.6.12
 Exception Process|There is no documented exception process for this.
+Tags|
 #### statefulset-scaling
 
 Property|Description
@@ -559,6 +600,7 @@ Result Type|normative
 Suggested Remediation|Ensure CNF statefulsets/replica sets can scale in/out successfully.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
+Tags|
 
 ### manageability
 
@@ -575,6 +617,7 @@ Result Type|normative
 Suggested Remediation|Ensure that the container's ports name follow our partner naming conventions
 Best Practice Reference|https://TODO Section 4.6.20
 Exception Process|There is no documented exception process for this.
+Tags|
 #### containers-image-tag
 
 Property|Description
@@ -588,6 +631,7 @@ Result Type|informative
 Suggested Remediation|Ensure that all the container images are tagged
 Best Practice Reference|https://TODO Section 4.6.12
 Exception Process|There is no documented exception process for this.
+Tags|
 
 ### networking
 
@@ -604,6 +648,7 @@ Result Type|normative
 Suggested Remediation|Configure every CNF services with either a single stack ipv6 or dual stack (ipv4/ipv6) load balancer
 Best Practice Reference|https://TODO Section 3.5.7
 Exception Process|There is no documented exception process for this.
+Tags|
 #### icmpv4-connectivity
 
 Property|Description
@@ -617,6 +662,7 @@ Result Type|normative
 Suggested Remediation|Ensure that the CNF is able to communicate via the Default OpenShift network. In some rare cases, CNFs may require routing table changes in order to communicate over the Default network. To exclude a particular pod from ICMPv4 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
+Tags|common
 #### icmpv4-connectivity-multus
 
 Property|Description
@@ -630,6 +676,7 @@ Result Type|normative
 Suggested Remediation|Ensure that the CNF is able to communicate via the Multus network(s). In some rare cases, 	CNFs may require routing table changes in order to communicate over the Multus network(s). To exclude a particular pod 	from ICMPv4 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
+Tags|
 #### icmpv6-connectivity
 
 Property|Description
@@ -643,6 +690,7 @@ Result Type|normative
 Suggested Remediation|Ensure that the CNF is able to communicate via the Default OpenShift network. In some rare cases, 	CNFs may require routing table changes in order to communicate over the Default network. To exclude a particular pod 	from ICMPv6 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
+Tags|
 #### icmpv6-connectivity-multus
 
 Property|Description
@@ -656,6 +704,7 @@ Result Type|normative
 Suggested Remediation|Ensure that the CNF is able to communicate via the Multus network(s). In some rare cases, 	CNFs may require routing table changes in order to communicate over the Multus network(s). To exclude a particular pod 	from ICMPv6 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it.The label value is not important, only its presence.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
+Tags|
 #### iptables
 
 Property|Description
@@ -669,6 +718,7 @@ Result Type|normative
 Suggested Remediation|Do not configure iptables on any CNF container.
 Best Practice Reference|https://TODO Section 4.6.23
 Exception Process|There is no documented exception process for this.
+Tags|
 #### network-policy-deny-all
 
 Property|Description
@@ -682,6 +732,7 @@ Result Type|informative
 Suggested Remediation|Ensure that a NetworkPolicy with a default deny-all is applied. After the default is applied, apply a network policy to allow the traffic your application requires.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 10.6
 Exception Process|There is no documented exception process for this.
+Tags|common
 #### nftables
 
 Property|Description
@@ -695,6 +746,7 @@ Result Type|normative
 Suggested Remediation|Do not configure nftables on any CNF container.
 Best Practice Reference|https://TODO Section 4.6.23
 Exception Process|There is no documented exception process for this.
+Tags|
 #### ocp-reserved-ports-usage
 
 Property|Description
@@ -708,6 +760,7 @@ Result Type|normative
 Suggested Remediation|Ensure that CNF apps do not listen on ports that are reserved by OpenShift
 Best Practice Reference|https://TODO Section 3.5.9
 Exception Process|There is no documented exception process for this.
+Tags|
 #### reserved-partner-ports
 
 Property|Description
@@ -721,6 +774,7 @@ Result Type|informative
 Suggested Remediation|Ensure ports are not being used that are reserved by our partner
 Best Practice Reference|https://TODO Section 4.6.24
 Exception Process|There is no documented exception process for this.
+Tags|extended
 #### service-type
 
 Property|Description
@@ -734,6 +788,7 @@ Result Type|normative
 Suggested Remediation|Ensure Services are not configured to use NodePort(s).
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.3.1
 Exception Process|There is no documented exception process for this.
+Tags|
 #### undeclared-container-ports-usage
 
 Property|Description
@@ -747,6 +802,7 @@ Result Type|normative
 Suggested Remediation|Ensure the CNF apps do not listen on undeclared containers' ports
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 16.3.1.1
 Exception Process|There is no documented exception process for this.
+Tags|
 
 ### observability
 
@@ -763,6 +819,7 @@ Result Type|informative
 Suggested Remediation|Ensure containers are not redirecting stdout/stderr
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 10.1
 Exception Process|There is no documented exception process for this.
+Tags|
 #### crd-status
 
 Property|Description
@@ -776,6 +833,7 @@ Result Type|informative
 Suggested Remediation|Ensure that all the CRDs have a meaningful status specification (Spec.versions[].Schema.OpenAPIV3Schema.Properties["status"]).
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
+Tags|
 #### pod-disruption-budget
 
 Property|Description
@@ -789,6 +847,7 @@ Result Type|normative
 Suggested Remediation|Ensure minAvailable is not zero and maxUnavailable does not equal the number of pods in the replica
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 4.6.20
 Exception Process|There is no documented exception process for this.
+Tags|
 #### termination-policy
 
 Property|Description
@@ -802,6 +861,7 @@ Result Type|informative
 Suggested Remediation|Ensure containers are all using FallbackToLogsOnError in terminationMessagePolicy
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 12.1
 Exception Process|There is no documented exception process for this.
+Tags|
 
 ### operator
 
@@ -818,6 +878,7 @@ Result Type|normative
 Suggested Remediation|Ensure that your Operator is installed via OLM.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.12 and 5.3.3
 Exception Process|There is no documented exception process for this.
+Tags|
 #### install-status-no-privileges
 
 Property|Description
@@ -831,6 +892,7 @@ Result Type|normative
 Suggested Remediation|Ensure all the CNF operators have no privileges on cluster resources.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.12 and 5.3.3
 Exception Process|There is no documented exception process for this.
+Tags|
 #### install-status-succeeded
 
 Property|Description
@@ -844,6 +906,7 @@ Result Type|normative
 Suggested Remediation|Ensure all the CNF operators have been successfully installed by OLM.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.12 and 5.3.3
 Exception Process|There is no documented exception process for this.
+Tags|
 
 ### platform-alteration
 
@@ -860,6 +923,7 @@ Result Type|normative
 Suggested Remediation|Ensure that Container applications do not modify the Container Base Image.  In particular, ensure that the following 	directories are not modified: 	1) /var/lib/rpm 	2) /var/lib/dpkg 	3) /bin 	4) /sbin 	5) /lib 	6) /lib64 	7) /usr/bin 	8) /usr/sbin 	9) /usr/lib 	10) /usr/lib64 	Ensure that all required binaries are built directly into the container image, and are not installed post startup.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.1.4
 Exception Process|Images should not be changed during runtime.  There is no exception process for this.
+Tags|
 #### boot-params
 
 Property|Description
@@ -873,6 +937,7 @@ Result Type|normative
 Suggested Remediation|Ensure that boot parameters are set directly through the MachineConfigOperator, or indirectly through the PerformanceAddonOperator.   	Boot parameters should not be changed directly through the Node, as OpenShift should manage the changes for you.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.13 and 5.2.14
 Exception Process|There is no documented exception process for this.
+Tags|
 #### hugepages-2m-only
 
 Property|Description
@@ -886,6 +951,7 @@ Result Type|normative
 Suggested Remediation|Modify pod to consume 2Mi hugepages only
 Best Practice Reference|https://TODO Section 3.5.4
 Exception Process|There is no documented exception process for this.
+Tags|extended
 #### hugepages-config
 
 Property|Description
@@ -899,6 +965,7 @@ Result Type|normative
 Suggested Remediation|HugePage settings should be configured either directly through the MachineConfigOperator or indirectly using the 	PerformanceAddonOperator.  This ensures that OpenShift is aware of the special MachineConfig requirements, and can 	provision your CNF on a Node that is part of the corresponding MachineConfigSet.  Avoid making changes directly to an 	underlying Node, and let OpenShift handle the heavy lifting of configuring advanced settings.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
+Tags|
 #### is-selinux-enforcing
 
 Property|Description
@@ -912,6 +979,7 @@ Result Type|normative
 Suggested Remediation|Configure selinux and enable enforcing mode.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 10.3 Pod Security
 Exception Process|There is no documented exception process for this.
+Tags|
 #### isredhat-release
 
 Property|Description
@@ -925,6 +993,7 @@ Result Type|normative
 Suggested Remediation|Build a new container image that is based on UBI (Red Hat Universal Base Image).
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|Document which containers are not able to meet the RHEL-based container  											requirement and if/when the base image can be updated.
+Tags|
 #### ocp-lifecycle
 
 Property|Description
@@ -938,6 +1007,7 @@ Result Type|normative
 Suggested Remediation|Please update your cluster to a version that is generally available.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 7.9
 Exception Process|There is no documented exception process for this.
+Tags|
 #### ocp-node-os-lifecycle
 
 Property|Description
@@ -951,6 +1021,7 @@ Result Type|normative
 Suggested Remediation|Please update your workers to a version that is supported by your version of OpenShift
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 7.9
 Exception Process|There is no documented exception process for this.
+Tags|
 #### service-mesh-usage
 
 Property|Description
@@ -964,6 +1035,7 @@ Result Type|normative
 Suggested Remediation|Ensure all the CNF pods are using service mesh if the cluster provides it.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
+Tags|
 #### sysctl-config
 
 Property|Description
@@ -977,6 +1049,7 @@ Result Type|normative
 Suggested Remediation|You should recreate the node or change the sysctls, recreating is recommended because there might be other unknown changes
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
 Exception Process|There is no documented exception process for this.
+Tags|
 #### tainted-node-kernel
 
 Property|Description
@@ -990,4 +1063,5 @@ Result Type|normative
 Suggested Remediation|Test failure indicates that the underlying Node's kernel is tainted.  Ensure that you have not altered underlying 	Node(s) kernels in order to run the CNF.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.14
 Exception Process|There is no documented exception process for this.
+Tags|
 

--- a/cmd/tnf/generate/catalog/catalog.go
+++ b/cmd/tnf/generate/catalog/catalog.go
@@ -135,6 +135,8 @@ func Unique(slice []string) []string {
 }
 
 // outputTestCases outputs the Markdown representation for test cases from the catalog to stdout.
+//
+//nolint:funlen
 func outputTestCases() {
 	// Building a separate data structure to store the key order for the map
 	keys := make([]claim.Identifier, 0, len(identifiers.Catalog))
@@ -173,6 +175,7 @@ func outputTestCases() {
 			fmt.Fprintf(os.Stdout, "Suggested Remediation|%s\n", strings.ReplaceAll(identifiers.Catalog[k.identifier].Remediation, "\n", " "))
 			fmt.Fprintf(os.Stdout, "Best Practice Reference|%s\n", strings.ReplaceAll(identifiers.Catalog[k.identifier].BestPracticeReference, "\n", " "))
 			fmt.Fprintf(os.Stdout, "Exception Process|%s\n", strings.ReplaceAll(identifiers.Catalog[k.identifier].ExceptionProcess, "\n", " "))
+			fmt.Fprintf(os.Stdout, "Tags|%s\n", strings.ReplaceAll(identifiers.Catalog[k.identifier].Tags, "\n", " "))
 		}
 	}
 	fmt.Println()

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -659,6 +659,7 @@ var Catalog = map[claim.Identifier]TestCaseDescription{
 		Remediation:           NodeOperatingSystemRemediation,
 		ExceptionProcess:      NoDocumentedProcess,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 7.9",
+		Tags:                  TestNodeOperatingSystemIdentifier.Tags,
 	},
 
 	TestOCPLifecycleIdentifier: {
@@ -668,6 +669,7 @@ var Catalog = map[claim.Identifier]TestCaseDescription{
 		Remediation:           OCPLifecycleRemediation,
 		ExceptionProcess:      NoDocumentedProcess,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 7.9",
+		Tags:                  TestOCPLifecycleIdentifier.Tags,
 	},
 
 	TestDeploymentScalingIdentifier: {
@@ -682,6 +684,7 @@ var Catalog = map[claim.Identifier]TestCaseDescription{
 		Remediation:           DeploymentScalingRemediation,
 		ExceptionProcess:      NoDocumentedProcess,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
+		Tags:                  TestDeploymentScalingIdentifier.Tags,
 	},
 	TestStateFulSetScalingIdentifier: {
 		Identifier: TestStateFulSetScalingIdentifier,
@@ -695,6 +698,7 @@ var Catalog = map[claim.Identifier]TestCaseDescription{
 		Remediation:           StatefulSetScalingRemediation,
 		ExceptionProcess:      NoDocumentedProcess,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
+		Tags:                  TestStateFulSetScalingIdentifier.Tags,
 	},
 	TestSecConCapabilitiesIdentifier: {
 		Identifier:       TestSecConCapabilitiesIdentifier,
@@ -709,6 +713,7 @@ var Catalog = map[claim.Identifier]TestCaseDescription{
 			- IPC_LOCK
 `),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
+		Tags:                  TestSecConCapabilitiesIdentifier.Tags,
 	},
 	// TestPodDeleteIdentifier: {
 	// 	Identifier:  TestPodDeleteIdentifier,
@@ -726,6 +731,7 @@ var Catalog = map[claim.Identifier]TestCaseDescription{
 		Description: formDescription(TestSecConNonRootUserIdentifier,
 			`Checks the security context runAsUser parameter in pods and containers to make sure it is not set to uid root(0)`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
+		Tags:                  TestSecConNonRootUserIdentifier.Tags,
 	},
 	TestSecConPrivilegeEscalation: {
 		Identifier:       TestSecConPrivilegeEscalation,
@@ -735,6 +741,7 @@ var Catalog = map[claim.Identifier]TestCaseDescription{
 		Description: formDescription(TestSecConPrivilegeEscalation,
 			`Checks if privileged escalation is enabled (AllowPrivilegeEscalation=true)`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
+		Tags:                  TestSecConPrivilegeEscalation.Tags,
 	},
 	TestContainerIsCertifiedIdentifier: {
 		Identifier:  TestContainerIsCertifiedIdentifier,
@@ -744,6 +751,7 @@ var Catalog = map[claim.Identifier]TestCaseDescription{
 			`Tests whether container images listed in the configuration file have passed the Red Hat Container Certification Program (CCP).`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.3.7",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestContainerIsCertifiedDigestIdentifier.Tags,
 	},
 	TestContainerHostPort: {
 		Identifier:  TestContainerHostPort,
@@ -753,6 +761,7 @@ var Catalog = map[claim.Identifier]TestCaseDescription{
 			`Verifies if containers define a hostPort.`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.3.6",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestContainerHostPort.Tags,
 	},
 	TestPodHostNetwork: {
 		Identifier:  TestPodHostNetwork,
@@ -762,6 +771,7 @@ var Catalog = map[claim.Identifier]TestCaseDescription{
 			`Verifies that the spec.HostNetwork parameter is set to false`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.3.6",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestPodHostNetwork.Tags,
 	},
 	TestPodHostPath: {
 		Identifier:  TestPodHostPath,
@@ -771,6 +781,7 @@ var Catalog = map[claim.Identifier]TestCaseDescription{
 			`Verifies that the spec.HostPath parameter is not set (not present)`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.3.6",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestPodHostPath.Tags,
 	},
 	TestPodHostIPC: {
 		Identifier:  TestPodHostIPC,
@@ -780,6 +791,7 @@ var Catalog = map[claim.Identifier]TestCaseDescription{
 			`Verifies that the spec.HostIpc parameter is set to false`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.3.6",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestPodHostIPC.Tags,
 	},
 	TestPodHostPID: {
 		Identifier:  TestPodHostPID,
@@ -789,6 +801,7 @@ var Catalog = map[claim.Identifier]TestCaseDescription{
 			`Verifies that the spec.HostPid parameter is set to false`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.3.6",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestPodHostIPC.Tags,
 	},
 	TestHugepagesNotManuallyManipulated: {
 		Identifier:  TestHugepagesNotManuallyManipulated,
@@ -802,6 +815,7 @@ for configured HugePages through inspection of /proc/meminfo.  The results are c
 they are the same.`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestHugepagesNotManuallyManipulated.Tags,
 	},
 	TestICMPv6ConnectivityIdentifier: {
 		Identifier:  TestICMPv6ConnectivityIdentifier,
@@ -812,6 +826,7 @@ they are the same.`),
 test case requires the Deployment of the debug daemonset.`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestICMPv6ConnectivityIdentifier.Tags,
 	},
 
 	TestICMPv4ConnectivityMultusIdentifier: {
@@ -823,6 +838,7 @@ test case requires the Deployment of the debug daemonset.`),
 test case requires the Deployment of the debug daemonset.`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestICMPv4ConnectivityIdentifier.Tags,
 	},
 
 	TestICMPv6ConnectivityMultusIdentifier: {
@@ -834,6 +850,7 @@ test case requires the Deployment of the debug daemonset.`),
 test case requires the Deployment of the debug daemonset.`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestICMPv6ConnectivityIdentifier.Tags,
 	},
 
 	TestServiceDualStackIdentifier: {
@@ -845,6 +862,7 @@ test case requires the Deployment of the debug daemonset.`),
 test case requires the deployment of the debug daemonset.`),
 		BestPracticeReference: bestPracticeDocV1dot4URL + " Section 3.5.7",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestServiceDualStackIdentifier.Tags,
 	},
 
 	TestNFTablesIdentifier: {
@@ -855,6 +873,7 @@ test case requires the deployment of the debug daemonset.`),
 			`Checks that the output of "nft list ruleset" is empty, e.g. there is no nftables configuration on any CNF containers.`),
 		BestPracticeReference: bestPracticeDocV1dot4URL + " Section 4.6.23",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestNFTablesIdentifier.Tags,
 	},
 
 	TestIPTablesIdentifier: {
@@ -865,6 +884,7 @@ test case requires the deployment of the debug daemonset.`),
 			`Checks that the output of "iptables-save" is empty, e.g. there is no iptables configuration on any CNF containers.`),
 		BestPracticeReference: bestPracticeDocV1dot4URL + " Section 4.6.23",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestIPTablesIdentifier.Tags,
 	},
 
 	TestNamespaceBestPracticesIdentifier: {
@@ -877,6 +897,7 @@ the following conditions: (1) It was declared in the yaml config file under the 
 tag. (2) It doesn't have any of the following prefixes: default, openshift-, istio- and aspenmesh-`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2, 16.3.8 and 16.3.9",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestNamespaceBestPracticesIdentifier.Tags,
 	},
 
 	TestNonTaintedNodeKernelsIdentifier: {
@@ -889,6 +910,7 @@ to support Highly Available CNFs, since when a CNF is re-instantiated on a backu
 the same hacks.'`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2.14",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestNonTaintedNodeKernelsIdentifier.Tags,
 	},
 
 	TestOperatorInstallStatusSucceededIdentifier: {
@@ -899,6 +921,7 @@ the same hacks.'`),
 			`Ensures that the target CNF operators report "Succeeded" as their installation status.`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2.12 and 5.3.3",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestOperatorInstallStatusSucceededIdentifier.Tags,
 	},
 
 	TestOperatorNoPrivileges: {
@@ -910,6 +933,7 @@ the same hacks.'`),
 with no resourceNames under its rules.`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2.12 and 5.3.3",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestOperatorNoPrivileges.Tags,
 	},
 
 	TestOperatorIsCertifiedIdentifier: {
@@ -920,6 +944,7 @@ with no resourceNames under its rules.`),
 			`Tests whether CNF Operators listed in the configuration file have passed the Red Hat Operator Certification Program (OCP).`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2.12 and 5.3.3",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestOperatorIsCertifiedIdentifier.Tags,
 	},
 
 	TestHelmIsCertifiedIdentifier: {
@@ -930,6 +955,7 @@ with no resourceNames under its rules.`),
 			`Tests whether helm charts listed in the cluster passed the Red Hat Helm Certification Program.`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2.12 and 5.3.3",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestHelmIsCertifiedIdentifier.Tags,
 	},
 
 	TestOperatorIsInstalledViaOLMIdentifier: {
@@ -940,6 +966,7 @@ with no resourceNames under its rules.`),
 			`Tests whether a CNF Operator is installed via OLM.`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2.12 and 5.3.3",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestOperatorIsInstalledViaOLMIdentifier.Tags,
 	},
 
 	TestPodNodeSelectorAndAffinityBestPractices: {
@@ -951,6 +978,7 @@ with no resourceNames under its rules.`),
 instantiation on any underlying Node.`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestPodNodeSelectorAndAffinityBestPractices.Tags,
 	},
 
 	TestPodHighAvailabilityBestPractices: {
@@ -961,6 +989,7 @@ instantiation on any underlying Node.`),
 			`Ensures that CNF Pods specify podAntiAffinity rules and replica value is set to more than 1.`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestPodHighAvailabilityBestPractices.Tags,
 	},
 
 	TestPodClusterRoleBindingsBestPracticesIdentifier: {
@@ -971,6 +1000,7 @@ instantiation on any underlying Node.`),
 			`Tests that a Pod does not specify ClusterRoleBindings.`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2.10 and 5.3.6",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestPodClusterRoleBindingsBestPracticesIdentifier.Tags,
 	},
 
 	TestPodDeploymentBestPracticesIdentifier: {
@@ -981,6 +1011,7 @@ instantiation on any underlying Node.`),
 			`Tests that CNF Pod(s) are deployed as part of a ReplicaSet(s)/StatefulSet(s).`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.3.3 and 5.3.8",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestPodDeploymentBestPracticesIdentifier.Tags,
 	},
 	TestImagePullPolicyIdentifier: {
 		Identifier:  TestImagePullPolicyIdentifier,
@@ -990,6 +1021,7 @@ instantiation on any underlying Node.`),
 			`Ensure that the containers under test are using IfNotPresent as Image Pull Policy..`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + "  Section 12.6",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestImagePullPolicyIdentifier.Tags,
 	},
 
 	TestPodRoleBindingsBestPracticesIdentifier: {
@@ -1000,6 +1032,7 @@ instantiation on any underlying Node.`),
 			`Ensures that a CNF does not utilize RoleBinding(s) in a non-CNF Namespace.`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.3.3 and 5.3.5",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestPodRoleBindingsBestPracticesIdentifier.Tags,
 	},
 
 	TestPodServiceAccountBestPracticesIdentifier: {
@@ -1010,6 +1043,7 @@ instantiation on any underlying Node.`),
 			`Tests that each CNF Pod utilizes a valid Service Account.`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2.3 and 5.2.7",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestPodServiceAccountBestPracticesIdentifier.Tags,
 	},
 
 	TestServicesDoNotUseNodeportsIdentifier: {
@@ -1020,6 +1054,7 @@ instantiation on any underlying Node.`),
 			`Tests that each CNF Service does not utilize NodePort(s).`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.3.1",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestServicesDoNotUseNodeportsIdentifier.Tags,
 	},
 
 	TestUnalteredBaseImageIdentifier: {
@@ -1041,6 +1076,7 @@ that there are no changes to the following directories:
 10) /usr/lib64`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.1.4",
 		ExceptionProcess:      UnalteredBaseImageExceptionProcess,
+		Tags:                  TestUnalteredBaseImageIdentifier.Tags,
 	},
 
 	TestUnalteredStartupBootParamsIdentifier: {
@@ -1051,6 +1087,7 @@ that there are no changes to the following directories:
 			`Tests that boot parameters are set through the MachineConfigOperator, and not set manually on the Node.`),
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2.13 and 5.2.14",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestUnalteredStartupBootParamsIdentifier.Tags,
 	},
 	TestShutdownIdentifier: {
 		Identifier: TestShutdownIdentifier,
@@ -1060,6 +1097,7 @@ that there are no changes to the following directories:
 		Remediation:           ShutdownRemediation,
 		ExceptionProcess:      ShutdownExceptionProcess,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.1.3, 12.2 and 12.5",
+		Tags:                  TestShutdownIdentifier.Tags,
 	},
 	TestPodRecreationIdentifier: {
 		Identifier: TestPodRecreationIdentifier,
@@ -1072,6 +1110,7 @@ that there are no changes to the following directories:
 		Remediation:           PodRecreationRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestPodRecreationIdentifier.Tags,
 	},
 	TestSysctlConfigsIdentifier: {
 		Identifier: TestSysctlConfigsIdentifier,
@@ -1083,6 +1122,7 @@ that there are no changes to the following directories:
 		Remediation:           SysctlConfigsRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestSysctlConfigsIdentifier.Tags,
 	},
 	TestServiceMeshIdentifier: {
 		Identifier: TestServiceMeshIdentifier,
@@ -1092,6 +1132,7 @@ that there are no changes to the following directories:
 		Remediation:           ServiceMeshRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestServiceMeshIdentifier.Tags,
 	},
 	TestScalingIdentifier: {
 		Identifier: TestScalingIdentifier,
@@ -1103,6 +1144,7 @@ that there are no changes to the following directories:
 		Remediation:           ScalingRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestScalingIdentifier.Tags,
 	},
 	TestIsRedHatReleaseIdentifier: {
 		Identifier: TestIsRedHatReleaseIdentifier,
@@ -1112,6 +1154,7 @@ that there are no changes to the following directories:
 		Remediation:           IsRedHatReleaseRemediation,
 		ExceptionProcess:      IsRedHatReleaseExceptionProcess,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
+		Tags:                  TestIsRedHatReleaseIdentifier.Tags,
 	},
 	TestIsSELinuxEnforcingIdentifier: {
 		Identifier: TestIsSELinuxEnforcingIdentifier,
@@ -1121,6 +1164,7 @@ that there are no changes to the following directories:
 		Remediation:           IsSELinuxEnforcingRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 10.3 Pod Security",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestIsSELinuxEnforcingIdentifier.Tags,
 	},
 	TestUndeclaredContainerPortsUsage: {
 		Identifier: TestUndeclaredContainerPortsUsage,
@@ -1130,6 +1174,7 @@ that there are no changes to the following directories:
 		Remediation:           UndeclaredContainerPortsRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 16.3.1.1",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestUndeclaredContainerPortsUsage.Tags,
 	},
 	TestOCPReservedPortsUsage: {
 		Identifier: TestOCPReservedPortsUsage,
@@ -1139,6 +1184,7 @@ that there are no changes to the following directories:
 		Remediation:           OCPReservedPortsUsageRemediation,
 		BestPracticeReference: bestPracticeDocV1dot4URL + " Section 3.5.9",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestOCPReservedPortsUsage.Tags,
 	},
 	TestCrdsStatusSubresourceIdentifier: {
 		Identifier: TestCrdsStatusSubresourceIdentifier,
@@ -1148,6 +1194,7 @@ that there are no changes to the following directories:
 		Remediation:           CrdsStatusSubresourceRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestCrdsStatusSubresourceIdentifier.Tags,
 	},
 	TestLoggingIdentifier: {
 		Identifier: TestLoggingIdentifier,
@@ -1157,6 +1204,7 @@ that there are no changes to the following directories:
 		Remediation:           LoggingRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 10.1",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestLoggingIdentifier.Tags,
 	},
 	TestTerminationMessagePolicyIdentifier: {
 		Identifier: TestTerminationMessagePolicyIdentifier,
@@ -1166,6 +1214,7 @@ that there are no changes to the following directories:
 		Remediation:           TerminationMessagePolicyRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 12.1",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestTerminationMessagePolicyIdentifier.Tags,
 	},
 	TestPodAutomountServiceAccountIdentifier: {
 		Identifier: TestPodAutomountServiceAccountIdentifier,
@@ -1175,6 +1224,7 @@ that there are no changes to the following directories:
 		Remediation:           AutomountServiceTokenRemediation,
 		ExceptionProcess:      AutomountServiceTokenExceptionProcess,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 12.7",
+		Tags:                  TestPodAutomountServiceAccountIdentifier.Tags,
 	},
 	TestLivenessProbeIdentifier: {
 		Identifier:            TestLivenessProbeIdentifier,
@@ -1183,6 +1233,7 @@ that there are no changes to the following directories:
 		Remediation:           LivenessProbeRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2.16, 12.1 and 12.5",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestLivenessProbeIdentifier.Tags,
 	},
 	TestReadinessProbeIdentifier: {
 		Identifier:            TestReadinessProbeIdentifier,
@@ -1191,6 +1242,7 @@ that there are no changes to the following directories:
 		Remediation:           ReadinessProbeRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2.16, 12.1 and 12.5",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestReadinessProbeIdentifier.Tags,
 	},
 	TestStartupProbeIdentifier: {
 		Identifier:            TestStartupProbeIdentifier,
@@ -1199,6 +1251,7 @@ that there are no changes to the following directories:
 		Remediation:           StartupProbeRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 4.6.12", // TODO Change this to v1.4 when available
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestStartupProbeIdentifier.Tags,
 	},
 	TestOneProcessPerContainerIdentifier: {
 		Identifier:            TestOneProcessPerContainerIdentifier,
@@ -1207,6 +1260,7 @@ that there are no changes to the following directories:
 		Remediation:           OneProcessPerContainerRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 10.8.3",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestOneProcessPerContainerIdentifier.Tags,
 	},
 	TestSYSNiceRealtimeCapabilityIdentifier: {
 		Identifier:            TestSYSNiceRealtimeCapabilityIdentifier,
@@ -1215,6 +1269,7 @@ that there are no changes to the following directories:
 		Remediation:           SYSNiceRealtimeCapabilityRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 2.7.4",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestSYSNiceRealtimeCapabilityIdentifier.Tags,
 	},
 	TestSysPtraceCapabilityIdentifier: {
 		Identifier:            TestSysPtraceCapabilityIdentifier,
@@ -1223,6 +1278,7 @@ that there are no changes to the following directories:
 		Remediation:           SysPtraceCapabilityRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 2.7.5",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestSysPtraceCapabilityIdentifier.Tags,
 	},
 	TestPodRequestsAndLimitsIdentifier: {
 		Identifier:            TestPodRequestsAndLimitsIdentifier,
@@ -1231,6 +1287,7 @@ that there are no changes to the following directories:
 		Remediation:           RequestsAndLimitsRemediation,
 		BestPracticeReference: bestPracticeDocV1dot4URL + " Section 4.6.11",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestPodRequestsAndLimitsIdentifier.Tags,
 	},
 	TestPersistentVolumeReclaimPolicyIdentifier: {
 		Identifier:            TestPersistentVolumeReclaimPolicyIdentifier,
@@ -1239,6 +1296,7 @@ that there are no changes to the following directories:
 		Remediation:           PersistentVolumeReclaimPolicyRemediation,
 		BestPracticeReference: bestPracticeDocV1dot4URL + " Section 3.3.4",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestPersistentVolumeReclaimPolicyIdentifier.Tags,
 	},
 	TestContainersImageTag: {
 		Identifier:            TestContainersImageTag,
@@ -1247,6 +1305,7 @@ that there are no changes to the following directories:
 		Remediation:           ContainersImageTag,
 		BestPracticeReference: bestPracticeDocV1dot4URL + " Section 4.6.12",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestContainersImageTag.Tags,
 	},
 	TestNamespaceResourceQuotaIdentifier: {
 		Identifier:            TestNamespaceResourceQuotaIdentifier,
@@ -1255,6 +1314,7 @@ that there are no changes to the following directories:
 		Remediation:           NamespaceResourceQuotaRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 4.6.8", // TODO Change this to v1.4 when available
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestNamespaceResourceQuotaIdentifier.Tags,
 	},
 	TestPodDisruptionBudgetIdentifier: {
 		Identifier:            TestPodDisruptionBudgetIdentifier,
@@ -1263,6 +1323,7 @@ that there are no changes to the following directories:
 		Remediation:           PodDisruptionBudgetRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 4.6.20", // TODO Change this to v1.4 when available
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestPodDisruptionBudgetIdentifier.Tags,
 	},
 	TestPodTolerationBypassIdentifier: {
 		Identifier:            TestPodTolerationBypassIdentifier,
@@ -1271,6 +1332,7 @@ that there are no changes to the following directories:
 		Remediation:           PodTolerationBypassRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 10.6",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestPodTolerationBypassIdentifier.Tags,
 	},
 	TestNoSSHDaemonsAllowedIdentifier: {
 		Identifier:            TestNoSSHDaemonsAllowedIdentifier,
@@ -1279,6 +1341,7 @@ that there are no changes to the following directories:
 		Remediation:           NoSSHDaemonsAllowedRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 4.6.12", // TODO Change this to v1.4 when available
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestNoSSHDaemonsAllowedIdentifier.Tags,
 	},
 	TestCPUIsolationIdentifier: {
 		Identifier: TestCPUIsolationIdentifier,
@@ -1288,6 +1351,7 @@ that there are no changes to the following directories:
 		Remediation:           CPUIsolationRemediation,
 		BestPracticeReference: bestPracticeDocV1dot4URL + " Section 3.5.5",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestCPUIsolationIdentifier.Tags,
 	},
 	TestContainerPortNameFormat: {
 		Identifier:            TestContainerPortNameFormat,
@@ -1296,5 +1360,6 @@ that there are no changes to the following directories:
 		Remediation:           ContainerPortNameFormatRemediation,
 		BestPracticeReference: bestPracticeDocV1dot4URL + " Section 4.6.20",
 		ExceptionProcess:      NoDocumentedProcess,
+		Tags:                  TestContainerPortNameFormat.Tags,
 	},
 }

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -58,6 +58,9 @@ type TestCaseDescription struct {
 
 	// ExceptionProcess will show any possible exception processes documented for partners to follow.
 	ExceptionProcess string `json:"exceptionProcess,omitempty" yaml:"exceptionProcess,omitempty"`
+
+	// Tags will show all of the ginkgo tags that the test case applies to
+	Tags string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 func init() {
@@ -86,6 +89,7 @@ func AddCatalogEntry(testID, suiteName, description, remediation, testType, exce
 	aTCDescription.Remediation = remediation
 	aTCDescription.ExceptionProcess = exception
 	aTCDescription.BestPracticeReference = reference
+	aTCDescription.Tags = strings.Join(tags, ",")
 
 	Catalog[aID] = aTCDescription
 


### PR DESCRIPTION
Resolves: #551 

Any catalog entry generated by the `AddCatalogEntry` helper function will now include its tags in the catalog.  This will be the initial commit and we will have to have a subsequent commit that translates all of the existing catalog entries to use the helper function.