### PR TITLE
Adjust Dockerfile to be able to built locally

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -198,14 +198,8 @@ jobs:
 
       - name: Build the `cnf-certification-test` image
         run: |
-          VERSIONS=($(sudo curl -sH 'Accept: application/json' "https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-${RELEASE_LEVEL}&arch=amd64" | jq -r '.nodes[].version' | sort -t "." -k1,1n -k2,2n -k3,3n))
-          OPENSHIFT_VERSION=${VERSIONS[${#VERSIONS[@]} - 1]}
-          docker build --no-cache \
-            -t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${TNF_IMAGE_TAG} \
-            -t ${REGISTRY}/${TNF_IMAGE_NAME}:${TNF_IMAGE_TAG} \
-            --build-arg TNF_VERSION=${COMMIT_SHA} \
-            --build-arg TNF_SRC_URL=${TNF_SRC_URL} \
-            --build-arg OPENSHIFT_VERSION=${OPENSHIFT_VERSION} .
+          make build-image-local
+
         env:
           COMMIT_SHA: ${{ github.sha }}
 

--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -112,15 +112,7 @@ jobs:
 
       - name: Build the `cnf-certification-test` image
         run: |
-          VERSIONS=($(sudo curl -sH 'Accept: application/json' "https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-${RELEASE_LEVEL}&arch=amd64" | jq -r '.nodes[].version' | sort -t "." -k1,1n -k2,2n -k3,3n))
-          OPENSHIFT_VERSION=${VERSIONS[${#VERSIONS[@]} - 1]}
-          docker build --no-cache \
-            -t ${REGISTRY_LOCAL}/${IMAGE_NAME}:${IMAGE_TAG} \
-            -t ${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} \
-            -t ${REGISTRY}/${IMAGE_NAME}:${TNF_VERSION} \
-            --build-arg TNF_VERSION=${TNF_VERSION} \
-            --build-arg TNF_SRC_URL=${TNF_SRC_URL} \
-            --build-arg OPENSHIFT_VERSION=${OPENSHIFT_VERSION} .
+          make build-image-local
 
       # Create a minikube cluster for testing.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest AS build
 
-ARG OPENSHIFT_VERSION
-ENV OPENSHIFT_VERSION=${OPENSHIFT_VERSION}
 ENV TNF_DIR=/usr/tnf
 ENV TNF_SRC_DIR=${TNF_DIR}/tnf-src
 ENV TNF_BIN_DIR=${TNF_DIR}/cnf-certification-test

--- a/Makefile
+++ b/Makefile
@@ -147,4 +147,4 @@ build-image-local: install-tools build-cnf-tests
 	docker build --no-cache \
 		-t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${TNF_IMAGE_TAG} \
 		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${TNF_IMAGE_TAG} \
-		--build-arg OPENSHIFT_VERSION=$(shell ./script/get-release-level.sh ${RELEASE_VERSION}) -f Dockerfile .
+		-f Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ get-db:
 delete-db:
 	rm -rf ${REPO_DIR}/cmd/tnf/fetch
 
-build-image-local: install-tools build-cnf-tests
+build-image-local:
 	docker build --no-cache \
 		-t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${TNF_IMAGE_TAG} \
 		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${TNF_IMAGE_TAG} \

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,13 @@
 
 GO_PACKAGES=$(shell go list ./... | grep -v vendor)
 
+# Default values
+REGISTRY_LOCAL?=localhost
+REGISTRY?=quay.io
+TNF_IMAGE_NAME?=cnf-certification-test
+TNF_IMAGE_TAG?=localtest
+RELEASE_VERSION?=4.11
+
 .PHONY:	build \
 	clean \
 	lint \
@@ -100,6 +107,7 @@ build-cnf-tests:
 	PATH=${PATH}:${GOBIN} ginkgo build -ldflags "${LINKER_TNF_RELEASE_FLAGS}" ./cnf-certification-test
 	make build-catalog-md
 
+# build the CNF test binary with debug flags
 build-cnf-tests-debug:
 	PATH=${PATH}:${GOBIN} ginkgo build -gcflags "all=-N -l" -ldflags "${LINKER_TNF_RELEASE_FLAGS} -extldflags '-z relro -z now'" ./cnf-certification-test
 	make build-catalog-md
@@ -134,3 +142,9 @@ get-db:
 	docker run -v ${REPO_DIR}/cmd/tnf/fetch:/tmp/dump:Z --user $(shell id -u):$(shell id -g) --env OCT_DUMP_ONLY=true ${OCT_IMAGE}
 delete-db:
 	rm -rf ${REPO_DIR}/cmd/tnf/fetch
+
+build-image-local: install-tools build-cnf-tests
+	docker build --no-cache \
+		-t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${TNF_IMAGE_TAG} \
+		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${TNF_IMAGE_TAG} \
+		--build-arg OPENSHIFT_VERSION=$(shell ./script/get-release-level.sh ${RELEASE_VERSION}) -f Dockerfile .

--- a/docs/test-container.md
+++ b/docs/test-container.md
@@ -100,11 +100,9 @@ export TNF_CONTAINER_CLIENT=docker
 ```shell
 podman build -t cnf-certification-test:v4.1.2 \
   --build-arg TNF_VERSION=v4.1.2 \
-  --build-arg OPENSHIFT_VERSION=4.7.55 .
 ```
 
   - `TNF_VERSION` value is set to a branch, a tag, or a hash of a commit that will be installed into the image
-  -  `OPENSHIFT_VERSION` value points to the OCP version of the cluster in which the workloads to be tested are deployed.
 
 
 ### Build from an unofficial source
@@ -115,9 +113,8 @@ Use the `TNF_SRC_URL` build argument to override the URL to a source repository.
 
 ```shell
 podman build -t cnf-certification-test:v4.1.2 \
-  --build-arg TNF_VERSION=v1.0.5 \
-  --build-arg TNF_SRC_URL=https://github.com/test-network-function/cnf-certification-test \
-  --build-arg OPENSHIFT_VERSION=4.7.55 .
+  --build-arg TNF_VERSION=v4.1.2 \
+  --build-arg TNF_SRC_URL=https://github.com/test-network-function/cnf-certification-test .
 ```
 
 ### Run the tests

--- a/script/get-release-level.sh
+++ b/script/get-release-level.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-RELEASE_LEVEL=$1
-VERSIONS=($(curl -sH 'Accept: application/json' "https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-${RELEASE_LEVEL}&arch=amd64" | jq -r '.nodes[].version' | sort -t "." -k1,1n -k2,2n -k3,3n))
-OPENSHIFT_VERSION=${VERSIONS[${#VERSIONS[@]} - 1]}
-echo $OPENSHIFT_VERSION

--- a/script/get-release-level.sh
+++ b/script/get-release-level.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+RELEASE_LEVEL=$1
+VERSIONS=($(curl -sH 'Accept: application/json' "https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-${RELEASE_LEVEL}&arch=amd64" | jq -r '.nodes[].version' | sort -t "." -k1,1n -k2,2n -k3,3n))
+OPENSHIFT_VERSION=${VERSIONS[${#VERSIONS[@]} - 1]}
+echo $OPENSHIFT_VERSION


### PR DESCRIPTION
Notable changes:
- Changed the github workflows to run `make build-image-local` instead of copy/pasting the docker build command information.
- Removed the logic from the Dockerfile that clones the repo(not sure why we ever did this) and builds the binary to just use the already built binary as part of `make build-cnf-tests` which is ran in `make build-image-local` as a pre-req.
- Added default values/strings in the Makefile.
- Removed `jq` and `git` dependencies from the first stage of the Dockerfile.
- BONUS: Added `operator-sdk` binary to the image PATH to be able to use in the preflight work in #631.