### PR TITLE
Fix minor typos in bootparams

### DIFF
--- a/cnf-certification-test/platform/bootparams/bootparams.go
+++ b/cnf-certification-test/platform/bootparams/bootparams.go
@@ -78,7 +78,7 @@ func getGrubKernelArgs(env *provider.TestEnvironment, nodeName string) (aMap map
 	ctx := clientsholder.NewContext(env.DebugPods[nodeName].Namespace, env.DebugPods[nodeName].Name, env.DebugPods[nodeName].Spec.Containers[0].Name)
 	bootConfig, errStr, err := o.ExecCommandContainer(ctx, grubKernelArgsCommand)
 	if err != nil || errStr != "" {
-		return aMap, fmt.Errorf("cannot exucute %s on debug pod %s, err=%s, stderr=%s", grubKernelArgsCommand, env.DebugPods[nodeName], err, errStr)
+		return aMap, fmt.Errorf("cannot execute %s on debug pod %s, err=%s, stderr=%s", grubKernelArgsCommand, env.DebugPods[nodeName], err, errStr)
 	}
 
 	splitBootConfig := strings.Split(bootConfig, "\n")
@@ -97,10 +97,10 @@ func getGrubKernelArgs(env *provider.TestEnvironment, nodeName string) (aMap map
 func getCurrentKernelCmdlineArgs(cut *provider.Container) (aMap map[string]string, err error) {
 	o := clientsholder.GetClientsHolder()
 	ctx := clientsholder.NewContext(cut.Namespace, cut.Podname, cut.Name)
-	currnetKernelCmdlineArgs, errStr, err := o.ExecCommandContainer(ctx, kernelArgscommand)
+	currentKernelCmdlineArgs, errStr, err := o.ExecCommandContainer(ctx, kernelArgscommand)
 	if err != nil || errStr != "" {
 		return aMap, fmt.Errorf("cannot execute %s on container %s, err=%s, stderr=%s", grubKernelArgsCommand, cut, err, errStr)
 	}
-	currentSplitKernelCmdlineArgs := strings.Split(strings.TrimSuffix(currnetKernelCmdlineArgs, "\n"), " ")
+	currentSplitKernelCmdlineArgs := strings.Split(strings.TrimSuffix(currentKernelCmdlineArgs, "\n"), " ")
 	return arrayhelper.ArgListToMap(currentSplitKernelCmdlineArgs), nil
 }


### PR DESCRIPTION
Just a few minor typos in the `bootparams` package.