### PR TITLE
Switch clientsholder to user constructor style

### DIFF
--- a/cnf-certification-test/accesscontrol/pidshelper_test.go
+++ b/cnf-certification-test/accesscontrol/pidshelper_test.go
@@ -86,11 +86,8 @@ func TestGetNbOfProcessesInPidNamespace(t *testing.T) {
 				return tc.execOutStr, tc.execErrStr, tc.execErr
 			},
 		}
-		result, err := getNbOfProcessesInPidNamespace(clientsholder.Context{
-			Namespace:     "testNamespace",
-			Podname:       "testPod",
-			Containername: "containerName",
-		}, tc.testPID, ch)
+
+		result, err := getNbOfProcessesInPidNamespace(clientsholder.NewContext("testNamespace", "testPod", "containerName"), tc.testPID, ch)
 
 		// assertions
 		assert.Equal(t, tc.expectedResult, result)

--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -445,12 +445,7 @@ func TestOneProcessPerContainer(env *provider.TestEnvironment) {
 		if debugPod == nil {
 			ginkgo.Fail(fmt.Sprintf("Debug pod not found on Node: %s", cut.NodeName))
 		}
-		ocpContext := clientsholder.Context{
-			Namespace:     debugPod.Namespace,
-			Podname:       debugPod.Name,
-			Containername: debugPod.Spec.Containers[0].Name,
-		}
-
+		ocpContext := clientsholder.NewContext(debugPod.Namespace, debugPod.Name, debugPod.Spec.Containers[0].Name)
 		pid, err := crclient.GetPidFromContainer(cut, ocpContext)
 		if err != nil {
 			tnf.ClaimFilePrintf("Could not get PID for: %s, error: %s", cut, err)
@@ -568,8 +563,7 @@ func TestNoSSHDaemonsAllowed(env *provider.TestEnvironment) {
 	r := regexp.MustCompile(sshDaemonProcessName)
 
 	for _, cut := range env.Containers {
-		ctx := clientsholder.Context{Namespace: cut.Namespace, Podname: cut.Podname, Containername: cut.Name}
-		stdout, stderr, err := o.ExecCommandContainer(ctx, listProcessesCmd)
+		stdout, stderr, err := o.ExecCommandContainer(clientsholder.NewContext(cut.Namespace, cut.Podname, cut.Name), listProcessesCmd)
 		if err != nil || stderr != "" {
 			tnf.ClaimFilePrintf("Could not list processes on: %s, error: %s", cut, err)
 			errorContainers = append(errorContainers, cut.String())

--- a/cnf-certification-test/platform/bootparams/bootparams.go
+++ b/cnf-certification-test/platform/bootparams/bootparams.go
@@ -75,9 +75,7 @@ func GetMcKernelArguments(env *provider.TestEnvironment, nodeName string) (aMap 
 
 func getGrubKernelArgs(env *provider.TestEnvironment, nodeName string) (aMap map[string]string, er error) {
 	o := clientsholder.GetClientsHolder()
-	ctx := clientsholder.Context{Namespace: env.DebugPods[nodeName].Namespace,
-		Podname:       env.DebugPods[nodeName].Name,
-		Containername: env.DebugPods[nodeName].Spec.Containers[0].Name}
+	ctx := clientsholder.NewContext(env.DebugPods[nodeName].Namespace, env.DebugPods[nodeName].Name, env.DebugPods[nodeName].Spec.Containers[0].Name)
 	bootConfig, errStr, err := o.ExecCommandContainer(ctx, grubKernelArgsCommand)
 	if err != nil || errStr != "" {
 		return aMap, fmt.Errorf("cannot exucute %s on debug pod %s, err=%s, stderr=%s", grubKernelArgsCommand, env.DebugPods[nodeName], err, errStr)
@@ -98,9 +96,7 @@ func getGrubKernelArgs(env *provider.TestEnvironment, nodeName string) (aMap map
 
 func getCurrentKernelCmdlineArgs(cut *provider.Container) (aMap map[string]string, err error) {
 	o := clientsholder.GetClientsHolder()
-	ctx := clientsholder.Context{Namespace: cut.Namespace,
-		Podname:       cut.Podname,
-		Containername: cut.Name}
+	ctx := clientsholder.NewContext(cut.Namespace, cut.Podname, cut.Name)
 	currnetKernelCmdlineArgs, errStr, err := o.ExecCommandContainer(ctx, kernelArgscommand)
 	if err != nil || errStr != "" {
 		return aMap, fmt.Errorf("cannot execute %s on container %s, err=%s, stderr=%s", grubKernelArgsCommand, cut, err, errStr)

--- a/cnf-certification-test/platform/hugepages/hugepages.go
+++ b/cnf-certification-test/platform/hugepages/hugepages.go
@@ -80,11 +80,7 @@ func NewTester(node *provider.Node, debugPod *corev1.Pod, commander clientsholde
 	tester := &Tester{
 		node:      node,
 		commander: commander,
-		context: clientsholder.Context{
-			Namespace:     debugPod.Namespace,
-			Podname:       debugPod.Name,
-			Containername: debugPod.Spec.Containers[0].Name,
-		},
+		context:   clientsholder.NewContext(debugPod.Namespace, debugPod.Name, debugPod.Spec.Containers[0].Name),
 	}
 
 	logrus.Infof("Getting node %s numa's hugepages values.", node.Data.Name)

--- a/cnf-certification-test/platform/isredhat/isredhat_test.go
+++ b/cnf-certification-test/platform/isredhat/isredhat_test.go
@@ -85,15 +85,12 @@ func TestTestContainerIsRedHatRelease(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		ctx := clientsholder.NewContext("testNamespace", "testPodName", "testContainer")
 		bit := NewBaseImageTester(&clientsholder.CommandMock{
 			// Mock out the return values from actually running the command.
 			ExecCommandContainerFunc: func(context clientsholder.Context, s string) (string, string, error) {
 				return tc.resultStdOut, tc.resultStdErr, tc.resultErr
-			}}, clientsholder.Context{
-			Namespace:     "testNamespace",
-			Podname:       "testPodName",
-			Containername: "testContainer",
-		})
+			}}, ctx)
 
 		result, err := bit.TestContainerIsRedHatRelease()
 		assert.Equal(t, tc.expectedErr, err)

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -185,11 +185,7 @@ func testContainersFsDiff(env *provider.TestEnvironment) {
 			ginkgo.Fail(fmt.Sprintf("Debug pod not found on Node: %s", cut.NodeName))
 		}
 		fsDiffTester := cnffsdiff.NewFsDiffTester(clientsholder.GetClientsHolder())
-		fsDiffTester.RunTest(clientsholder.Context{
-			Namespace:     debugPod.Namespace,
-			Podname:       debugPod.Name,
-			Containername: debugPod.Spec.Containers[0].Name,
-		}, cut.UID)
+		fsDiffTester.RunTest(clientsholder.NewContext(debugPod.Namespace, debugPod.Name, debugPod.Spec.Containers[0].Name), cut.UID)
 		switch fsDiffTester.GetResults() {
 		case testhelper.SUCCESS:
 			continue
@@ -221,11 +217,7 @@ func testTainted(env *provider.TestEnvironment, testerFuncs nodetainted.TaintedF
 	// Loop through the debug pods that are tied to each node.
 	for _, dp := range env.DebugPods {
 		// Create OCP context to pass around
-		ocpContext := clientsholder.Context{
-			Namespace:     dp.Namespace,
-			Podname:       dp.Name,
-			Containername: dp.Spec.Containers[0].Name,
-		}
+		ocpContext := clientsholder.NewContext(dp.Namespace, dp.Name, dp.Spec.Containers[0].Name)
 
 		// Get the taint information from the node kernel
 		taintInfo, err := testerFuncs.GetKernelTaintInfo(ocpContext)
@@ -320,11 +312,7 @@ func testIsRedHatRelease(env *provider.TestEnvironment) {
 	failedContainers := []string{}
 	for _, cut := range env.Containers {
 		ginkgo.By(fmt.Sprintf("%s is checked for Red Hat version", cut))
-		baseImageTester := isredhat.NewBaseImageTester(clientsholder.GetClientsHolder(), clientsholder.Context{
-			Namespace:     cut.Namespace,
-			Podname:       cut.Podname,
-			Containername: cut.Name,
-		})
+		baseImageTester := isredhat.NewBaseImageTester(clientsholder.GetClientsHolder(), clientsholder.NewContext(cut.Namespace, cut.Podname, cut.Name))
 
 		result, err := baseImageTester.TestContainerIsRedHatRelease()
 		if err != nil {
@@ -351,7 +339,7 @@ func testIsSELinuxEnforcing(env *provider.TestEnvironment) {
 	nodesFailed := 0
 	nodesError := 0
 	for _, debugPod := range env.DebugPods {
-		ctx := clientsholder.Context{Namespace: debugPod.Namespace, Podname: debugPod.Name, Containername: debugPod.Spec.Containers[0].Name}
+		ctx := clientsholder.NewContext(debugPod.Namespace, debugPod.Name, debugPod.Spec.Containers[0].Name)
 		outStr, errStr, err := o.ExecCommandContainer(ctx, getenforceCommand)
 		if err != nil || errStr != "" {
 			logrus.Errorf("Failed to execute command %s in debug %s, errStr: %s, err: %s", getenforceCommand, debugPod.String(), errStr, err)

--- a/cnf-certification-test/platform/sysctlconfig/sysctlconfig.go
+++ b/cnf-certification-test/platform/sysctlconfig/sysctlconfig.go
@@ -52,10 +52,7 @@ func GetSysctlSettings(env *provider.TestEnvironment, nodeName string) (map[stri
 	)
 
 	o := clientsholder.GetClientsHolder()
-	ctx := clientsholder.Context{
-		Namespace:     env.DebugPods[nodeName].Namespace,
-		Podname:       env.DebugPods[nodeName].Name,
-		Containername: env.DebugPods[nodeName].Spec.Containers[0].Name}
+	ctx := clientsholder.NewContext(env.DebugPods[nodeName].Namespace, env.DebugPods[nodeName].Name, env.DebugPods[nodeName].Spec.Containers[0].Name)
 
 	outStr, errStr, err := o.ExecCommandContainer(ctx, sysctlCommand)
 	if err != nil || errStr != "" {

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -193,3 +193,29 @@ func newClientsHolder(filenames ...string) (*ClientsHolder, error) { //nolint:fu
 	clientsHolder.ready = true
 	return &clientsHolder, nil
 }
+
+type Context struct {
+	namespace     string
+	podName       string
+	containerName string
+}
+
+func NewContext(namespace, podName, containerName string) Context {
+	return Context{
+		namespace:     namespace,
+		podName:       podName,
+		containerName: containerName,
+	}
+}
+
+func (c *Context) GetNamespace() string {
+	return c.namespace
+}
+
+func (c *Context) GetPodName() string {
+	return c.podName
+}
+
+func (c *Context) GetContainerName() string {
+	return c.containerName
+}

--- a/internal/clientsholder/command.go
+++ b/internal/clientsholder/command.go
@@ -23,15 +23,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/kubectl/pkg/scheme"
 )
-
-type Context struct {
-	Namespace     string
-	Podname       string
-	Containername string
-}
 
 //go:generate moq -out command_moq.go . Command
 type Command interface {
@@ -44,15 +38,15 @@ func (clientsholder *ClientsHolder) ExecCommandContainer(
 	commandStr := []string{"sh", "-c", command}
 	var buffOut bytes.Buffer
 	var buffErr bytes.Buffer
-	logrus.Trace(fmt.Sprintf("execute command on ns=%s, pod=%s container=%s, cmd: %s", ctx.Namespace, ctx.Podname, ctx.Containername, strings.Join(commandStr, " ")))
+	logrus.Trace(fmt.Sprintf("execute command on ns=%s, pod=%s container=%s, cmd: %s", ctx.GetNamespace(), ctx.GetPodName(), ctx.GetContainerName(), strings.Join(commandStr, " ")))
 	req := clientsholder.K8sClient.CoreV1().RESTClient().
 		Post().
-		Namespace(ctx.Namespace).
+		Namespace(ctx.GetNamespace()).
 		Resource("pods").
-		Name(ctx.Podname).
+		Name(ctx.GetPodName()).
 		SubResource("exec").
 		VersionedParams(&corev1.PodExecOptions{
-			Container: ctx.Containername,
+			Container: ctx.GetContainerName(),
 			Command:   commandStr,
 			Stdin:     false,
 			Stdout:    true,

--- a/internal/crclient/crclient.go
+++ b/internal/crclient/crclient.go
@@ -65,7 +65,7 @@ func ExecCommandContainerNSEnter(command string,
 		return "", "", err
 	}
 	o := clientsholder.GetClientsHolder()
-	ctx := clientsholder.Context{Namespace: debugPod.Namespace, Podname: debugPod.Name, Containername: debugPod.Spec.Containers[0].Name}
+	ctx := clientsholder.NewContext(debugPod.Namespace, debugPod.Name, debugPod.Spec.Containers[0].Name)
 
 	// Get the container PID to build the nsenter command
 	containerPid, err := GetPidFromContainer(aContainer, ctx)

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -59,7 +59,7 @@ func GetCniPlugins() (out map[string][]interface{}) {
 	o := clientsholder.GetClientsHolder()
 	out = make(map[string][]interface{})
 	for _, debugPod := range env.DebugPods {
-		ctx := clientsholder.Context{Namespace: debugPod.Namespace, Podname: debugPod.Name, Containername: debugPod.Spec.Containers[0].Name}
+		ctx := clientsholder.NewContext(debugPod.Namespace, debugPod.Name, debugPod.Spec.Containers[0].Name)
 		outStr, errStr, err := o.ExecCommandContainer(ctx, cniPluginsCommand)
 		if err != nil || errStr != "" {
 			logrus.Errorf("Failed to execute command %s in debug pod %s", cniPluginsCommand, debugPod.String())
@@ -107,7 +107,7 @@ func GetHwInfoAllNodes() (out map[string]NodeHwInfo) {
 
 // getHWJsonOutput performs a query via debug pod and returns the JSON blob
 func getHWJsonOutput(debugPod *corev1.Pod, o clientsholder.Command, cmd string) (out interface{}, err error) {
-	ctx := clientsholder.Context{Namespace: debugPod.Namespace, Podname: debugPod.Name, Containername: debugPod.Spec.Containers[0].Name}
+	ctx := clientsholder.NewContext(debugPod.Namespace, debugPod.Name, debugPod.Spec.Containers[0].Name)
 	outStr, errStr, err := o.ExecCommandContainer(ctx, cmd)
 	if err != nil || errStr != "" {
 		return out, fmt.Errorf("command %s failed with error err: %s , stderr: %s", cmd, err, errStr)
@@ -121,7 +121,7 @@ func getHWJsonOutput(debugPod *corev1.Pod, o clientsholder.Command, cmd string) 
 
 // getHWTextOutput performs a query via debug and returns plaintext lines
 func getHWTextOutput(debugPod *corev1.Pod, o clientsholder.Command, cmd string) (out []string, err error) {
-	ctx := clientsholder.Context{Namespace: debugPod.Namespace, Podname: debugPod.Name, Containername: debugPod.Spec.Containers[0].Name}
+	ctx := clientsholder.NewContext(debugPod.Namespace, debugPod.Name, debugPod.Spec.Containers[0].Name)
 	outStr, errStr, err := o.ExecCommandContainer(ctx, cmd)
 	if err != nil || errStr != "" {
 		return out, fmt.Errorf("command %s failed with error err: %s , stderr: %s", lspciCommand, err, errStr)


### PR DESCRIPTION
Further compartmentalize the clientsholder `Context` struct by using a more constructor-esque style with appropriate Getter functions.

Created a new `NewContext` func to help build clientsholder.Context objects.