### PR TITLE
Move some tests to their respective files

### DIFF
--- a/pkg/provider/deployments_test.go
+++ b/pkg/provider/deployments_test.go
@@ -103,3 +103,16 @@ func TestIsAffinityCompliantDeployments(t *testing.T) {
 		assert.Equal(t, tc.isCompliant, result)
 	}
 }
+
+func TestDeploymentToString(t *testing.T) {
+	dp := Deployment{
+		Deployment: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test1",
+				Namespace: "testNS",
+			},
+		},
+	}
+
+	assert.Equal(t, "deployment: test1 ns: testNS", dp.ToString())
+}

--- a/pkg/provider/pods_test.go
+++ b/pkg/provider/pods_test.go
@@ -154,3 +154,15 @@ func TestIsAffinityCompliantPods(t *testing.T) {
 		assert.Equal(t, tc.isCompliant, result)
 	}
 }
+
+func TestPodString(t *testing.T) {
+	p := Pod{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test1",
+				Namespace: "testNS",
+			},
+		},
+	}
+	assert.Equal(t, "pod: test1 ns: testNS", p.String())
+}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -789,32 +789,6 @@ func TestContainerStringFuncs(t *testing.T) {
 	}
 }
 
-func TestDeploymentToString(t *testing.T) {
-	dp := Deployment{
-		Deployment: &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test1",
-				Namespace: "testNS",
-			},
-		},
-	}
-
-	assert.Equal(t, "deployment: test1 ns: testNS", dp.ToString())
-}
-
-func TestStatefulsetToString(t *testing.T) {
-	ss := StatefulSet{
-		StatefulSet: &appsv1.StatefulSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test1",
-				Namespace: "testNS",
-			},
-		},
-	}
-
-	assert.Equal(t, "statefulset: test1 ns: testNS", ss.ToString())
-}
-
 func TestCsvToString(t *testing.T) {
 	assert.Equal(t, "operator csv: test1 ns: testNS", CsvToString(&olmv1Alpha.ClusterServiceVersion{
 		ObjectMeta: metav1.ObjectMeta{
@@ -822,18 +796,6 @@ func TestCsvToString(t *testing.T) {
 			Namespace: "testNS",
 		},
 	}))
-}
-
-func TestPodString(t *testing.T) {
-	p := Pod{
-		Pod: &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test1",
-				Namespace: "testNS",
-			},
-		},
-	}
-	assert.Equal(t, "pod: test1 ns: testNS", p.String())
 }
 
 func TestOperatorString(t *testing.T) {

--- a/pkg/provider/statefulsets_test.go
+++ b/pkg/provider/statefulsets_test.go
@@ -103,3 +103,16 @@ func TestIsAffinityCompliantStatefulSets(t *testing.T) {
 		assert.Equal(t, tc.isCompliant, result)
 	}
 }
+
+func TestStatefulsetToString(t *testing.T) {
+	ss := StatefulSet{
+		StatefulSet: &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test1",
+				Namespace: "testNS",
+			},
+		},
+	}
+
+	assert.Equal(t, "statefulset: test1 ns: testNS", ss.ToString())
+}


### PR DESCRIPTION
Found some stragglers when it comes to the deployment, pod, statefulset tests.