### PR TITLE
Added support for Red Hat kernel taints bits 27-31

### DIFF
--- a/cnf-certification-test/platform/nodetainted/nodetainted.go
+++ b/cnf-certification-test/platform/nodetainted/nodetainted.go
@@ -111,19 +111,19 @@ var kernelTaints = map[int]string{
 
 	// RedHat custom taints for RHEL/CoreOS
 	// https://access.redhat.com/solutions/40594
-	27: "Red Hat extension: Hardware for which support has been removed. / OMGZOMBIES easter egg.",
-	28: "Red Hat extension: Unsupported hardware. Refer to \"UNSUPPORTED HARDWARE DEVICE:\" kernel log entry for details.",
-	29: "Red Hat extension: Technology Preview code was loaded; cf. Technology Preview features support scope description. Refer to \"TECH PREVIEW:\" kernel log entry for details.",
-	30: "Red Hat extension: reserved taint bit 30",
-	31: "Red Hat extension: reserved taint bit 31",
+	27: "Red Hat extension: Hardware for which support has been removed. / OMGZOMBIES easter egg",
+	28: "Red Hat extension: Unsupported hardware. Refer to \"UNSUPPORTED HARDWARE DEVICE:\" kernel log entry for details",
+	29: "Red Hat extension: Technology Preview code was loaded; cf. Technology Preview features support scope description. Refer to \"TECH PREVIEW:\" kernel log entry for details",
+	30: "Red Hat extension: reserved",
+	31: "Red Hat extension: reserved",
 }
 
 func getTaintMsg(bit int) string {
 	if taintMsg, exists := kernelTaints[bit]; exists {
-		return taintMsg
+		return fmt.Sprintf("%s (tainted bit %d)", taintMsg, bit)
 	}
 
-	return fmt.Sprintf("reserved kernel taint bit %d", bit)
+	return fmt.Sprintf("reserved (tainted bit %d)", bit)
 }
 
 func DecodeKernelTaints(bitmap uint64) []string {

--- a/cnf-certification-test/platform/nodetainted/nodetainted.go
+++ b/cnf-certification-test/platform/nodetainted/nodetainted.go
@@ -87,42 +87,54 @@ func (nt *NodeTainted) ModuleInTree(moduleName string, ctx clientsholder.Context
 	return !strings.Contains(cmdOutput, "O")
 }
 
-func GetTaintedBitValues() []string {
-	return []string{"proprietary module was loaded",
-		"module was force loaded",
-		"kernel running on an out of specification system",
-		"module was force unloaded",
-		"processor reported a Machine Check Exception (MCE)",
-		"bad page referenced or some unexpected page flags",
-		"taint requested by userspace application",
-		"kernel died recently, i.e. there was an OOPS or BUG",
-		"ACPI table overridden by user",
-		"kernel issued warning",
-		"staging driver was loaded",
-		"workaround for bug in platform firmware applied",
-		"externally-built (“out-of-tree”) module was loaded",
-		"unsigned module was loaded",
-		"soft lockup occurred",
-		"kernel has been live patched",
-		"auxiliary taint, defined for and used by distros",
-		"kernel was built with the struct randomization plugin",
-	}
+var kernelTaints = map[int]string{
+	// Linux standard kernel taints
+	0:  "proprietary module was loaded",
+	1:  "module was force loaded",
+	2:  "kernel running on an out of specification system",
+	3:  "module was force unloaded",
+	4:  "processor reported a Machine Check Exception (MCE)",
+	5:  "bad page referenced or some unexpected page flags",
+	6:  "taint requested by userspace application",
+	7:  "kernel died recently, i.e. there was an OOPS or BUG",
+	8:  "ACPI table overridden by user",
+	9:  "kernel issued warning",
+	10: "staging driver was loaded",
+	11: "workaround for bug in platform firmware applied",
+	12: "externally-built (“out-of-tree”) module was loaded",
+	13: "unsigned module was loaded",
+	14: "soft lockup occurred",
+	15: "kernel has been live patched",
+	16: "auxiliary taint, defined for and used by distros",
+	17: "kernel was built with the struct randomization plugin",
+	18: "an in-kernel test has been run",
+
+	// RedHat custom taints for RHEL/CoreOS
+	// https://access.redhat.com/solutions/40594
+	27: "Red Hat extension: Hardware for which support has been removed. / OMGZOMBIES easter egg.",
+	28: "Red Hat extension: Unsupported hardware. Refer to \"UNSUPPORTED HARDWARE DEVICE:\" kernel log entry for details.",
+	29: "Red Hat extension: Technology Preview code was loaded; cf. Technology Preview features support scope description. Refer to \"TECH PREVIEW:\" kernel log entry for details.",
+	30: "Red Hat extension: reserved taint bit 30",
+	31: "Red Hat extension: reserved taint bit 31",
 }
 
-//nolint:gocritic
-func DecodeKernelTaints(bitmap uint64) (string, []string) {
-	values := GetTaintedBitValues()
-	var sb strings.Builder
-	individualTaints := []string{}
-	for i := 0; i < 32; i++ {
+func getTaintMsg(bit int) string {
+	if taintMsg, exists := kernelTaints[bit]; exists {
+		return taintMsg
+	}
+
+	return fmt.Sprintf("reserved kernel taint bit %d", bit)
+}
+
+func DecodeKernelTaints(bitmap uint64) []string {
+	taints := []string{}
+	for i := 0; i < 64; i++ {
 		bit := (bitmap >> i) & 1
 		if bit == 1 {
-			sb.WriteString(fmt.Sprintf("%s, ", values[i]))
-			// Storing the individual taint messages for extra parsing.
-			individualTaints = append(individualTaints, values[i])
+			taints = append(taints, getTaintMsg(i))
 		}
 	}
-	return sb.String(), individualTaints
+	return taints
 }
 
 func (nt *NodeTainted) GetOutOfTreeModules(modules []string, ctx clientsholder.Context) []string {

--- a/cnf-certification-test/platform/nodetainted/nodetainted_test.go
+++ b/cnf-certification-test/platform/nodetainted/nodetainted_test.go
@@ -78,49 +78,49 @@ func TestDecodeKernelTaints(t *testing.T) {
 		// Reserved taint bit 23
 		{
 			taintsBitMask:  1 << 23,
-			expectedTaints: []string{"reserved kernel taint bit 23"},
+			expectedTaints: []string{"reserved (tainted bit 23)"},
 		},
 
 		// Taint bit 0
 		{
 			taintsBitMask:  1 << 0,
-			expectedTaints: []string{"proprietary module was loaded"},
+			expectedTaints: []string{"proprietary module was loaded (tainted bit 0)"},
 		},
 
 		// Taint bit 11
 		{
 			taintsBitMask:  1 << 11,
-			expectedTaints: []string{"workaround for bug in platform firmware applied"},
+			expectedTaints: []string{"workaround for bug in platform firmware applied (tainted bit 11)"},
 		},
 
 		// Bit 18
 		{
 			taintsBitMask:  1 << 18,
-			expectedTaints: []string{"an in-kernel test has been run"},
+			expectedTaints: []string{"an in-kernel test has been run (tainted bit 18)"},
 		},
 
 		// Bits 0 and 18
 		{
 			taintsBitMask:  (1 << 0) | (1 << 18),
-			expectedTaints: []string{"proprietary module was loaded", "an in-kernel test has been run"},
+			expectedTaints: []string{"proprietary module was loaded (tainted bit 0)", "an in-kernel test has been run (tainted bit 18)"},
 		},
 
-		// Bits 1, 24 and 30
+		// Bits 0, 24 and 30
 		{
 			taintsBitMask:  (1 << 0) | (1 << 24) | (1 << 30),
-			expectedTaints: []string{"proprietary module was loaded", "reserved kernel taint bit 24", "Red Hat extension: reserved taint bit 30"},
+			expectedTaints: []string{"proprietary module was loaded (tainted bit 0)", "reserved (tainted bit 24)", "Red Hat extension: reserved (tainted bit 30)"},
 		},
 
 		// RH's bit 29
 		{
 			taintsBitMask:  1 << 29,
-			expectedTaints: []string{"Red Hat extension: Technology Preview code was loaded; cf. Technology Preview features support scope description. Refer to \"TECH PREVIEW:\" kernel log entry for details."},
+			expectedTaints: []string{"Red Hat extension: Technology Preview code was loaded; cf. Technology Preview features support scope description. Refer to \"TECH PREVIEW:\" kernel log entry for details (tainted bit 29)"},
 		},
 
 		// RH's reserved bit 31
 		{
 			taintsBitMask:  1 << 31,
-			expectedTaints: []string{"Red Hat extension: reserved taint bit 31"},
+			expectedTaints: []string{"Red Hat extension: reserved (tainted bit 31)"},
 		},
 	}
 

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -239,16 +239,16 @@ func testTainted(env *provider.TestEnvironment, testerFuncs nodetainted.TaintedF
 			errNodes = append(errNodes, dp.Name)
 			break
 		}
-		taintMsg, individualTaints := nodetainted.DecodeKernelTaints(taintedBitmap)
 
+		taints := nodetainted.DecodeKernelTaints(taintedBitmap)
 		// Count how many taints come from `module was loaded` taints versus `other`
 		logrus.Debug("Checking for 'module was loaded' taints")
-		logrus.Debug("individualTaints", individualTaints)
+		logrus.Debugf("Taints found: %v", taints)
 		moduleTaintsFound := false
 		otherTaintsFound := false
 
 		otherTaints := []string{}
-		for _, it := range individualTaints {
+		for _, it := range taints {
 			if strings.Contains(it, `module was loaded`) {
 				moduleTaintsFound = true
 			} else {
@@ -289,7 +289,7 @@ func testTainted(env *provider.TestEnvironment, testerFuncs nodetainted.TaintedF
 
 		// Only print the message if there is something to report failure or tainted node wise.
 		if len(taintedNodes) != 0 || len(errNodes) != 0 {
-			tnf.ClaimFilePrintf("Decoded tainted kernel causes (code=%d) for node %s : %s\n", taintedBitmap, dp.Name, taintMsg)
+			tnf.ClaimFilePrintf("Decoded tainted kernel causes (code=%d) for node %s : %s\n", taintedBitmap, dp.Name, strings.Join(taints, ","))
 		}
 	}
 


### PR DESCRIPTION
This test case was panicking in a 3-nodes cluster with OCP 4.10 due to bit 29 being set in one of the nodes.

```
  runtime error: index out of range [29] with length 18

  Full Stack Trace
    github.com/test-network-function/cnf-certification-test/cnf-certification-test/platform/nodetainted.DecodeKernelTaints(0x20000000)
```

Some RHEL/CoreOS kernels were/are upgraded to use bits 27-31 as Red Hat extension taint bits. See https://access.redhat.com/solutions/40594 for more information about this extensions on each RHEL version.

Also, I added the standard kernel taint bit 18 which was either left out by mistake or added to the linux kernel recently.

- Changed taint messages list from slice to map.
- Refactored DecodeKernelTaints func.
- Updated UT for DecodeKernelTaints.