### PR TITLE
Add FailNow() if config marshal fails

### DIFF
--- a/cnf-certification-test/suite_test.go
+++ b/cnf-certification-test/suite_test.go
@@ -169,6 +169,7 @@ func TestTest(t *testing.T) {
 	configurations, err := claimhelper.MarshalConfigurations()
 	if err != nil {
 		log.Errorf("Configuration node missing because of: %s", err)
+		t.FailNow()
 	}
 
 	claimData.Nodes = claimhelper.GenerateNodes()


### PR DESCRIPTION
Similar to the line 159 we probably want to fail out gracefully if there's a failure to marshal the JSON correctly.