### PR TITLE
Bump partner to v4.1.1

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "partner_tag": "v4.1.0"
+  "partner_tag": "v4.1.1"
 }


### PR DESCRIPTION
https://github.com/test-network-function/cnf-certification-test-partner/releases/tag/v4.1.1

In preparation for release v4.1.1 of the test suite, we need to bump the partner release as well.