### PR TITLE
Be consistent with import naming

### DIFF
--- a/cnf-certification-test/accesscontrol/resources/resources_test.go
+++ b/cnf-certification-test/accesscontrol/resources/resources_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -26,13 +26,13 @@ func TestHasRequestsAndLimitsSet(t *testing.T) {
 	}{
 		{ // Test Case #1 - Happy path, all resource are set
 			testContainer: &provider.Container{
-				Container: &v1.Container{
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
+				Container: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
 							"cpu":    resource.MustParse(validCPULimit),
 							"memory": resource.MustParse(validMemLimit),
 						},
-						Limits: v1.ResourceList{
+						Limits: corev1.ResourceList{
 							"cpu":    resource.MustParse(validCPULimit),
 							"memory": resource.MustParse(validMemLimit),
 						},
@@ -43,9 +43,9 @@ func TestHasRequestsAndLimitsSet(t *testing.T) {
 		},
 		{ // Test Case #2 - Failure due to missing limits
 			testContainer: &provider.Container{
-				Container: &v1.Container{
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
+				Container: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
 							"cpu":    resource.MustParse(validCPULimit),
 							"memory": resource.MustParse(validMemLimit),
 						},
@@ -57,13 +57,13 @@ func TestHasRequestsAndLimitsSet(t *testing.T) {
 		},
 		{ // Test Case #3 - Failure due to missing memory limit
 			testContainer: &provider.Container{
-				Container: &v1.Container{
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
+				Container: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
 							"cpu":    resource.MustParse(validCPULimit),
 							"memory": resource.MustParse(validMemLimit),
 						},
-						Limits: v1.ResourceList{
+						Limits: corev1.ResourceList{
 							"cpu": resource.MustParse(validCPULimit),
 						},
 					},
@@ -73,7 +73,7 @@ func TestHasRequestsAndLimitsSet(t *testing.T) {
 		},
 		{ // Test Case #4 - Failure due to missing resources in general
 			testContainer: &provider.Container{
-				Container: &v1.Container{},
+				Container: &corev1.Container{},
 			},
 			expectedResult: false,
 		},

--- a/cnf-certification-test/accesscontrol/tolerations/tolerations.go
+++ b/cnf-certification-test/accesscontrol/tolerations/tolerations.go
@@ -17,15 +17,15 @@
 package tolerations
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var (
-	nonCompliantTolerations  = []v1.TaintEffect{v1.TaintEffectNoExecute, v1.TaintEffectNoSchedule, v1.TaintEffectPreferNoSchedule}
+	nonCompliantTolerations  = []corev1.TaintEffect{corev1.TaintEffectNoExecute, corev1.TaintEffectNoSchedule, corev1.TaintEffectPreferNoSchedule}
 	tolerationSecondsDefault = 300
 )
 
-func IsTolerationModified(t v1.Toleration, qosClass v1.PodQOSClass) bool {
+func IsTolerationModified(t corev1.Toleration, qosClass corev1.PodQOSClass) bool {
 	const (
 		notReadyStr       = "node.kubernetes.io/not-ready"
 		unreachableStr    = "node.kubernetes.io/unreachable"
@@ -46,17 +46,17 @@ func IsTolerationModified(t v1.Toleration, qosClass v1.PodQOSClass) bool {
 	//   key: node.kubernetes.io/memory-pressure
 	//   operator: Exists
 
-	if t.Effect == v1.TaintEffectNoExecute {
+	if t.Effect == corev1.TaintEffectNoExecute {
 		if t.Key == notReadyStr || t.Key == unreachableStr &&
-			(t.Operator == v1.TolerationOpExists && t.TolerationSeconds != nil && *t.TolerationSeconds == int64(tolerationSecondsDefault)) {
+			(t.Operator == corev1.TolerationOpExists && t.TolerationSeconds != nil && *t.TolerationSeconds == int64(tolerationSecondsDefault)) {
 			return false
 		}
-	} else if t.Effect == v1.TaintEffectNoSchedule {
+	} else if t.Effect == corev1.TaintEffectNoSchedule {
 		// If toleration is NoSchedule - node.kubernetes.io/memory-pressure - Exists and the QoS class for
 		// the pod is different than BestEffort, it is also a default toleration added by k8s
 		if (t.Key == memoryPressureStr) &&
-			(t.Operator == v1.TolerationOpExists) &&
-			(qosClass != v1.PodQOSBestEffort) {
+			(t.Operator == corev1.TolerationOpExists) &&
+			(qosClass != corev1.PodQOSBestEffort) {
 			return false
 		}
 	}

--- a/cnf-certification-test/accesscontrol/tolerations/tolerations_test.go
+++ b/cnf-certification-test/accesscontrol/tolerations/tolerations_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 //nolint:funlen
@@ -30,79 +30,79 @@ func TestIsTolerationModified(t *testing.T) {
 	}
 
 	testCases := []struct {
-		testToleration v1.Toleration
+		testToleration corev1.Toleration
 		expectedOutput bool
-		qosClass       v1.PodQOSClass
+		qosClass       corev1.PodQOSClass
 	}{
 		{ // Test Case #1 - default not-ready toleration
-			testToleration: v1.Toleration{
+			testToleration: corev1.Toleration{
 				Key:               "node.kubernetes.io/not-ready",
-				Operator:          v1.TolerationOpExists,
-				Effect:            v1.TaintEffectNoExecute,
+				Operator:          corev1.TolerationOpExists,
+				Effect:            corev1.TaintEffectNoExecute,
 				TolerationSeconds: getInt64Pointer(300),
 			},
 			expectedOutput: false,
-			qosClass:       v1.PodQOSGuaranteed,
+			qosClass:       corev1.PodQOSGuaranteed,
 		},
 		{ // Test Case #2 - default unreachable toleration
-			testToleration: v1.Toleration{
+			testToleration: corev1.Toleration{
 				Key:               "node.kubernetes.io/unreachable",
-				Operator:          v1.TolerationOpExists,
-				Effect:            v1.TaintEffectNoExecute,
+				Operator:          corev1.TolerationOpExists,
+				Effect:            corev1.TaintEffectNoExecute,
 				TolerationSeconds: getInt64Pointer(300),
 			},
 			expectedOutput: false,
-			qosClass:       v1.PodQOSGuaranteed,
+			qosClass:       corev1.PodQOSGuaranteed,
 		},
 		{ // Test Case #3 - modified unreachable toleration
-			testToleration: v1.Toleration{
+			testToleration: corev1.Toleration{
 				Key:               "node.kubernetes.io/unreachable",
-				Operator:          v1.TolerationOpExists,
-				Effect:            v1.TaintEffectNoExecute,
+				Operator:          corev1.TolerationOpExists,
+				Effect:            corev1.TaintEffectNoExecute,
 				TolerationSeconds: getInt64Pointer(350), // modified from 300
 			},
 			expectedOutput: true,
-			qosClass:       v1.PodQOSGuaranteed,
+			qosClass:       corev1.PodQOSGuaranteed,
 		},
 		{ // Test Case #4 - modified unreachable toleration
-			testToleration: v1.Toleration{
+			testToleration: corev1.Toleration{
 				Key:               "node.kubernetes.io/unreachable",
-				Operator:          v1.TolerationOpEqual, // modified from exists
-				Effect:            v1.TaintEffectNoExecute,
+				Operator:          corev1.TolerationOpEqual, // modified from exists
+				Effect:            corev1.TaintEffectNoExecute,
 				TolerationSeconds: getInt64Pointer(300),
 			},
 			expectedOutput: true,
-			qosClass:       v1.PodQOSGuaranteed,
+			qosClass:       corev1.PodQOSGuaranteed,
 		},
 		{ // Test Case #5 - missing effect
-			testToleration: v1.Toleration{
+			testToleration: corev1.Toleration{
 				Key:      "node.kubernetes.io/unreachable",
-				Operator: v1.TolerationOpExists,
-				// Effect:            v1.TaintEffectNoExecute,
+				Operator: corev1.TolerationOpExists,
+				// Effect:            corev1.TaintEffectNoExecute,
 				TolerationSeconds: getInt64Pointer(300),
 			},
 			expectedOutput: false,
-			qosClass:       v1.PodQOSGuaranteed,
+			qosClass:       corev1.PodQOSGuaranteed,
 		},
 		{ // Test Case #6 - example from QE and DCI - this should pass only if qosClass is
 			// different than BestEffort, which is the case
-			testToleration: v1.Toleration{
+			testToleration: corev1.Toleration{
 				Key:      "node.kubernetes.io/memory-pressure",
-				Operator: v1.TolerationOpExists,
-				Effect:   v1.TaintEffectNoSchedule,
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
 			},
 			expectedOutput: false,
-			qosClass:       v1.PodQOSGuaranteed,
+			qosClass:       corev1.PodQOSGuaranteed,
 		},
 		{ // Test Case #7 - example from QE and DCI - however, if qosClass is BestEffort, it
 			// must be considered as a modified toleration
-			testToleration: v1.Toleration{
+			testToleration: corev1.Toleration{
 				Key:      "node.kubernetes.io/memory-pressure",
-				Operator: v1.TolerationOpExists,
-				Effect:   v1.TaintEffectNoSchedule,
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
 			},
 			expectedOutput: true,
-			qosClass:       v1.PodQOSBestEffort,
+			qosClass:       corev1.PodQOSBestEffort,
 		},
 	}
 

--- a/pkg/postmortem/postmortem.go
+++ b/pkg/postmortem/postmortem.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func Log() (out string) {
@@ -39,7 +39,7 @@ func Log() (out string) {
 	}
 	out += "\nPending Pods:\n"
 	for _, p := range env.AllPods {
-		if p.Status.Phase != v1.PodSucceeded && p.Status.Phase != v1.PodRunning {
+		if p.Status.Phase != corev1.PodSucceeded && p.Status.Phase != corev1.PodRunning {
 			out += p.String() + "\n"
 		}
 	}

--- a/pkg/provider/isolation_test.go
+++ b/pkg/provider/isolation_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -48,13 +48,13 @@ func TestCPUIsolation(t *testing.T) {
 			testPod: &Pod{
 				Containers: []*Container{
 					{
-						Container: &v1.Container{
-							Resources: v1.ResourceRequirements{
-								Requests: v1.ResourceList{
+						Container: &corev1.Container{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse(validCPULimit),
 									"memory": resource.MustParse(validMemLimit),
 								},
-								Limits: v1.ResourceList{
+								Limits: corev1.ResourceList{
 									"cpu":    resource.MustParse(validCPULimit),
 									"memory": resource.MustParse(validMemLimit),
 								},
@@ -62,8 +62,8 @@ func TestCPUIsolation(t *testing.T) {
 						},
 					},
 				},
-				Pod: &v1.Pod{
-					Spec: v1.PodSpec{
+				Pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
 						RuntimeClassName: &testClassName,
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -83,13 +83,13 @@ func TestCPUIsolation(t *testing.T) {
 			testPod: &Pod{
 				Containers: []*Container{
 					{
-						Container: &v1.Container{
-							Resources: v1.ResourceRequirements{
-								Requests: v1.ResourceList{
+						Container: &corev1.Container{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse(validCPULimit),
 									"memory": resource.MustParse(validMemLimit),
 								},
-								Limits: v1.ResourceList{
+								Limits: corev1.ResourceList{
 									"cpu":    resource.MustParse(invalidCPULimit2),
 									"memory": resource.MustParse(invalidMemLimit2),
 								},
@@ -97,8 +97,8 @@ func TestCPUIsolation(t *testing.T) {
 						},
 					},
 				},
-				Pod: &v1.Pod{
-					Spec: v1.PodSpec{
+				Pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
 						RuntimeClassName: &testClassName,
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -118,13 +118,13 @@ func TestCPUIsolation(t *testing.T) {
 			testPod: &Pod{
 				Containers: []*Container{
 					{
-						Container: &v1.Container{
-							Resources: v1.ResourceRequirements{
-								Requests: v1.ResourceList{
+						Container: &corev1.Container{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse(invalidCPULimit1),
 									"memory": resource.MustParse(invalidMemLimit1),
 								},
-								Limits: v1.ResourceList{
+								Limits: corev1.ResourceList{
 									"cpu":    resource.MustParse(invalidCPULimit1),
 									"memory": resource.MustParse(invalidMemLimit1),
 								},
@@ -132,8 +132,8 @@ func TestCPUIsolation(t *testing.T) {
 						},
 					},
 				},
-				Pod: &v1.Pod{
-					Spec: v1.PodSpec{
+				Pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
 						RuntimeClassName: &testClassName,
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -153,13 +153,13 @@ func TestCPUIsolation(t *testing.T) {
 			testPod: &Pod{
 				Containers: []*Container{
 					{
-						Container: &v1.Container{
-							Resources: v1.ResourceRequirements{
-								Requests: v1.ResourceList{
+						Container: &corev1.Container{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse(validCPULimit),
 									"memory": resource.MustParse(validMemLimit),
 								},
-								Limits: v1.ResourceList{
+								Limits: corev1.ResourceList{
 									"cpu":    resource.MustParse(validCPULimit),
 									"memory": resource.MustParse(validMemLimit),
 								},
@@ -167,8 +167,8 @@ func TestCPUIsolation(t *testing.T) {
 						},
 					},
 				},
-				Pod: &v1.Pod{
-					Spec: v1.PodSpec{
+				Pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
 						RuntimeClassName: nil,
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -188,13 +188,13 @@ func TestCPUIsolation(t *testing.T) {
 			testPod: &Pod{
 				Containers: []*Container{
 					{
-						Container: &v1.Container{
-							Resources: v1.ResourceRequirements{
-								Requests: v1.ResourceList{
+						Container: &corev1.Container{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse(validCPULimit),
 									"memory": resource.MustParse(validMemLimit),
 								},
-								Limits: v1.ResourceList{
+								Limits: corev1.ResourceList{
 									"cpu":    resource.MustParse(validCPULimit),
 									"memory": resource.MustParse(validMemLimit),
 								},
@@ -202,8 +202,8 @@ func TestCPUIsolation(t *testing.T) {
 						},
 					},
 				},
-				Pod: &v1.Pod{
-					Spec: v1.PodSpec{
+				Pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
 						RuntimeClassName: &testClassName,
 					},
 					ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Rename `v1` to `corev1` across some files to be more consistent.

Similar to: https://github.com/test-network-function/cnf-certification-test/pull/177