### PR TITLE
Allow Guaranteed Pods to be tested by lifecycle-pod-scheduling TC.

### DIFF
--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -110,8 +110,9 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 		if env.GetWorkerCount() < minWorkerNodesForLifecycle {
 			ginkgo.Skip("Skipping pod scheduling test because invalid number of available workers.")
 		}
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.GetNonGuaranteedPodsWithAntiAffinity())
-		testPodNodeSelectorAndAffinityBestPractices(&env)
+		testPods := env.GetPodsWithoutAffinityRequiredLabel()
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testPods)
+		testPodNodeSelectorAndAffinityBestPractices(testPods)
 	})
 
 	if env.IsIntrusive() {
@@ -259,9 +260,9 @@ func testPodsOwnerReference(env *provider.TestEnvironment) {
 	testhelper.AddTestResultLog("Non-compliant", badPods, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
-func testPodNodeSelectorAndAffinityBestPractices(env *provider.TestEnvironment) {
+func testPodNodeSelectorAndAffinityBestPractices(testPods []*provider.Pod) {
 	var badPods []*corev1.Pod
-	for _, put := range env.GetNonGuaranteedPodsWithAntiAffinity() {
+	for _, put := range testPods {
 		if len(put.Spec.NodeSelector) != 0 {
 			tnf.ClaimFilePrintf("ERROR: %s has a node selector clause. Node selector: %v", put, &put.Spec.NodeSelector)
 			badPods = append(badPods, put.Pod)

--- a/pkg/provider/filters.go
+++ b/pkg/provider/filters.go
@@ -44,10 +44,10 @@ func (env *TestEnvironment) GetNonGuaranteedPods() []*Pod {
 	return filteredPods
 }
 
-func (env *TestEnvironment) GetNonGuaranteedPodsWithAntiAffinity() []*Pod {
+func (env *TestEnvironment) GetPodsWithoutAffinityRequiredLabel() []*Pod {
 	var filteredPods []*Pod
 	for _, p := range env.Pods {
-		if !p.IsPodGuaranteed() && !p.AffinityRequired() {
+		if !p.AffinityRequired() {
 			filteredPods = append(filteredPods, p)
 		}
 	}


### PR DESCRIPTION
There's no reason to skip guaranteed pods for this TC. They should also be tested as long as they don't have the AffinityRequired label.