### PR TITLE
Add IstioProxy check func; extra tests

### DIFF
--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -43,10 +43,6 @@ import (
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/platform/nodetainted"
 )
 
-const (
-	istioContainerName = "istio-proxy"
-)
-
 // All actual test code belongs below here.  Utilities belong above.
 var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 	logrus.Debugf("Entering %s suite", common.PlatformAlterationTestKey)
@@ -160,7 +156,7 @@ func TestServiceMesh(env *provider.TestEnvironment) {
 	for _, put := range env.Pods {
 		istioProxyFound := false
 		for _, cut := range put.Containers {
-			if cut.Status.Name == istioContainerName {
+			if cut.IsIstioProxy() {
 				tnf.ClaimFilePrintf("Istio proxy container found on %s", put)
 				istioProxyFound = true
 				break

--- a/pkg/provider/containers.go
+++ b/pkg/provider/containers.go
@@ -88,3 +88,7 @@ func (c *Container) HasIgnoredContainerName() bool {
 	}
 	return false
 }
+
+func (c *Container) IsIstioProxy() bool {
+	return c.Name == "istio-proxy" //nolint:goconst
+}

--- a/pkg/provider/containers_test.go
+++ b/pkg/provider/containers_test.go
@@ -15,3 +15,38 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestIsIstioProxy(t *testing.T) {
+	testCases := []struct {
+		testContainer  Container
+		expectedOutput bool
+	}{
+		{
+			testContainer: Container{
+				Container: &v1.Container{
+					Name: "istio-proxy",
+				},
+			},
+			expectedOutput: true,
+		},
+		{
+			testContainer: Container{
+				Container: &v1.Container{
+					Name: "not-istio-proxy",
+				},
+			},
+			expectedOutput: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedOutput, tc.testContainer.IsIstioProxy())
+	}
+}

--- a/pkg/provider/pods_test.go
+++ b/pkg/provider/pods_test.go
@@ -166,3 +166,39 @@ func TestPodString(t *testing.T) {
 	}
 	assert.Equal(t, "pod: test1 ns: testNS", p.String())
 }
+
+func TestContainsIstioProxy(t *testing.T) {
+	testCases := []struct {
+		testPod        Pod
+		expectedOutput bool
+	}{
+		{
+			testPod: Pod{
+				Containers: []*Container{
+					{
+						Container: &corev1.Container{
+							Name: "istio-proxy",
+						},
+					},
+				},
+			},
+			expectedOutput: true,
+		},
+		{
+			testPod: Pod{
+				Containers: []*Container{
+					{
+						Container: &corev1.Container{
+							Name: "not-istio-proxy",
+						},
+					},
+				},
+			},
+			expectedOutput: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedOutput, tc.testPod.ContainsIstioProxy())
+	}
+}


### PR DESCRIPTION
Instead of hardcoding the `istioContainerName` variable in the suite.go, I made it a `Container` object func that provides whether or not the container is istio-proxy or not.

Also added some more tests to the `Pod` func that does similar things.

Builds upon: https://github.com/test-network-function/cnf-certification-test/pull/673/