### PR TITLE
Use the right variable for bad statefulsets.

### DIFF
--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -405,7 +405,7 @@ func testHighAvailability(env *provider.TestEnvironment) {
 
 		if st.Spec.Template.Spec.Affinity == nil ||
 			st.Spec.Template.Spec.Affinity.PodAntiAffinity == nil {
-			badDeployments = append(badDeployments, st.ToString())
+			badStatefulSet = append(badStatefulSet, st.ToString())
 			tnf.ClaimFilePrintf("StatefulSet found without valid high availability: %s", st.ToString())
 		}
 	}


### PR DESCRIPTION
Simple fix to use the right output variable to hold the bad statefulsets in the lifecycle-high-availability test case.