### PR TITLE
Fix for SYS_PTRACE panic and logic

### DIFF
--- a/pkg/provider/filters.go
+++ b/pkg/provider/filters.go
@@ -102,3 +102,13 @@ func filterDPDKRunningPods(pods []*Pod) []*Pod {
 	}
 	return filteredPods
 }
+
+func (env *TestEnvironment) GetShareProcessNamespacePods() []*Pod {
+	var filteredPods []*Pod
+	for _, p := range env.Pods {
+		if p.IsShareProcessNamespace() {
+			filteredPods = append(filteredPods, p)
+		}
+	}
+	return filteredPods
+}

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -166,3 +166,7 @@ func (p *Pod) IsAffinityCompliant() (bool, error) {
 	}
 	return true, nil
 }
+
+func (p *Pod) IsShareProcessNamespace() bool {
+	return p.Spec.ShareProcessNamespace != nil && *p.Spec.ShareProcessNamespace
+}


### PR DESCRIPTION
Adding a null check and now only check for SYS_PTRACE in capabilities.add (instead of add/drop)
Also skipping the test for pods that do not have shareProcessNamespace: true
Please review only this commit:
https://github.com/test-network-function/cnf-certification-test/pull/661/commits/d9546db979677ed450814cab82fed279a1ad8cd2
Partner repo PR:
https://github.com/test-network-function/cnf-certification-test-partner/pull/187