### PR TITLE
Created merged kube config file in the clientsholder.

### DIFF
--- a/cnf-certification-test/suite_test.go
+++ b/cnf-certification-test/suite_test.go
@@ -122,6 +122,14 @@ func getGitVersion() string {
 	return gitDisplayRelease + " ( " + GitCommit + " )"
 }
 
+func deleteMergedKubeConfigfile(file string) {
+	log.Infof("Deleting merged kube config file %s", file)
+	err := os.Remove(file)
+	if err != nil {
+		log.Errorf("Failed to delete merged kube config file %s: %s", file, err)
+	}
+}
+
 //nolint:funlen // TestTest invokes the CNF Certification Test Suite.
 func TestTest(t *testing.T) {
 	// When running unit tests, skip the suite
@@ -148,7 +156,10 @@ func TestTest(t *testing.T) {
 	}
 
 	// Set clientsholder singleton with the filenames from the env vars.
-	_ = clientsholder.GetClientsHolder(getK8sClientsConfigFileNames()...)
+	client := clientsholder.GetClientsHolder(getK8sClientsConfigFileNames()...)
+
+	// Make sure the temp file for the merged kube config is deleted at the end.
+	defer deleteMergedKubeConfigfile(client.MergedKubeConfigFile)
 
 	// Deploy the daemonset before getting the environment for the first time
 	err := daemonset.DeployPartnerTestDaemonset()


### PR DESCRIPTION
build-depends: 26624
build-depends: https://github.com/dci-labs/dallas-pipelines/pull/570

Serialize the merged kube config into a temporary file and save the file path so it can be read on demand.

This could be used by Brandon's wip #631 for the preflight lib integration.