### PR TITLE
Switch GetContainer to NewContainer

### DIFF
--- a/pkg/provider/containers.go
+++ b/pkg/provider/containers.go
@@ -42,8 +42,10 @@ type Container struct {
 	ContainerImageIdentifier configuration.ContainerImageIdentifier
 }
 
-func GetContainer() *Container {
-	return &Container{}
+func NewContainer() *Container {
+	return &Container{
+		Container: &corev1.Container{}, // initialize the corev1.Container object
+	}
 }
 
 func (c *Container) GetUID() (string, error) {

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -158,8 +158,7 @@ func TestGetUID(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		c := GetContainer()
-		c.Container = &corev1.Container{}
+		c := NewContainer()
 		c.Status.ContainerID = tc.testCID
 		uid, err := c.GetUID()
 		assert.Equal(t, tc.expectedErr, err)


### PR DESCRIPTION
I was looking at the `containers.go` and I saw that we have a `GetContainer()` that just makes a new `Container` object.  And it was only used in one spot, so I'm not entirely sure that it needs to exist in the first place but I wanted to change the name to what it's actually doing.