### PR TITLE
Add ability to skip scaling tests via config

### DIFF
--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -274,7 +274,7 @@ func testPodNodeSelectorAndAffinityBestPractices(env *provider.TestEnvironment) 
 	testhelper.AddTestResultLog("Non-compliant", badPods, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
-func nameInDeploymentSkipList(name, namespace string, list []configuration.SkipScalingTestDeploymentNamesInfo) bool {
+func nameInDeploymentSkipList(name, namespace string, list []configuration.SkipScalingTestDeploymentsInfo) bool {
 	for _, l := range list {
 		if name == l.Name && namespace == l.Namespace {
 			return true
@@ -283,7 +283,7 @@ func nameInDeploymentSkipList(name, namespace string, list []configuration.SkipS
 	return false
 }
 
-func nameInStatefulSetSkipList(name, namespace string, list []configuration.SkipScalingTestStatefulSetNamesInfo) bool {
+func nameInStatefulSetSkipList(name, namespace string, list []configuration.SkipScalingTestStatefulSetsInfo) bool {
 	for _, l := range list {
 		if name == l.Name && namespace == l.Namespace {
 			return true
@@ -299,8 +299,8 @@ func testDeploymentScaling(env *provider.TestEnvironment, timeout time.Duration)
 	failedDeployments := []string{}
 	for i := range env.Deployments {
 		// Skip deployment if it is allowed by config
-		if nameInDeploymentSkipList(env.Deployments[i].Name, env.Deployments[i].Namespace, env.Config.SkipScalingTestDeploymentNames) {
-			logrus.Debugf("%s is being skipped due to configuration setting", env.Deployments[i].String())
+		if nameInDeploymentSkipList(env.Deployments[i].Name, env.Deployments[i].Namespace, env.Config.SkipScalingTestDeployments) {
+			tnf.ClaimFilePrintf("%s is being skipped due to configuration setting", env.Deployments[i].String())
 			continue
 		}
 
@@ -336,8 +336,8 @@ func testStatefulSetScaling(env *provider.TestEnvironment, timeout time.Duration
 	failedStatefulSets := []string{}
 	for i := range env.StatefulSets {
 		// Skip statefulset if it is allowed by config
-		if nameInStatefulSetSkipList(env.StatefulSets[i].Name, env.StatefulSets[i].Namespace, env.Config.SkipScalingTestStatefulSetNames) {
-			logrus.Debugf("%s is being skipped due to configuration setting", env.StatefulSets[i].String())
+		if nameInStatefulSetSkipList(env.StatefulSets[i].Name, env.StatefulSets[i].Namespace, env.Config.SkipScalingTestStatefulSets) {
+			tnf.ClaimFilePrintf("%s is being skipped due to configuration setting", env.StatefulSets[i].String())
 			continue
 		}
 

--- a/cnf-certification-test/tnf_config.yml
+++ b/cnf-certification-test/tnf_config.yml
@@ -20,9 +20,11 @@ checkDiscoveredContainerCertificationStatus: false
 acceptedKernelTaints:
   - module: vboxsf
   - module: vboxguest
-skipScalingTestDeploymentNames:
+skipScalingTestDeployments:
   - name: deployment1
-skipScalingTestStatefulsetNames:
+    namespace: tnf
+skipScalingTestStatefulsets:
   - name: statefulset1
+    namespace: tnf
 skipHelmChartList:
   - name: coredns

--- a/cnf-certification-test/tnf_config.yml
+++ b/cnf-certification-test/tnf_config.yml
@@ -20,5 +20,9 @@ checkDiscoveredContainerCertificationStatus: false
 acceptedKernelTaints:
   - module: vboxsf
   - module: vboxguest
+skipScalingTestDeploymentNames:
+  - name: deployment1
+skipScalingTestStatefulsetNames:
+  - name: statefulset1
 skipHelmChartList:
   - name: coredns

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -48,16 +48,16 @@ type AcceptedKernelTaintsInfo struct {
 	Module string `yaml:"module" json:"module"`
 }
 
-// SkipScalingTestDeploymentNamesInfo contains a list of names of deployments that should be skipped by the scaling tests to prevent issues
-type SkipScalingTestDeploymentNamesInfo struct {
+// SkipScalingTestDeploymentsInfo contains a list of names of deployments that should be skipped by the scaling tests to prevent issues
+type SkipScalingTestDeploymentsInfo struct {
 
 	// Deployment name and namespace that can be skipped by the scaling tests
 	Name      string `yaml:"name" json:"name"`
 	Namespace string `yaml:"namespace" json:"namespace"`
 }
 
-// SkipScalingTestStatefulSetNamesInfo contains a list of names of statefulsets that should be skipped by the scaling tests to prevent issues
-type SkipScalingTestStatefulSetNamesInfo struct {
+// SkipScalingTestStatefulSetsInfo contains a list of names of statefulsets that should be skipped by the scaling tests to prevent issues
+type SkipScalingTestStatefulSetsInfo struct {
 
 	// StatefulSet name and namespace that can be skipped by the scaling tests
 	Name      string `yaml:"name" json:"name"`
@@ -113,9 +113,9 @@ type TestConfiguration struct {
 	AcceptedKernelTaints []AcceptedKernelTaintsInfo `yaml:"acceptedKernelTaints,omitempty" json:"acceptedKernelTaints,omitempty"`
 	SkipHelmChartList    []SkipHelmChartList        `yaml:"skipHelmChartList" json:"skipHelmChartList"`
 	// SkipScalingTestDeploymentNames
-	SkipScalingTestDeploymentNames []SkipScalingTestDeploymentNamesInfo `yaml:"skipScalingTestDeploymentNames,omitempty" json:"skipScalingTestDeploymentNames,omitempty"`
+	SkipScalingTestDeployments []SkipScalingTestDeploymentsInfo `yaml:"skipScalingTestDeployments,omitempty" json:"skipScalingTestDeployments,omitempty"`
 	// SkipScalingTestStatefulSetNames
-	SkipScalingTestStatefulSetNames []SkipScalingTestStatefulSetNamesInfo `yaml:"skipScalingTestStatefulSetNames,omitempty" json:"skipScalingTestStatefulSetNames,omitempty"`
+	SkipScalingTestStatefulSets []SkipScalingTestStatefulSetsInfo `yaml:"skipScalingTestStatefulSets,omitempty" json:"skipScalingTestStatefulSets,omitempty"`
 	// CheckDiscoveredContainerCertificationStatus controls whether the container certification test will validate images used by autodiscovered containers, in addition to the configured image list
 	CheckDiscoveredContainerCertificationStatus bool `yaml:"checkDiscoveredContainerCertificationStatus" json:"checkDiscoveredContainerCertificationStatus"`
 }

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -48,6 +48,22 @@ type AcceptedKernelTaintsInfo struct {
 	Module string `yaml:"module" json:"module"`
 }
 
+// SkipScalingTestDeploymentNamesInfo contains a list of names of deployments that should be skipped by the scaling tests to prevent issues
+type SkipScalingTestDeploymentNamesInfo struct {
+
+	// Deployment name and namespace that can be skipped by the scaling tests
+	Name      string `yaml:"name" json:"name"`
+	Namespace string `yaml:"namespace" json:"namespace"`
+}
+
+// SkipScalingTestStatefulSetNamesInfo contains a list of names of statefulsets that should be skipped by the scaling tests to prevent issues
+type SkipScalingTestStatefulSetNamesInfo struct {
+
+	// StatefulSet name and namespace that can be skipped by the scaling tests
+	Name      string `yaml:"name" json:"name"`
+	Namespace string `yaml:"namespace" json:"namespace"`
+}
+
 // Label ns/name/value for resource lookup
 type Label struct {
 	Prefix string `yaml:"prefix" json:"prefix"`
@@ -96,6 +112,10 @@ type TestConfiguration struct {
 	// AcceptedKernelTaints
 	AcceptedKernelTaints []AcceptedKernelTaintsInfo `yaml:"acceptedKernelTaints,omitempty" json:"acceptedKernelTaints,omitempty"`
 	SkipHelmChartList    []SkipHelmChartList        `yaml:"skipHelmChartList" json:"skipHelmChartList"`
+	// SkipScalingTestDeploymentNames
+	SkipScalingTestDeploymentNames []SkipScalingTestDeploymentNamesInfo `yaml:"skipScalingTestDeploymentNames,omitempty" json:"skipScalingTestDeploymentNames,omitempty"`
+	// SkipScalingTestStatefulSetNames
+	SkipScalingTestStatefulSetNames []SkipScalingTestStatefulSetNamesInfo `yaml:"skipScalingTestStatefulSetNames,omitempty" json:"skipScalingTestStatefulSetNames,omitempty"`
 	// CheckDiscoveredContainerCertificationStatus controls whether the container certification test will validate images used by autodiscovered containers, in addition to the configured image list
 	CheckDiscoveredContainerCertificationStatus bool `yaml:"checkDiscoveredContainerCertificationStatus" json:"checkDiscoveredContainerCertificationStatus"`
 }

--- a/pkg/configuration/testdata/tnf_test_config.yml
+++ b/pkg/configuration/testdata/tnf_test_config.yml
@@ -20,3 +20,7 @@ certifiedoperatorinfo:
 acceptedKernelTaints:
   - module: "taint1"
   - module: "taint2"
+skipScalingTestDeploymentNames:
+  - name: "deployment1"
+skipScalingTestStatefulSetNames:
+  - name: "statefulset1"

--- a/pkg/configuration/testdata/tnf_test_config.yml
+++ b/pkg/configuration/testdata/tnf_test_config.yml
@@ -20,7 +20,9 @@ certifiedoperatorinfo:
 acceptedKernelTaints:
   - module: "taint1"
   - module: "taint2"
-skipScalingTestDeploymentNames:
+skipScalingTestDeployments:
   - name: "deployment1"
+    namespace: "tnf"
 skipScalingTestStatefulSetNames:
   - name: "statefulset1"
+    namespace: "tnf"


### PR DESCRIPTION
Add tnf_config entry for the ability to exclude certain deployments and/or statefulsets from the scaling tests.