### PR TITLE
Fix networking tests that fail with istio-proxy related issues

### DIFF
--- a/cnf-certification-test/networking/netcommons/netcommons.go
+++ b/cnf-certification-test/networking/netcommons/netcommons.go
@@ -160,6 +160,20 @@ func FindRogueContainersDeclaringPorts(containers []*provider.Container, portsTo
 	return rogueContainers
 }
 
+var ReservedIstioPorts = map[int32]bool{
+	// https://istio.io/latest/docs/ops/deployment/requirements/#ports-used-by-istio
+	15090: true, // Envoy Prometheus telemetry
+	15053: true, // DNS port, if capture is enabled
+	15021: true, // Health checks
+	15020: true, // Merged Prometheus telemetry from Istio agent, Envoy, and application
+	15009: true, // HBONE port for secure networks
+	15008: true, // HBONE mTLS tunnel port
+	15006: true, // Envoy inbound
+	15004: true, // Debug port
+	15001: true, // Envoy outbound
+	15000: true, // Envoy admin port (commands/diagnostics)
+}
+
 func FindRoguePodsListeningToPorts(pods []*provider.Pod, portsToTest map[int32]bool) (roguePods []string, failedContainers int) {
 	for _, put := range pods {
 		cut := put.Containers[0]
@@ -170,9 +184,17 @@ func FindRoguePodsListeningToPorts(pods []*provider.Pod, portsToTest map[int32]b
 			failedContainers++
 			continue
 		}
+
 		for port := range listeningPorts {
 			if portsToTest[int32(port.PortNumber)] {
-				tnf.ClaimFilePrintf("%s has one container listening on port %d that has been reserved", put, port.PortNumber)
+				// If pod contains an "istio-proxy" container, we need to make sure that the ports returned
+				// overlap with the known istio ports
+				if put.ContainsIstioProxy() && ReservedIstioPorts[int32(port.PortNumber)] {
+					tnf.ClaimFilePrintf("%s was found to be listening to port %d due to istio-proxy being present. Ignoring.", put, port.PortNumber)
+					continue
+				}
+
+				tnf.ClaimFilePrintf("%s has one container (%s) listening on port %d that has been reserved", put, cut.Name, port.PortNumber)
 				roguePods = append(roguePods, put.String())
 			}
 		}

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -172,6 +172,11 @@ func testUndeclaredContainerPortsUsage(env *provider.TestEnvironment) {
 		// Verify that all the listening ports have been declared in the container spec
 		failedPod := false
 		for listeningPort := range listeningPorts {
+			if put.ContainsIstioProxy() && netcommons.ReservedIstioPorts[int32(listeningPort.PortNumber)] {
+				tnf.ClaimFilePrintf("%s is listening on port %d protocol %s, but the pod also contains istio-proxy. Ignoring.", put, listeningPort.PortNumber, listeningPort.Protocol)
+				continue
+			}
+
 			if !declaredPorts[listeningPort] {
 				tnf.ClaimFilePrintf("%s is listening on port %d protocol %s, but that port was not declared in any container spec.", put, listeningPort.PortNumber, listeningPort.Protocol)
 				failedPod = true

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -170,3 +170,12 @@ func (p *Pod) IsAffinityCompliant() (bool, error) {
 func (p *Pod) IsShareProcessNamespace() bool {
 	return p.Spec.ShareProcessNamespace != nil && *p.Spec.ShareProcessNamespace
 }
+
+func (p *Pod) ContainsIstioProxy() bool {
+	for _, container := range p.Containers {
+		if container.Name == "istio-proxy" {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Fix a couple of `networking` suite tests that still fail due to istio-proxy being injected into pods.

Created a method in the `Pod` struct called `ContainsIstioProxy` which just allows us whether or not a pod has an injected `istio-proxy` container.  The "[]Pod.Containers" are not filtered the way the "env.Containers" slices are filtered, see #554.

Notes:
- GetReservedIstioPorts() returns a hardcoded slice of ports and commented details about what they are used for.