### PR TITLE
Optimize and clean the TNF image

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -4,11 +4,6 @@ To test the newly added test / existing tests locally, follow the steps
 
 
 -  Clone the repo
-- Specify the location of the partner repo
-
-    ```shell
-    export TNF_PARTNER_SRC_DIR=/home/userid/code/cnf-certification-test-partner
-    ```
 
 - Set runtime environment variables, as per the requirement.
 

--- a/docs/runtime-env.md
+++ b/docs/runtime-env.md
@@ -29,17 +29,6 @@ Likewise, to enable intrusive tests, set the following:
 export TNF_NON_INTRUSIVE_ONLY=false
 ```
 
-## Specify the location of the partner repo
-This env var is optional, but highly recommended if running the test suite from a clone of this github repo. It's not needed or used if running the tnf image.
-
-To set it, clone the partner [repo](https://github.com/test-network-function/cnf-certification-test-partner) and set TNF_PARTNER_SRC_DIR to point to it.
-
-```shell
-export TNF_PARTNER_SRC_DIR=/home/userid/code/cnf-certification-test-partner
-```
-
-When this variable is set, the run-cnf-suites.sh script will deploy/refresh the partner deployments/pods in the cluster before starting the test run.
-
 ## Disconnected environment
 In a disconnected environment, only specific versions of images are mirrored to the local repo. For those environments,
 the partner pod image `quay.io/testnetworkfunction/cnf-test-partner` and debug pod image `quay.io/testnetworkfunction/debug-partner` should be mirrored

--- a/run-cnf-suites.sh
+++ b/run-cnf-suites.sh
@@ -132,8 +132,3 @@ else
 fi
 
 cd ./cnf-certification-test && ./cnf-certification-test.test ${FOCUS_STRING} ${SKIP_STRING} "${LABEL_STRING}" ${GINKGO_ARGS}
-
-# if [[ ! -z "${TNF_PARTNER_SRC_DIR}" ]]; then
-# 	echo "attempting to delete litmus"
-# 	make -C $TNF_PARTNER_SRC_DIR delete-litmus
-# fi


### PR DESCRIPTION
Use ubi-minimal as base image and remove some unneeded elements.

Image size reduced to 232MB from almost 1GB.