### PR TITLE
Add tests for testhelper pkg

### DIFF
--- a/pkg/testhelper/testhelper_test.go
+++ b/pkg/testhelper/testhelper_test.go
@@ -108,3 +108,49 @@ func TestSkipIfEmptyFuncs(t *testing.T) {
 		}
 	}
 }
+
+func TestAddTestResultLog(t *testing.T) {
+	logFuncCtr := 0
+	failFuncCtr := 0
+	testCases := []struct {
+		testPrefix          string
+		testObject          interface{}
+		logFunc             func(string, ...interface{})
+		failFunc            func(string, ...int)
+		expectedLogCtr      int
+		expectedFailFuncCtr int
+	}{
+		{
+			testPrefix: "test1",
+			testObject: []string{"fail1", "fail2"},
+			logFunc: func(s string, i ...interface{}) {
+				logFuncCtr++
+			},
+			failFunc: func(s string, i ...int) {
+				failFuncCtr++
+			},
+			expectedLogCtr:      1,
+			expectedFailFuncCtr: 1,
+		},
+		{
+			testPrefix: "test2",
+			testObject: []string{},
+			logFunc: func(s string, i ...interface{}) {
+				logFuncCtr++
+			},
+			failFunc: func(s string, i ...int) {
+				failFuncCtr++
+			},
+			expectedLogCtr:      0,
+			expectedFailFuncCtr: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		AddTestResultLog(tc.testPrefix, tc.testObject, tc.logFunc, tc.failFunc)
+		assert.Equal(t, tc.expectedFailFuncCtr, failFuncCtr)
+		assert.Equal(t, tc.expectedLogCtr, logFuncCtr)
+		logFuncCtr = 0
+		failFuncCtr = 0
+	}
+}


### PR DESCRIPTION
build-depends: 26624
build-depends: https://github.com/dci-labs/dallas-pipelines/pull/570

Brings the `testhelper` package up to `96.4% of statements`.