### PR TITLE
upgrading some test cases to normative

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -30,7 +30,7 @@ Test Case Label|access-control-container-host-port
 Unique ID|http://test-network-function.com/testcases/access-control/container-host-port
 Version|v1.0.0
 Description|http://test-network-function.com/testcases/access-control/container-host-port Verifies if containers define a hostPort.
-Result Type|informative
+Result Type|normative
 Suggested Remediation|Remove hostPort configuration from the container
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.3.6
 Exception Process|There is no documented exception process for this.
@@ -45,7 +45,7 @@ Unique ID|http://test-network-function.com/testcases/access-control/namespace
 Version|v1.0.0
 Description|http://test-network-function.com/testcases/access-control/namespace Tests that all CNF's resources (PUTs and CRs) belong to valid namespaces. A valid namespace meets the following conditions: (1) It was declared in the yaml config file under the targetNameSpaces tag. (2) It doesn't have any of the following prefixes: default, openshift-, istio- and aspenmesh-
 Result Type|normative
-Suggested Remediation|Ensure that your CNF utilizes namespaces declared in the yaml config file. Additionally, 	the namespaces should not start with "default, openshift-, istio- or aspenmesh-", except in rare cases.
+Suggested Remediation|Ensure that your CNF utilizes namespaces declared in the yaml config file. Additionally, 	the namespaces should not start with "default, openshift-, istio- or aspenmesh-".
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2, 16.3.8 and 16.3.9
 Exception Process|There is no documented exception process for this.
 Tags|common
@@ -58,7 +58,7 @@ Test Case Label|access-control-namespace-resource-quota
 Unique ID|http://test-network-function.com/testcases/access-control/namespace-resource-quota
 Version|v1.0.0
 Description|http://test-network-function.com/testcases/access-control/namespace-resource-quota Checks to see if CNF workload pods are running in namespaces that have resource quotas applied.
-Result Type|informative
+Result Type|normative
 Suggested Remediation|Apply a ResourceQuota to the namespace your CNF is running in
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 4.6.8
 Exception Process|There is no documented exception process for this.

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -792,7 +792,7 @@ var Catalog = map[claim.Identifier]TestCaseDescription{
 	},
 	TestContainerHostPort: {
 		Identifier:  TestContainerHostPort,
-		Type:        InformativeResult,
+		Type:        NormativeResult,
 		Remediation: ContainerHostPortRemediation,
 		Description: formDescription(TestContainerHostPort,
 			`Verifies if containers define a hostPort.`),
@@ -1324,7 +1324,7 @@ that there are no changes to the following directories:
 	},
 	TestNamespaceResourceQuotaIdentifier: {
 		Identifier:            TestNamespaceResourceQuotaIdentifier,
-		Type:                  InformativeResult,
+		Type:                  NormativeResult,
 		Description:           formDescription(TestNamespaceResourceQuotaIdentifier, `Checks to see if CNF workload pods are running in namespaces that have resource quotas applied.`),
 		Remediation:           NamespaceResourceQuotaRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 4.6.8", // TODO Change this to v1.4 when available

--- a/cnf-certification-test/identifiers/remediation.go
+++ b/cnf-certification-test/identifiers/remediation.go
@@ -92,7 +92,7 @@ const (
 	TestIPTablesRemediation = `Do not configure iptables on any CNF container.`
 
 	NamespaceBestPracticesRemediation = `Ensure that your CNF utilizes namespaces declared in the yaml config file. Additionally,
-	the namespaces should not start with "default, openshift-, istio- or aspenmesh-", except in rare cases.`
+	the namespaces should not start with "default, openshift-, istio- or aspenmesh-".`
 
 	NonTaintedNodeKernelsRemediation = `Test failure indicates that the underlying Node's kernel is tainted.  Ensure that you have not altered underlying
 	Node(s) kernels in order to run the CNF.`


### PR DESCRIPTION
Moving the following TCs from informativre to normative:
- container-host-port
- namespace-resource-quota
