### PR TITLE
Remove redundant affinity/anti-affinity tests

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -363,20 +363,6 @@ Tags|common,online
 
 ### lifecycle
 
-#### affinity-required-deployments
-
-Property|Description
----|---
-Test Case Name|affinity-required-deployments
-Test Case Label|lifecycle-affinity-required-deployments
-Unique ID|http://test-network-function.com/testcases/lifecycle/affinity-required-deployments
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/lifecycle/affinity-required-deployments Checks that affinity rules are in place if AffinityRequired: 'true' labels are set on Deployments.
-Result Type|informative
-Suggested Remediation|If a pod/statefulset/deployment is required to use affinity rules, please add AffinityRequired: 'true' as a label
-Best Practice Reference|https://TODO Section 4.6.24
-Exception Process|There is no documented exception process for this.
-Tags|extended
 #### affinity-required-pods
 
 Property|Description
@@ -386,20 +372,6 @@ Test Case Label|lifecycle-affinity-required-pods
 Unique ID|http://test-network-function.com/testcases/lifecycle/affinity-required-pods
 Version|v1.0.0
 Description|http://test-network-function.com/testcases/lifecycle/affinity-required-pods Checks that affinity rules are in place if AffinityRequired: 'true' labels are set on Pods.
-Result Type|informative
-Suggested Remediation|If a pod/statefulset/deployment is required to use affinity rules, please add AffinityRequired: 'true' as a label
-Best Practice Reference|https://TODO Section 4.6.24
-Exception Process|There is no documented exception process for this.
-Tags|extended
-#### affinity-required-statefulsets
-
-Property|Description
----|---
-Test Case Name|affinity-required-statefulsets
-Test Case Label|lifecycle-affinity-required-statefulsets
-Unique ID|http://test-network-function.com/testcases/lifecycle/affinity-required-statefulsets
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/lifecycle/affinity-required-statefulsets Checks that affinity rules are in place if AffinityRequired: 'true' labels are set on StatefulSets.
 Result Type|informative
 Suggested Remediation|If a pod/statefulset/deployment is required to use affinity rules, please add AffinityRequired: 'true' as a label
 Best Practice Reference|https://TODO Section 4.6.24

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The label test-network-function.com/skip_connectivity_tests excludes pods from a
 The label test-network-function.com/skip_multus_connectivity_tests excludes pods from multus connectivity tests. Tests on default interface are still done. The label value is not important, only its presence.
 
 ### AffinityRequired
-For CNF workloads that require pods to use Pod or Node Affinity rules, the label `AffinityRequired: true` must be included on either the Deployment, StatefulSet, or Pod YAML.  This will prevent any tests for anti-affinity to fail as well as test your workloads for affinity rules that support your CNF's use-case.
+For CNF workloads that require pods to use Pod or Node Affinity rules, the label `AffinityRequired: true` must be included on the Pod YAML.  This will prevent any tests for anti-affinity to fail as well as test your workloads for affinity rules that support your CNF's use-case.
 
 ### certifiedcontainerinfo
 

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -104,8 +104,6 @@ var (
 	TestPodHugePages2M                       claim.Identifier
 	TestReservedExtendedPartnerPorts         claim.Identifier
 	TestAffinityRequiredPods                 claim.Identifier
-	TestAffinityRequiredDeployments          claim.Identifier
-	TestAffinityRequiredStatefulSets         claim.Identifier
 	TestStartupIdentifier                    claim.Identifier
 	TestShutdownIdentifier                   claim.Identifier
 )
@@ -186,28 +184,6 @@ The label value is not important, only its presence.`,
 		"affinity-required-pods",
 		common.LifecycleTestKey,
 		`Checks that affinity rules are in place if AffinityRequired: 'true' labels are set on Pods.`,
-		AffinityRequiredRemediation,
-		InformativeResult,
-		NoDocumentedProcess,
-		VersionOne,
-		bestPracticeDocV1dot4URL+" Section 4.6.24",
-		TagExtended)
-
-	TestAffinityRequiredDeployments = AddCatalogEntry(
-		"affinity-required-deployments",
-		common.LifecycleTestKey,
-		`Checks that affinity rules are in place if AffinityRequired: 'true' labels are set on Deployments.`,
-		AffinityRequiredRemediation,
-		InformativeResult,
-		NoDocumentedProcess,
-		VersionOne,
-		bestPracticeDocV1dot4URL+" Section 4.6.24",
-		TagExtended)
-
-	TestAffinityRequiredStatefulSets = AddCatalogEntry(
-		"affinity-required-statefulsets",
-		common.LifecycleTestKey,
-		`Checks that affinity rules are in place if AffinityRequired: 'true' labels are set on StatefulSets.`,
 		AffinityRequiredRemediation,
 		InformativeResult,
 		NoDocumentedProcess,

--- a/pkg/provider/deployments.go
+++ b/pkg/provider/deployments.go
@@ -18,9 +18,7 @@ package provider
 
 import (
 	"fmt"
-	"strconv"
 
-	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/pkg/autodiscover"
 	appsv1 "k8s.io/api/apps/v1"
 	appv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
@@ -65,31 +63,6 @@ func (d *Deployment) ToString() string {
 		d.Name,
 		d.Namespace,
 	)
-}
-
-func (d *Deployment) AffinityRequired() bool {
-	if val, ok := d.Labels[AffinityRequiredKey]; ok {
-		result, err := strconv.ParseBool(val)
-		if err != nil {
-			logrus.Warnf("failure to parse bool %v", val)
-			return false
-		}
-		return result
-	}
-	return false
-}
-
-func (d *Deployment) IsAffinityCompliant() (bool, error) {
-	if d.Spec.Template.Spec.Affinity == nil {
-		return false, fmt.Errorf("%s has been found with an AffinityRequired flag but is missing corresponding affinity rules", d.String())
-	}
-	if d.Spec.Template.Spec.Affinity.PodAntiAffinity != nil {
-		return false, fmt.Errorf("%s has been found with an AffinityRequired flag but has anti-affinity rules", d.String())
-	}
-	if d.Spec.Template.Spec.Affinity.PodAffinity == nil && d.Spec.Template.Spec.Affinity.NodeAffinity == nil {
-		return false, fmt.Errorf("%s has been found with an AffinityRequired flag but is missing corresponding pod/node affinity rules", d.String())
-	}
-	return true, nil
 }
 
 func GetUpdatedDeployment(ac appv1client.AppsV1Interface, namespace, podName string) (*Deployment, error) {

--- a/pkg/provider/deployments_test.go
+++ b/pkg/provider/deployments_test.go
@@ -17,92 +17,12 @@
 package provider
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-//nolint:funlen
-func TestIsAffinityCompliantDeployments(t *testing.T) {
-	testCases := []struct {
-		testDeployment Deployment
-		resultErrStr   error
-		isCompliant    bool
-	}{
-		{ // Test Case #1 - Affinity is nil, AffinityRequired label is set, fail
-			testDeployment: Deployment{
-				Deployment: &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							AffinityRequiredKey: "true",
-						},
-					},
-					Spec: appsv1.DeploymentSpec{
-						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Affinity: nil,
-							},
-						},
-					},
-				},
-			},
-			resultErrStr: errors.New("has been found with an AffinityRequired flag but is missing corresponding affinity rules"),
-			isCompliant:  false,
-		},
-		{ // Test Case #2 - Affinity is not nil, but PodAffinity/NodeAffinity are also not set, fail
-			testDeployment: Deployment{
-				Deployment: &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							AffinityRequiredKey: "true",
-						},
-					},
-					Spec: appsv1.DeploymentSpec{
-						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Affinity: &corev1.Affinity{},
-							},
-						},
-					},
-				},
-			},
-			resultErrStr: errors.New("has been found with an AffinityRequired flag but is missing corresponding pod/node affinity rules"),
-			isCompliant:  false,
-		},
-		{ // Test Case #3 - Affinity is not nil, but anti-affinity rule is set which defeats the purpose of the Required flag
-			testDeployment: Deployment{
-				Deployment: &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							AffinityRequiredKey: "true",
-						},
-					},
-					Spec: appsv1.DeploymentSpec{
-						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Affinity: &corev1.Affinity{
-									PodAntiAffinity: &corev1.PodAntiAffinity{},
-								},
-							},
-						},
-					},
-				},
-			},
-			resultErrStr: errors.New("has been found with an AffinityRequired flag but has anti-affinity rules"),
-			isCompliant:  false,
-		},
-	}
-
-	for _, tc := range testCases {
-		result, testErr := tc.testDeployment.IsAffinityCompliant()
-		assert.Contains(t, testErr.Error(), tc.resultErrStr.Error())
-		assert.Equal(t, tc.isCompliant, result)
-	}
-}
 
 func TestDeploymentToString(t *testing.T) {
 	dp := Deployment{

--- a/pkg/provider/filters.go
+++ b/pkg/provider/filters.go
@@ -56,56 +56,6 @@ func (env *TestEnvironment) GetAffinityRequiredPods() []*Pod {
 	return filteredPods
 }
 
-func (env *TestEnvironment) GetAntiAffinityRequiredPods() []*Pod {
-	var filteredPods []*Pod
-	for _, p := range env.Pods {
-		if !p.AffinityRequired() {
-			filteredPods = append(filteredPods, p)
-		}
-	}
-	return filteredPods
-}
-
-func (env *TestEnvironment) GetAffinityRequiredDeployments() []*Deployment {
-	var filteredDeployments []*Deployment
-	for _, d := range env.Deployments {
-		if d.AffinityRequired() {
-			filteredDeployments = append(filteredDeployments, d)
-		}
-	}
-	return filteredDeployments
-}
-
-func (env *TestEnvironment) GetAntiAffinityRequiredDeployments() []*Deployment {
-	var filteredDeployments []*Deployment
-	for _, d := range env.Deployments {
-		if !d.AffinityRequired() {
-			filteredDeployments = append(filteredDeployments, d)
-		}
-	}
-	return filteredDeployments
-}
-
-func (env *TestEnvironment) GetAffinityRequiredStatefulSets() []*StatefulSet {
-	var filteredStatefulSets []*StatefulSet
-	for _, d := range env.StatefulSets {
-		if d.AffinityRequired() {
-			filteredStatefulSets = append(filteredStatefulSets, d)
-		}
-	}
-	return filteredStatefulSets
-}
-
-func (env *TestEnvironment) GetAntiAffinityRequiredStatefulSets() []*StatefulSet {
-	var filteredStatefulSets []*StatefulSet
-	for _, d := range env.StatefulSets {
-		if !d.AffinityRequired() {
-			filteredStatefulSets = append(filteredStatefulSets, d)
-		}
-	}
-	return filteredStatefulSets
-}
-
 func (env *TestEnvironment) GetHugepagesPods() []*Pod {
 	var filteredPods []*Pod
 	for _, p := range env.Pods {

--- a/pkg/provider/statefulsets.go
+++ b/pkg/provider/statefulsets.go
@@ -18,9 +18,7 @@ package provider
 
 import (
 	"fmt"
-	"strconv"
 
-	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/pkg/autodiscover"
 	appsv1 "k8s.io/api/apps/v1"
 	appv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
@@ -50,31 +48,6 @@ func (ss *StatefulSet) ToString() string {
 		ss.Name,
 		ss.Namespace,
 	)
-}
-
-func (ss *StatefulSet) AffinityRequired() bool {
-	if val, ok := ss.Labels[AffinityRequiredKey]; ok {
-		result, err := strconv.ParseBool(val)
-		if err != nil {
-			logrus.Warnf("failure to parse bool %v", val)
-			return false
-		}
-		return result
-	}
-	return false
-}
-
-func (ss *StatefulSet) IsAffinityCompliant() (bool, error) {
-	if ss.Spec.Template.Spec.Affinity == nil {
-		return false, fmt.Errorf("%s has been found with an AffinityRequired flag but is missing corresponding affinity rules", ss.String())
-	}
-	if ss.Spec.Template.Spec.Affinity.PodAntiAffinity != nil {
-		return false, fmt.Errorf("%s has been found with an AffinityRequired flag but has anti-affinity rules", ss.String())
-	}
-	if ss.Spec.Template.Spec.Affinity.PodAffinity == nil && ss.Spec.Template.Spec.Affinity.NodeAffinity == nil {
-		return false, fmt.Errorf("%s has been found with an AffinityRequired flag but is missing corresponding pod/node affinity rules", ss.String())
-	}
-	return true, nil
 }
 
 func GetUpdatedStatefulset(ac appv1client.AppsV1Interface, namespace, podName string) (*StatefulSet, error) {

--- a/pkg/provider/statefulsets_test.go
+++ b/pkg/provider/statefulsets_test.go
@@ -17,92 +17,12 @@
 package provider
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-//nolint:funlen
-func TestIsAffinityCompliantStatefulSets(t *testing.T) {
-	testCases := []struct {
-		testStatefulSet StatefulSet
-		resultErrStr    error
-		isCompliant     bool
-	}{
-		{ // Test Case #1 - Affinity is nil, AffinityRequired label is set, fail
-			testStatefulSet: StatefulSet{
-				StatefulSet: &appsv1.StatefulSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							AffinityRequiredKey: "true",
-						},
-					},
-					Spec: appsv1.StatefulSetSpec{
-						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Affinity: nil,
-							},
-						},
-					},
-				},
-			},
-			resultErrStr: errors.New("has been found with an AffinityRequired flag but is missing corresponding affinity rules"),
-			isCompliant:  false,
-		},
-		{ // Test Case #2 - Affinity is not nil, but PodAffinity/NodeAffinity are also not set, fail
-			testStatefulSet: StatefulSet{
-				StatefulSet: &appsv1.StatefulSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							AffinityRequiredKey: "true",
-						},
-					},
-					Spec: appsv1.StatefulSetSpec{
-						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Affinity: &corev1.Affinity{}, // not nil
-							},
-						},
-					},
-				},
-			},
-			resultErrStr: errors.New("has been found with an AffinityRequired flag but is missing corresponding pod/node affinity rules"),
-			isCompliant:  false,
-		},
-		{ // Test Case #3 - Affinity is not nil, but anti-affinity rule is set which defeats the purpose of the Required flag
-			testStatefulSet: StatefulSet{
-				StatefulSet: &appsv1.StatefulSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							AffinityRequiredKey: "true",
-						},
-					},
-					Spec: appsv1.StatefulSetSpec{
-						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Affinity: &corev1.Affinity{
-									PodAntiAffinity: &corev1.PodAntiAffinity{}, // anti-affinity set
-								},
-							},
-						},
-					},
-				},
-			},
-			resultErrStr: errors.New("has been found with an AffinityRequired flag but has anti-affinity rules"),
-			isCompliant:  false,
-		},
-	}
-
-	for _, tc := range testCases {
-		result, testErr := tc.testStatefulSet.IsAffinityCompliant()
-		assert.Contains(t, testErr.Error(), tc.resultErrStr.Error())
-		assert.Equal(t, tc.isCompliant, result)
-	}
-}
 
 func TestStatefulsetToString(t *testing.T) {
 	ss := StatefulSet{


### PR DESCRIPTION
Thanks to @shaior for pointing out these redundant tests.

Essentially what we were doing was duplicating tests when all we needed to look at was the Pod YAMLs.

For example, `st.Spec.Template.Spec.Affinity.PodAntiAffinity` was what we were looking for when it came to the statefulset affinitycompliant check.  This was going into the "Template" section which essentially became the Pod YAML.

Also, I added a skip to the `highAvailability` test to skip whenever we encounter a deployment/statefulset that contains a pod spec like:

```
// Skip any AffinityRequired pods
//nolint:goconst
if dp.Spec.Template.Labels["AffinityRequired"] == "true" {
	continue
}
```