### PR TITLE
Update GolangCI-Lint to v1.50.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ COMMON_GO_ARGS=-race
 GIT_COMMIT=$(shell script/create-version-files.sh)
 GIT_RELEASE=$(shell script/get-git-release.sh)
 GIT_PREVIOUS_RELEASE=$(shell script/get-git-previous-release.sh)
-GOLANGCI_VERSION=v1.50.0
+GOLANGCI_VERSION=v1.50.1
 LINKER_TNF_RELEASE_FLAGS=-X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitCommit=${GIT_COMMIT}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitRelease=${GIT_RELEASE}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitPreviousRelease=${GIT_PREVIOUS_RELEASE}

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ At a minimum, the following dependencies must be installed *prior* to running `m
 Dependency|Minimum Version
 ---|---
 [GoLang](https://golang.org/dl/)|1.18
-[golangci-lint](https://golangci-lint.run/usage/install/)|1.50.0
+[golangci-lint](https://golangci-lint.run/usage/install/)|1.50.1
 [jq](https://stedolan.github.io/jq/)|1.6
 [OpenShift Client](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/)|4.7
 

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -231,7 +231,7 @@ func testTainted(env *provider.TestEnvironment, testerFuncs nodetainted.TaintedF
 
 		var taintedBitmap uint64
 		nodeTaintsAccepted := true
-		taintedBitmap, err = strconv.ParseUint(taintInfo, 10, 64) //nolint:gomnd // base 10 and uint64
+		taintedBitmap, err = strconv.ParseUint(taintInfo, 10, 64) // base 10 and uint64
 
 		if err != nil {
 			logrus.Errorf("failed to parse uint with: %s", err)


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.50.1