### PR TITLE
Add 'entering suite' logging strings to match other suites

### DIFF
--- a/cnf-certification-test/certification/suite.go
+++ b/cnf-certification-test/certification/suite.go
@@ -41,6 +41,7 @@ const (
 )
 
 var _ = ginkgo.Describe(common.AffiliatedCertTestKey, func() {
+	logrus.Debugf("Entering %s suite", common.AffiliatedCertTestKey)
 	var env provider.TestEnvironment
 	ginkgo.BeforeEach(func() {
 		env = provider.GetTestEnvironment()

--- a/cnf-certification-test/chaostesting/suite.go
+++ b/cnf-certification-test/chaostesting/suite.go
@@ -23,6 +23,7 @@ const (
 )
 
 var _ = ginkgo.Describe(common.ChaosTesting, func() {
+	logrus.Debugf("Entering %s suite", common.ChaosTesting)
 	var env provider.TestEnvironment
 
 	ginkgo.BeforeEach(func() {

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -46,6 +46,7 @@ const (
 
 // All actual test code belongs below here.  Utilities belong above.
 var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
+	logrus.Debugf("Entering %s suite", common.LifecycleTestKey)
 	var env provider.TestEnvironment
 	ginkgo.BeforeEach(func() {
 		env = provider.GetTestEnvironment()

--- a/cnf-certification-test/manageability/suite.go
+++ b/cnf-certification-test/manageability/suite.go
@@ -31,6 +31,7 @@ import (
 
 // All actual test code belongs below here.  Utilities belong above.
 var _ = ginkgo.Describe(common.ManageabilityTestKey, func() {
+	logrus.Debugf("Entering %s suite", common.ManageabilityTestKey)
 	var env provider.TestEnvironment
 	ginkgo.BeforeEach(func() {
 		env = provider.GetTestEnvironment()

--- a/cnf-certification-test/observability/suite.go
+++ b/cnf-certification-test/observability/suite.go
@@ -37,6 +37,7 @@ import (
 
 // All actual test code belongs below here.  Utilities belong above.
 var _ = ginkgo.Describe(common.ObservabilityTestKey, func() {
+	logrus.Debugf("Entering %s suite", common.ObservabilityTestKey)
 	var env provider.TestEnvironment
 	ginkgo.BeforeEach(func() {
 		env = provider.GetTestEnvironment()

--- a/cnf-certification-test/operator/suite.go
+++ b/cnf-certification-test/operator/suite.go
@@ -37,6 +37,7 @@ import (
 
 // All actual test code belongs below here.  Utilities belong above.
 var _ = ginkgo.Describe(common.OperatorTestKey, func() {
+	logrus.Debugf("Entering %s suite", common.OperatorTestKey)
 	var env provider.TestEnvironment
 	ginkgo.BeforeEach(func() {
 		env = provider.GetTestEnvironment()


### PR DESCRIPTION
To match the networking suite that already has this [log line](https://github.com/test-network-function/cnf-certification-test/blob/main/cnf-certification-test/networking/suite.go#L52), I find this helpful to figure out which suite is running.