### PR TITLE
Move 4.7 to 'end of life' section

### DIFF
--- a/pkg/compatibility/compatibility.go
+++ b/pkg/compatibility/compatibility.go
@@ -93,6 +93,8 @@ var (
 			MinRHCOSVersion:      "4.8",
 			RHELVersionsAccepted: []string{"7.9"},
 		},
+
+		// End of life
 		"4.7": {
 			GADate:  time.Date(2021, 2, 24, 0, 0, 0, 0, time.UTC),  // February 24, 2021
 			FSEDate: time.Date(2021, 10, 27, 0, 0, 0, 0, time.UTC), // October 27, 2021
@@ -102,8 +104,6 @@ var (
 			MinRHCOSVersion:      "4.7",
 			RHELVersionsAccepted: []string{"7.9"},
 		},
-
-		// End of life
 		"4.6": {
 			GADate:  time.Date(2020, 10, 27, 0, 0, 0, 0, time.UTC), // October 27, 2020
 			FSEDate: time.Date(2021, 3, 24, 0, 0, 0, 0, time.UTC),  // March 24, 2021


### PR DESCRIPTION
build-depends: 26624
build-depends: https://github.com/dci-labs/dallas-pipelines/pull/570

I was looking at the doc page: https://access.redhat.com/support/policy/updates/openshift

And the 4.7 release was moved to the end of life section.