### PR TITLE
Fixed UT for online certification checks.

### DIFF
--- a/cnf-certification-test/tnf_config.yml
+++ b/cnf-certification-test/tnf_config.yml
@@ -15,7 +15,7 @@ certifiedcontainerinfo:
   - name: rocketchat/rocketchat
     repository: registry.connect.redhat.com
     tag: 0.56.0-1
-    digest: sha256:c358eee360a1e7754c2d555ec5fba4e6a42f1ede2bc9dd9e59068dd287113b33
+    digest: sha256:03f7f2499233a302351821d6f78f0e813c3f749258184f4133144558097c57b0
 checkDiscoveredContainerCertificationStatus: false
 acceptedKernelTaints:
   - module: vboxsf

--- a/internal/api/onlinecheck/api_test.go
+++ b/internal/api/onlinecheck/api_test.go
@@ -30,11 +30,11 @@ func TestIsContainerCertified(t *testing.T) {
 	v = client.IsContainerCertified("registry.connect.redhat.com", "rocketchat/rocketchat", "0.56.0-1", "")
 	assert.Equal(t, true, v) // true
 
-	v = client.IsContainerCertified("registry.connect.redhat.com", "rocketchat/rocketchat", "0.56.0-1", "sha256:c358eee360a1e7754c2d555ec5fba4e6a42f1ede2bc9dd9e59068dd287113b33")
+	v = client.IsContainerCertified("registry.connect.redhat.com", "rocketchat/rocketchat", "0.56.0-1", "sha256:03f7f2499233a302351821d6f78f0e813c3f749258184f4133144558097c57b0")
 	assert.Equal(t, true, v) // true
 
 	// wrong tag, valid digest, should be true
-	v = client.IsContainerCertified("registry.connect.redhat.com", "rocketchat/rocketchat", "0.56.0-100", "sha256:c358eee360a1e7754c2d555ec5fba4e6a42f1ede2bc9dd9e59068dd287113b33")
+	v = client.IsContainerCertified("registry.connect.redhat.com", "rocketchat/rocketchat", "0.56.0-100", "sha256:03f7f2499233a302351821d6f78f0e813c3f749258184f4133144558097c57b0")
 	assert.Equal(t, true, v) // true
 
 	// wrong tag, everything else is valid


### PR DESCRIPTION
build-depends: https://github.com/dci-labs/dallas-pipelines/pull/551
build-depends: 26470

The RocketChat container digest was updated in RH's online catalog due to a migration of very old images with invalid schemas.