### PR TITLE
Bump timeout to 5 minutes for scaling tests

### DIFF
--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	timeout                    = 60 * time.Second
+	timeout                    = 300 * time.Second
 	timeoutPodRecreationPerPod = time.Minute
 	timeoutPodSetReady         = 7 * time.Minute
 	minWorkerNodesForLifecycle = 2


### PR DESCRIPTION
Change the timeout value to 5 minutes for the scaling tests to accommodate slower clusters. 