### PR TITLE
Use '%v' when referencing an error

### DIFF
--- a/cmd/tnf/main.go
+++ b/cmd/tnf/main.go
@@ -12,7 +12,7 @@ import (
 var (
 	rootCmd = &cobra.Command{
 		Use:   "tnf",
-		Short: "A CLI for creating, validating , and test-network-function tests.",
+		Short: "A CLI for creating, validating, and test-network-function tests.",
 	}
 
 	generate = &cobra.Command{

--- a/cnf-certification-test/accesscontrol/rbac/automount.go
+++ b/cnf-certification-test/accesscontrol/rbac/automount.go
@@ -30,7 +30,7 @@ func AutomountServiceAccountSetOnSA(serviceAccountName, podNamespace string) (*b
 	clientsHolder := clientsholder.GetClientsHolder()
 	sa, err := clientsHolder.K8sClient.CoreV1().ServiceAccounts(podNamespace).Get(context.TODO(), serviceAccountName, metav1.GetOptions{})
 	if err != nil {
-		logrus.Errorf("executing serviceaccount command failed with error: %s", err)
+		logrus.Errorf("executing serviceaccount command failed with error: %v", err)
 		return nil, err
 	}
 	return sa.AutomountServiceAccountToken, nil

--- a/cnf-certification-test/accesscontrol/rbac/clusterrolebinding.go
+++ b/cnf-certification-test/accesscontrol/rbac/clusterrolebinding.go
@@ -29,7 +29,7 @@ func GetClusterRoleBindings(serviceAccountName, podNamespace string) ([]string, 
 	clientsHolder := clientsholder.GetClientsHolder()
 	crbList, crbErr := clientsHolder.K8sClient.RbacV1().ClusterRoles().List(context.TODO(), metav1.ListOptions{})
 	if crbErr != nil {
-		logrus.Errorf("executing clusterrolebinding command failed with error: %s", crbErr)
+		logrus.Errorf("executing clusterrolebinding command failed with error: %v", crbErr)
 		return nil, crbErr
 	}
 

--- a/cnf-certification-test/accesscontrol/rbac/rolebinding.go
+++ b/cnf-certification-test/accesscontrol/rbac/rolebinding.go
@@ -30,7 +30,7 @@ func GetRoleBindings(podNamespace, serviceAccountName string) ([]string, error) 
 	clientsHolder := clientsholder.GetClientsHolder()
 	roleList, roleErr := clientsHolder.K8sClient.RbacV1().Roles("").List(context.TODO(), metav1.ListOptions{})
 	if roleErr != nil {
-		logrus.Errorf("executing rolebinding command failed with error: %s", roleErr)
+		logrus.Errorf("executing rolebinding command failed with error: %v", roleErr)
 		return nil, roleErr
 	}
 

--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -458,14 +458,14 @@ func TestOneProcessPerContainer(env *provider.TestEnvironment) {
 		ocpContext := clientsholder.NewContext(debugPod.Namespace, debugPod.Name, debugPod.Spec.Containers[0].Name)
 		pid, err := crclient.GetPidFromContainer(cut, ocpContext)
 		if err != nil {
-			tnf.ClaimFilePrintf("Could not get PID for: %s, error: %s", cut, err)
+			tnf.ClaimFilePrintf("Could not get PID for: %s, error: %v", cut, err)
 			badContainers = append(badContainers, cut.String())
 			continue
 		}
 
 		nbProcesses, err := getNbOfProcessesInPidNamespace(ocpContext, pid, clientsholder.GetClientsHolder())
 		if err != nil {
-			tnf.ClaimFilePrintf("Could not get number of processes for: %s, error: %s", cut, err)
+			tnf.ClaimFilePrintf("Could not get number of processes for: %s, error: %v", cut, err)
 			badContainers = append(badContainers, cut.String())
 			continue
 		}
@@ -576,7 +576,7 @@ func TestNoSSHDaemonsAllowed(env *provider.TestEnvironment) {
 	for _, cut := range env.Containers {
 		stdout, stderr, err := o.ExecCommandContainer(clientsholder.NewContext(cut.Namespace, cut.Podname, cut.Name), listProcessesCmd)
 		if err != nil || stderr != "" {
-			tnf.ClaimFilePrintf("Could not list processes on: %s, error: %s", cut, err)
+			tnf.ClaimFilePrintf("Could not list processes on: %s, error: %v", cut, err)
 			errorContainers = append(errorContainers, cut.String())
 			continue
 		}

--- a/cnf-certification-test/chaostesting/pod_delete/pod_delete.go
+++ b/cnf-certification-test/chaostesting/pod_delete/pod_delete.go
@@ -154,13 +154,13 @@ func fillTemplate(file string, values map[string]interface{}) ([]byte, error) {
 	// parse the template
 	tmpl, err := template.ParseFiles(file)
 	if err != nil {
-		logrus.Errorf("error while parsing the yaml file: %s error: %s", file, err)
+		logrus.Errorf("error while parsing the yaml file: %s error: %v", file, err)
 		return nil, err
 	}
 	var buffer bytes.Buffer
 	writer := bufio.NewWriter(&buffer)
 	if err := tmpl.Execute(writer, values); err != nil {
-		logrus.Errorf("error while executing the template to the yaml file: %s error: %s", file, err)
+		logrus.Errorf("error while executing the template to the yaml file: %s error: %v", file, err)
 		return nil, err
 	}
 	writer.Flush() // write to the buffer

--- a/cnf-certification-test/lifecycle/podsets/podsets.go
+++ b/cnf-certification-test/lifecycle/podsets/podsets.go
@@ -37,7 +37,7 @@ var WaitForDeploymentSetReady = func(ns, name string, timeout time.Duration) boo
 	for time.Since(start) < timeout {
 		dp, err := provider.GetUpdatedDeployment(clients.K8sClient.AppsV1(), ns, name)
 		if err != nil {
-			logrus.Errorf("Error while getting deployment %s (ns: %s), err: %s", name, ns, err)
+			logrus.Errorf("Error while getting deployment %s (ns: %s), err: %v", name, ns, err)
 		} else if !dp.IsDeploymentReady() {
 			logrus.Errorf("%s is not ready yet", dp.ToString())
 		} else {
@@ -58,10 +58,10 @@ func WaitForStatefulSetReady(ns, name string, timeout time.Duration) bool {
 	for time.Since(start) < timeout {
 		ss, err := provider.GetUpdatedStatefulset(clients.K8sClient.AppsV1(), ns, name)
 		if err == nil && ss.IsStatefulSetReady() {
-			logrus.Tracef("%s is ready, err: %s", ss.ToString(), err)
+			logrus.Tracef("%s is ready, err: %v", ss.ToString(), err)
 			return true
 		} else if err != nil {
-			logrus.Errorf("Error while getting the %s, err: %s", ss.ToString(), err)
+			logrus.Errorf("Error while getting the %s, err: %v", ss.ToString(), err)
 		}
 		time.Sleep(time.Second)
 	}

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -435,19 +435,19 @@ func testPodsRecreation(env *provider.TestEnvironment) { //nolint:funlen
 		err := podrecreation.CordonHelper(n, podrecreation.Cordon)
 		if err != nil {
 			logrus.Errorf("error cordoning the node: %s", n)
-			ginkgo.Fail(fmt.Sprintf("Cordoning node %s failed with err: %s. Test inconclusive, skipping", n, err))
+			ginkgo.Fail(fmt.Sprintf("Cordoning node %s failed with err: %v. Test inconclusive, skipping", n, err))
 		}
 		ginkgo.By(fmt.Sprintf("Draining and Cordoning node %s: ", n))
 		logrus.Debugf("node: %s cordoned", n)
 		count, err := podrecreation.CountPodsWithDelete(env.Pods, n, podrecreation.NoDelete)
 		if err != nil {
-			ginkgo.Fail(fmt.Sprintf("Getting pods list to drain in node %s failed with err: %s. Test inconclusive.", n, err))
+			ginkgo.Fail(fmt.Sprintf("Getting pods list to drain in node %s failed with err: %v. Test inconclusive.", n, err))
 		}
 		nodeTimeout := timeoutPodSetReady + timeoutPodRecreationPerPod*time.Duration(count)
 		logrus.Debugf("draining node: %s with timeout: %s", n, nodeTimeout.String())
 		_, err = podrecreation.CountPodsWithDelete(env.Pods, n, podrecreation.DeleteForeground)
 		if err != nil {
-			ginkgo.Fail(fmt.Sprintf("Draining node %s failed with err: %s. Test inconclusive", n, err))
+			ginkgo.Fail(fmt.Sprintf("Draining node %s failed with err: %v. Test inconclusive", n, err))
 		}
 
 		claimsLog, podsNotReady := podsets.WaitForAllPodSetReady(env, nodeTimeout)

--- a/cnf-certification-test/networking/netcommons/netcommons.go
+++ b/cnf-certification-test/networking/netcommons/netcommons.go
@@ -180,7 +180,7 @@ func FindRoguePodsListeningToPorts(pods []*provider.Pod, portsToTest map[int32]b
 
 		listeningPorts, err := netutil.GetListeningPorts(cut)
 		if err != nil {
-			tnf.ClaimFilePrintf("Failed to get the listening ports on %s, err: %s", cut, err)
+			tnf.ClaimFilePrintf("Failed to get the listening ports on %s, err: %v", cut, err)
 			failedContainers++
 			continue
 		}

--- a/cnf-certification-test/networking/netutil/netutil.go
+++ b/cnf-certification-test/networking/netutil/netutil.go
@@ -58,7 +58,7 @@ func parseListeningPorts(cmdOut string) (map[PortInfo]bool, error) {
 
 		port, err := strconv.Atoi(s[len(s)-1])
 		if err != nil {
-			return nil, fmt.Errorf("string to int conversion error, err: %s", err)
+			return nil, fmt.Errorf("string to int conversion error, err: %v", err)
 		}
 		protocol := strings.ToUpper(fields[indexProtocol])
 		portInfo := PortInfo{port, protocol}
@@ -72,7 +72,7 @@ func parseListeningPorts(cmdOut string) (map[PortInfo]bool, error) {
 func GetListeningPorts(cut *provider.Container) (map[PortInfo]bool, error) {
 	outStr, errStr, err := crclient.ExecCommandContainerNSEnter(getListeningPortsCmd, cut)
 	if err != nil || errStr != "" {
-		return nil, fmt.Errorf("failed to execute command %s on %s, err: %s", getListeningPortsCmd, cut, err)
+		return nil, fmt.Errorf("failed to execute command %s on %s, err: %v", getListeningPortsCmd, cut, err)
 	}
 
 	return parseListeningPorts(outStr)
@@ -138,7 +138,7 @@ func stripSpaceTabLine(in string) string {
 func isIPOrNSTablesPresent(cut *provider.Container, command string) (bool, string, error) { //nolint:gocritic
 	outStr, errStr, err := crclient.ExecCommandContainerNSEnter(command, cut)
 	if err != nil || (errStr != "" && errStr != ipTablesLegacyWarning) {
-		return false, outStr, fmt.Errorf("failed to execute command %s on %s, err: %s, errStr: %s", command, cut, err, errStr)
+		return false, outStr, fmt.Errorf("failed to execute command %s on %s, err: %v, errStr: %s", command, cut, err, errStr)
 	}
 
 	if errStr == ipTablesLegacyWarning {

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -160,7 +160,7 @@ func testUndeclaredContainerPortsUsage(env *provider.TestEnvironment) {
 		firstPodContainer := put.Containers[0]
 		listeningPorts, err := netutil.GetListeningPorts(firstPodContainer)
 		if err != nil {
-			tnf.ClaimFilePrintf("Failed to get the container's listening ports, err: %s", err)
+			tnf.ClaimFilePrintf("Failed to get the container's listening ports, err: %v", err)
 			failedPods = append(failedPods, put)
 			continue
 		}
@@ -327,7 +327,7 @@ func testIsConfigPresent(env *provider.TestEnvironment, name string) {
 	for _, cut := range env.Containers {
 		result, log, err := function(cut)
 		if err != nil {
-			tnf.ClaimFilePrintf("Could not check %s config on: %s, error: %s log: %s", name, cut, err, log)
+			tnf.ClaimFilePrintf("Could not check %s config on: %s, error: %v log: %s", name, cut, err, log)
 			errorContainers = append(errorContainers, cut)
 			continue
 		}

--- a/cnf-certification-test/observability/suite.go
+++ b/cnf-certification-test/observability/suite.go
@@ -83,7 +83,7 @@ func containerHasLoggingOutput(cut *provider.Container) (bool, error) {
 
 	podLogsReaderCloser, err := req.Stream(context.TODO())
 	if err != nil {
-		return false, fmt.Errorf("unable to get log streamer, err: %s", err)
+		return false, fmt.Errorf("unable to get log streamer, err: %v", err)
 	}
 
 	defer podLogsReaderCloser.Close()
@@ -91,7 +91,7 @@ func containerHasLoggingOutput(cut *provider.Container) (bool, error) {
 	buf := new(bytes.Buffer)
 	_, err = io.Copy(buf, podLogsReaderCloser)
 	if err != nil {
-		return false, fmt.Errorf("unable to get log data, err: %s", err)
+		return false, fmt.Errorf("unable to get log data, err: %v", err)
 	}
 
 	return buf.String() != "", nil
@@ -180,7 +180,7 @@ func testPodDisruptionBudgets(env *provider.TestEnvironment) {
 				if deployment.Spec.Template.Labels[pdbLabelKey] == pdbLabelValue {
 					if ok, err := checkPDBIsValid(pdb, deployment.Spec.Replicas); !ok {
 						failedPDBs = append(failedPDBs, pdb.Name)
-						tnf.ClaimFilePrintf("PDB %s is not valid for deployment %s, err: %s", pdb.Name, deployment.Name, err)
+						tnf.ClaimFilePrintf("PDB %s is not valid for deployment %s, err: %v", pdb.Name, deployment.Name, err)
 					}
 				}
 			}
@@ -188,7 +188,7 @@ func testPodDisruptionBudgets(env *provider.TestEnvironment) {
 				if statefulSet.Spec.Template.Labels[pdbLabelKey] == pdbLabelValue {
 					if ok, err := checkPDBIsValid(pdb, statefulSet.Spec.Replicas); !ok {
 						failedPDBs = append(failedPDBs, pdb.Name)
-						tnf.ClaimFilePrintf("PDB %s is not valid for statefulset %s, err: %s", pdb.Name, statefulSet.Name, err)
+						tnf.ClaimFilePrintf("PDB %s is not valid for statefulset %s, err: %v", pdb.Name, statefulSet.Name, err)
 					}
 				}
 			}

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -343,7 +343,7 @@ func testIsSELinuxEnforcing(env *provider.TestEnvironment) {
 		ctx := clientsholder.NewContext(debugPod.Namespace, debugPod.Name, debugPod.Spec.Containers[0].Name)
 		outStr, errStr, err := o.ExecCommandContainer(ctx, getenforceCommand)
 		if err != nil || errStr != "" {
-			logrus.Errorf("Failed to execute command %s in debug %s, errStr: %s, err: %s", getenforceCommand, debugPod.String(), errStr, err)
+			logrus.Errorf("Failed to execute command %s in debug %s, errStr: %s, err: %v", getenforceCommand, debugPod.String(), errStr, err)
 			nodesError++
 			continue
 		}
@@ -426,7 +426,7 @@ func testSysctlConfigs(env *provider.TestEnvironment) {
 
 		sysctlSettings, err := sysctlconfig.GetSysctlSettings(env, cut.NodeName)
 		if err != nil {
-			tnf.ClaimFilePrintf("Could not get sysctl settings for node %s, error: %s", cut.NodeName, err)
+			tnf.ClaimFilePrintf("Could not get sysctl settings for node %s, error: %v", cut.NodeName, err)
 			badContainers = append(badContainers, cut.String())
 			continue
 		}
@@ -498,7 +498,7 @@ func testNodeOperatingSystemStatus(env *provider.TestEnvironment) {
 				// Get the short version from the node
 				shortVersion, err := node.GetRHCOSVersion()
 				if err != nil {
-					tnf.ClaimFilePrintf("Node %s failed to gather RHCOS version. Error: %s", node.Data.Name, err.Error())
+					tnf.ClaimFilePrintf("Node %s failed to gather RHCOS version. Error: %v", node.Data.Name, err)
 					failedWorkerNodes = append(failedWorkerNodes, node.Data.Name)
 					continue
 				}
@@ -519,7 +519,7 @@ func testNodeOperatingSystemStatus(env *provider.TestEnvironment) {
 				// Get the short version from the node
 				shortVersion, err := node.GetRHELVersion()
 				if err != nil {
-					tnf.ClaimFilePrintf("Node %s failed to gather RHEL version. Error: %s", node.Data.Name, err.Error())
+					tnf.ClaimFilePrintf("Node %s failed to gather RHEL version. Error: %v", node.Data.Name, err)
 					failedWorkerNodes = append(failedWorkerNodes, node.Data.Name)
 					continue
 				}

--- a/internal/crclient/crclient.go
+++ b/internal/crclient/crclient.go
@@ -70,7 +70,7 @@ func ExecCommandContainerNSEnter(command string,
 	// Get the container PID to build the nsenter command
 	containerPid, err := GetPidFromContainer(aContainer, ctx)
 	if err != nil {
-		return "", "", fmt.Errorf("cannot get PID from: %s, err: %s", aContainer, err)
+		return "", "", fmt.Errorf("cannot get PID from: %s, err: %v", aContainer, err)
 	}
 
 	// Add the container PID and the specific command to run with nsenter

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -108,7 +108,7 @@ func DoAutoDiscover() DiscoveredTestData {
 	var err error
 	data.TestData, err = configuration.LoadConfiguration(data.Env.ConfigurationPath)
 	if err != nil {
-		logrus.Fatalf("Cannot load configuration, error: %s", err)
+		logrus.Fatalf("Cannot load configuration, error: %v", err)
 	}
 	oc := clientsholder.GetClientsHolder()
 	data.Namespaces = namespacesListToStringList(data.TestData.TargetNameSpaces)
@@ -120,11 +120,11 @@ func DoAutoDiscover() DiscoveredTestData {
 	data.DebugPods, _ = findPodsByLabel(oc.K8sClient.CoreV1(), debugLabels, debugNS)
 	data.ResourceQuotaItems, err = getResourceQuotas(oc.K8sClient.CoreV1())
 	if err != nil {
-		logrus.Fatalf("Cannot get resource quotas, error: %s", err)
+		logrus.Fatalf("Cannot get resource quotas, error: %v", err)
 	}
 	data.PodDisruptionBudgets, err = getPodDisruptionBudgets(oc.K8sClient.PolicyV1(), data.Namespaces)
 	if err != nil {
-		logrus.Fatalf("Cannot get pod disruption budgets, error: %s", err)
+		logrus.Fatalf("Cannot get pod disruption budgets, error: %v", err)
 	}
 	data.NetworkPolicies, err = getNetworkPolicies(oc.K8sNetworkingClient)
 	if err != nil {
@@ -138,7 +138,7 @@ func DoAutoDiscover() DiscoveredTestData {
 	data.OpenshiftVersion = openshiftVersion
 	k8sVersion, err := oc.K8sClient.Discovery().ServerVersion()
 	if err != nil {
-		logrus.Fatalf("Cannot get the K8s version, error: %s", err)
+		logrus.Fatalf("Cannot get the K8s version, error: %v", err)
 	}
 	data.Istio = findIstioNamespace(oc.K8sClient.CoreV1())
 
@@ -151,19 +151,19 @@ func DoAutoDiscover() DiscoveredTestData {
 	data.Hpas = findHpaControllers(oc.K8sClient, data.Namespaces)
 	data.Nodes, err = oc.K8sClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		logrus.Fatalf("Cannot get list of nodes, error: %s", err)
+		logrus.Fatalf("Cannot get list of nodes, error: %v", err)
 	}
 	data.PersistentVolumes, err = getPersistentVolumes(oc.K8sClient.CoreV1())
 	if err != nil {
-		logrus.Fatalf("Cannot get list of persistent volumes, error: %s", err)
+		logrus.Fatalf("Cannot get list of persistent volumes, error: %v", err)
 	}
 	data.PersistentVolumeClaims, err = getPersistentVolumeClaims(oc.K8sClient.CoreV1())
 	if err != nil {
-		logrus.Fatalf("Cannot get list of persistent volume claims, error: %s", err)
+		logrus.Fatalf("Cannot get list of persistent volume claims, error: %v", err)
 	}
 	data.Services, err = getServices(oc.K8sClient.CoreV1(), data.Namespaces)
 	if err != nil {
-		logrus.Fatalf("Cannot get list of services, error: %s", err)
+		logrus.Fatalf("Cannot get list of services, error: %v", err)
 	}
 	return data
 }

--- a/pkg/claimhelper/claimhelper.go
+++ b/pkg/claimhelper/claimhelper.go
@@ -73,11 +73,11 @@ func UnmarshalClaim(claimFile []byte, claimRoot *claim.Root) {
 func ReadClaimFile(claimFileName string) (data []byte, err error) {
 	data, err = os.ReadFile(claimFileName)
 	if err != nil {
-		log.Errorf("ReadFile failed with err: %s", err)
+		log.Errorf("ReadFile failed with err: %v", err)
 	}
 	path, err := os.Getwd()
 	if err != nil {
-		log.Errorf("Getwd failed with err: %s", err)
+		log.Errorf("Getwd failed with err: %v", err)
 	}
 	log.Infof("Reading claim file at path: %s", path)
 	return data, nil
@@ -87,7 +87,7 @@ func ReadClaimFile(claimFileName string) (data []byte, err error) {
 func GetConfigurationFromClaimFile(claimFileName string) (env *provider.TestEnvironment, err error) {
 	data, err := ReadClaimFile(claimFileName)
 	if err != nil {
-		log.Errorf("ReadClaimFile failed with err: %s", err)
+		log.Errorf("ReadClaimFile failed with err: %v", err)
 		return env, err
 	}
 	var aRoot claim.Root

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -37,7 +37,7 @@ type CertifiedOperatorRequestInfo struct {
 	// Name is the name of the `operator bundle package name` that you want to check if exists in the RedHat catalog
 	Name string `yaml:"name" json:"name"`
 
-	// Organization as understood by the operator publisher , e.g. `redhat-marketplace`
+	// Organization as understood by the operator publisher, e.g. `redhat-marketplace`
 	Organization string `yaml:"organization" json:"organization"`
 }
 

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -110,7 +110,7 @@ func getHWJsonOutput(debugPod *corev1.Pod, o clientsholder.Command, cmd string) 
 	ctx := clientsholder.NewContext(debugPod.Namespace, debugPod.Name, debugPod.Spec.Containers[0].Name)
 	outStr, errStr, err := o.ExecCommandContainer(ctx, cmd)
 	if err != nil || errStr != "" {
-		return out, fmt.Errorf("command %s failed with error err: %s , stderr: %s", cmd, err, errStr)
+		return out, fmt.Errorf("command %s failed with error err: %v, stderr: %s", cmd, err, errStr)
 	}
 	err = json.Unmarshal([]byte(outStr), &out)
 	if err != nil {
@@ -124,7 +124,7 @@ func getHWTextOutput(debugPod *corev1.Pod, o clientsholder.Command, cmd string) 
 	ctx := clientsholder.NewContext(debugPod.Namespace, debugPod.Name, debugPod.Spec.Containers[0].Name)
 	outStr, errStr, err := o.ExecCommandContainer(ctx, cmd)
 	if err != nil || errStr != "" {
-		return out, fmt.Errorf("command %s failed with error err: %s , stderr: %s", lspciCommand, err, errStr)
+		return out, fmt.Errorf("command %s failed with error err: %v, stderr: %s", lspciCommand, err, errStr)
 	}
 
 	return strings.Split(outStr, "\n"), nil
@@ -170,7 +170,7 @@ func GetCsiDriver() (out map[string]interface{}) {
 
 	err = json.Unmarshal(data, &out)
 	if err != nil {
-		logrus.Errorf("failed to marshall nodes json, err: %s", err)
+		logrus.Errorf("failed to marshall nodes json, err: %v", err)
 		return out
 	}
 	return out

--- a/pkg/diagnostics/diagnostics_test.go
+++ b/pkg/diagnostics/diagnostics_test.go
@@ -60,7 +60,7 @@ func TestGetHWJsonOutput(t *testing.T) {
 			execStderr: "this is an error",
 			execErr:    nil,
 
-			expectedErr:    errors.New("command does not matter failed with error err: %!s(<nil>) , stderr: this is an error"),
+			expectedErr:    errors.New("command does not matter failed with error err: <nil>, stderr: this is an error"),
 			expectedResult: TestingJSON{},
 		},
 		{
@@ -68,7 +68,7 @@ func TestGetHWJsonOutput(t *testing.T) {
 			execStderr: "this is an error",
 			execErr:    errors.New("this is an error2"),
 
-			expectedErr:    errors.New("command does not matter failed with error err: %!s(<nil>) , stderr: this is an error"),
+			expectedErr:    errors.New("command does not matter failed with error err: <nil>, stderr: this is an error"),
 			expectedResult: TestingJSON{},
 		},
 	}
@@ -123,7 +123,7 @@ func TestGetHWTextOutput(t *testing.T) {
 			execStderr: "this is an error",
 			execErr:    nil,
 
-			expectedErr:    errors.New("command lspci failed with error err: %!s(<nil>) , stderr: this is an error"),
+			expectedErr:    errors.New("command lspci failed with error err: <nil>, stderr: this is an error"),
 			expectedResult: nil,
 		},
 		{
@@ -131,7 +131,7 @@ func TestGetHWTextOutput(t *testing.T) {
 			execStderr: "this is an error",
 			execErr:    errors.New("this is an error2"),
 
-			expectedErr:    errors.New("command lspci failed with error err: %!s(<nil>) , stderr: this is an error"),
+			expectedErr:    errors.New("command lspci failed with error err: <nil>, stderr: this is an error"),
 			expectedResult: nil,
 		},
 	}

--- a/pkg/provider/filters.go
+++ b/pkg/provider/filters.go
@@ -93,7 +93,7 @@ func filterDPDKRunningPods(pods []*Pod) []*Pod {
 		findCommand := fmt.Sprintf("%s '%s'", findDeviceSubCommand, pod.MultusPCIs[0])
 		outStr, errStr, err := o.ExecCommandContainer(ctx, findCommand)
 		if err != nil || errStr != "" {
-			logrus.Errorf("Failed to execute command %s in debug %s, errStr: %s, err: %s", findCommand, pod.String(), errStr, err)
+			logrus.Errorf("Failed to execute command %s in debug %s, errStr: %s, err: %v", findCommand, pod.String(), errStr, err)
 			continue
 		}
 		if strings.Contains(outStr, dpdkDriver) {

--- a/pkg/provider/operators.go
+++ b/pkg/provider/operators.go
@@ -78,13 +78,13 @@ func createOperators(csvs []olmv1Alpha.ClusterServiceVersion, subscriptions []ol
 
 		csvInstallPlans, err := getCsvInstallPlans(csv.Namespace, csv.Name, installPlans)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get installPlans for csv %s (ns %s), err: %s", csv.Name, csv.Namespace, err)
+			return nil, fmt.Errorf("failed to get installPlans for csv %s (ns %s), err: %v", csv.Name, csv.Namespace, err)
 		}
 
 		for _, installPlan := range csvInstallPlans {
 			indexImage, catalogErr := getCatalogSourceImageIndexFromInstallPlan(installPlan)
 			if catalogErr != nil {
-				return nil, fmt.Errorf("failed to get installPlan image index for csv %s (ns %s) installPlan %s, err: %s",
+				return nil, fmt.Errorf("failed to get installPlan image index for csv %s (ns %s) installPlan %s, err: %v",
 					csv.Name, csv.Namespace, installPlan.Name, catalogErr)
 			}
 
@@ -121,7 +121,7 @@ func getInstallPlansInNamespace(namespace string, clusterInstallPlans map[string
 	clients := clientsholder.GetClientsHolder()
 	installPlanList, err := clients.OlmClient.OperatorsV1alpha1().InstallPlans(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable get installplans in namespace %s, err: %s", namespace, err)
+		return nil, fmt.Errorf("unable get installplans in namespace %s, err: %v", namespace, err)
 	}
 
 	nsInstallPlans = installPlanList.Items

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -47,12 +47,12 @@ func NewPod(aPod *corev1.Pod) (out Pod) {
 	out.MultusIPs = make(map[string][]string)
 	out.MultusIPs, err = GetPodIPsPerNet(aPod.GetAnnotations()[CniNetworksStatusKey])
 	if err != nil {
-		logrus.Errorf("Could not decode networks-status annotation, error: %s", err)
+		logrus.Errorf("Could not decode networks-status annotation, error: %v", err)
 	}
 
 	out.MultusPCIs, err = GetPciPerPod(aPod.GetAnnotations()[CniNetworksStatusKey])
 	if err != nil {
-		logrus.Errorf("Could not decode networks-status annotation, error: %s", err)
+		logrus.Errorf("Could not decode networks-status annotation, error: %v", err)
 	}
 
 	if _, ok := aPod.GetLabels()[skipConnectivityTestsLabel]; ok {


### PR DESCRIPTION
Sometimes we'll see `err: %!s(<nil>)` messages in our logs because the format is incorrect.