### PR TITLE
Update Go to v1.19.2

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.19
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: 1.19.2
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go 1.19
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: 1.19.2
 
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"
@@ -92,7 +92,7 @@ jobs:
       - name: Set up Go 1.19
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: 1.19.2
 
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"
@@ -131,10 +131,10 @@ jobs:
       KUBECONFIG: '/home/runner/.kube/config'
 
     steps:
-      - name: Set up Go 1.19.1
+      - name: Set up Go 1.19.2
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: 1.19.2
 
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"

--- a/.github/workflows/update-certification.yml
+++ b/.github/workflows/update-certification.yml
@@ -16,10 +16,10 @@ jobs:
       SHELL: /bin/bash        
 
     steps:
-      - name: Set up Go 1.19.1
+      - name: Set up Go 1.19.2
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: 1.19.2
 
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN yum install -y gcc git jq make wget
 
 # Install Go binary
 ENV GO_DL_URL="https://golang.org/dl"
-ENV GO_BIN_TAR="go1.19.1.linux-amd64.tar.gz"
+ENV GO_BIN_TAR="go1.19.2.linux-amd64.tar.gz"
 ENV GO_BIN_URL_x86_64=${GO_DL_URL}/${GO_BIN_TAR}
 ENV GOPATH="/root/go"
 RUN if [[ "$(uname -m)" -eq "x86_64" ]] ; then \


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/xtuG5faxtaU

Security: Includes security fixes for archive/tar (CVE-2022-2879), net/http (CVE-2022-2880), and regexp (CVE-2022-41715).