### PR TITLE
Add shortcircuit to existing toleration test

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -189,20 +189,6 @@ Suggested Remediation|Ensure that the each CNF Pod is configured to use a valid 
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.3 and 5.2.7
 Exception Process|There is no documented exception process for this.
 Tags|common
-#### pod-toleration-bypass
-
-Property|Description
----|---
-Test Case Name|pod-toleration-bypass
-Test Case Label|access-control-pod-toleration-bypass
-Unique ID|http://test-network-function.com/testcases/access-control/pod-toleration-bypass
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/access-control/pod-toleration-bypass Check that pods do not have NoExecute, PreferNoSchedule, or NoSchedule tolerations that have been modified from the default.
-Result Type|informative
-Suggested Remediation|Do not allow pods to bypass the NoExecute, PreferNoSchedule, or NoSchedule tolerations that are default applied by Kubernetes.
-Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 10.6
-Exception Process|There is no documented exception process for this.
-Tags|common
 #### requests-and-limits
 
 Property|Description
@@ -543,6 +529,20 @@ Description|http://test-network-function.com/testcases/lifecycle/pod-scheduling 
 Result Type|normative
 Suggested Remediation|In most cases, Pod's should not specify their host Nodes through nodeSelector or nodeAffinity.  However, there are 	cases in which CNFs require specialized hardware specific to a particular class of Node.  As such, this test is purely 	informative, and will not prevent a CNF from being certified. However, one should have an appropriate justification as 	to why nodeSelector and/or nodeAffinity is utilized by a CNF.
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2
+Exception Process|There is no documented exception process for this.
+Tags|common
+#### pod-toleration-bypass
+
+Property|Description
+---|---
+Test Case Name|pod-toleration-bypass
+Test Case Label|lifecycle-pod-toleration-bypass
+Unique ID|http://test-network-function.com/testcases/lifecycle/pod-toleration-bypass
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/lifecycle/pod-toleration-bypass Check that pods do not have NoExecute, PreferNoSchedule, or NoSchedule tolerations that have been modified from the default.
+Result Type|normative
+Suggested Remediation|Do not allow pods to bypass the NoExecute, PreferNoSchedule, or NoSchedule tolerations that are default applied by Kubernetes.
+Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 10.6
 Exception Process|There is no documented exception process for this.
 Tags|common
 #### readiness-probe

--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -26,7 +26,6 @@ import (
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/accesscontrol/rbac"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/accesscontrol/resources"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/accesscontrol/securitycontextcontainer"
-	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/accesscontrol/tolerations"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/common"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/identifiers"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/networking/netutil"
@@ -164,11 +163,6 @@ var _ = ginkgo.Describe(common.AccessControlTestKey, func() {
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
 		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
 		TestNamespaceResourceQuota(&env)
-	})
-	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestPodTolerationBypassIdentifier)
-	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
-		TestPodTolerationBypass(&env)
 	})
 	// ssh daemons
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestNoSSHDaemonsAllowedIdentifier)
@@ -542,23 +536,6 @@ func TestNamespaceResourceQuota(env *provider.TestEnvironment) {
 	}
 
 	testhelper.AddTestResultLog("Non-compliant", namespacesMissingQuotas, tnf.ClaimFilePrintf, ginkgo.Fail)
-}
-
-func TestPodTolerationBypass(env *provider.TestEnvironment) {
-	var podsWithRestrictedTolerationsNotDefault []string
-
-	for _, put := range env.Pods {
-		for _, t := range put.Spec.Tolerations {
-			// Check if the tolerations fall outside the 'default' and are modified versions
-			// Take also into account the qosClass applied to the pod
-			if tolerations.IsTolerationModified(t, put.Status.QOSClass) {
-				podsWithRestrictedTolerationsNotDefault = append(podsWithRestrictedTolerationsNotDefault, put.String())
-				tnf.ClaimFilePrintf("%s has been found with non-default toleration %s which is not allowed.", put.String(), t.Effect)
-			}
-		}
-	}
-
-	testhelper.AddTestResultLog("Non-compliant", podsWithRestrictedTolerationsNotDefault, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 const (

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -605,7 +605,7 @@ var (
 	}
 	TestPodTolerationBypassIdentifier = claim.Identifier{
 		Tags:    formTestTags(TagCommon),
-		Url:     formTestURL(common.AccessControlTestKey, "pod-toleration-bypass"),
+		Url:     formTestURL(common.LifecycleTestKey, "pod-toleration-bypass"),
 		Version: VersionOne,
 	}
 	TestPersistentVolumeReclaimPolicyIdentifier = claim.Identifier{
@@ -1341,7 +1341,7 @@ that there are no changes to the following directories:
 	},
 	TestPodTolerationBypassIdentifier: {
 		Identifier:            TestPodTolerationBypassIdentifier,
-		Type:                  InformativeResult,
+		Type:                  NormativeResult,
 		Description:           formDescription(TestPodTolerationBypassIdentifier, `Check that pods do not have NoExecute, PreferNoSchedule, or NoSchedule tolerations that have been modified from the default.`),
 		Remediation:           PodTolerationBypassRemediation,
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 10.6",

--- a/cnf-certification-test/lifecycle/suite_test.go
+++ b/cnf-certification-test/lifecycle/suite_test.go
@@ -15,3 +15,82 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package lifecycle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
+)
+
+func TestNameInDeploymentSkipList(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		testNamespace  string
+		testList       []configuration.SkipScalingTestDeploymentsInfo
+		expectedOutput bool
+	}{
+		{
+			testName:      "test1",
+			testNamespace: "tnf",
+			testList: []configuration.SkipScalingTestDeploymentsInfo{
+				{
+					Name:      "test1",
+					Namespace: "tnf",
+				},
+			},
+			expectedOutput: true,
+		},
+		{
+			testName:      "test2",
+			testNamespace: "tnf",
+			testList: []configuration.SkipScalingTestDeploymentsInfo{
+				{
+					Name:      "test1",
+					Namespace: "tnf",
+				},
+			},
+			expectedOutput: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedOutput, nameInDeploymentSkipList(tc.testName, tc.testNamespace, tc.testList))
+	}
+}
+
+func TestNameInStatefulSetSkipList(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		testNamespace  string
+		testList       []configuration.SkipScalingTestStatefulSetsInfo
+		expectedOutput bool
+	}{
+		{
+			testName:      "test1",
+			testNamespace: "tnf",
+			testList: []configuration.SkipScalingTestStatefulSetsInfo{
+				{
+					Name:      "test1",
+					Namespace: "tnf",
+				},
+			},
+			expectedOutput: true,
+		},
+		{
+			testName:      "test2",
+			testNamespace: "tnf",
+			testList: []configuration.SkipScalingTestStatefulSetsInfo{
+				{
+					Name:      "test1",
+					Namespace: "tnf",
+				},
+			},
+			expectedOutput: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedOutput, nameInStatefulSetSkipList(tc.testName, tc.testNamespace, tc.testList))
+	}
+}

--- a/cnf-certification-test/lifecycle/tolerations/tolerations.go
+++ b/cnf-certification-test/lifecycle/tolerations/tolerations.go
@@ -17,6 +17,8 @@
 package tolerations
 
 import (
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -46,6 +48,11 @@ func IsTolerationModified(t corev1.Toleration, qosClass corev1.PodQOSClass) bool
 	//   key: node.kubernetes.io/memory-pressure
 	//   operator: Exists
 
+	// Short circuit.  Anything that is not 'node.kubernetes.io' is considered a modified toleration immediately.
+	if !IsTolerationDefault(t) {
+		return true
+	}
+
 	if t.Effect == corev1.TaintEffectNoExecute {
 		if t.Key == notReadyStr || t.Key == unreachableStr &&
 			(t.Operator == corev1.TolerationOpExists && t.TolerationSeconds != nil && *t.TolerationSeconds == int64(tolerationSecondsDefault)) {
@@ -69,4 +76,8 @@ func IsTolerationModified(t corev1.Toleration, qosClass corev1.PodQOSClass) bool
 	}
 
 	return false
+}
+
+func IsTolerationDefault(t corev1.Toleration) bool {
+	return strings.Contains(t.Key, "node.kubernetes.io")
 }

--- a/cnf-certification-test/lifecycle/tolerations/tolerations_test.go
+++ b/cnf-certification-test/lifecycle/tolerations/tolerations_test.go
@@ -104,9 +104,43 @@ func TestIsTolerationModified(t *testing.T) {
 			expectedOutput: true,
 			qosClass:       corev1.PodQOSBestEffort,
 		},
+		{ // Test Case #8 - Custom toleration - fails due to using a NoExecute taint
+			testToleration: corev1.Toleration{
+				Key:               "custom-toleration/test1",
+				Operator:          corev1.TolerationOpExists,
+				Effect:            corev1.TaintEffectNoExecute,
+				TolerationSeconds: getInt64Pointer(300),
+			},
+			expectedOutput: true,
+			qosClass:       corev1.PodQOSGuaranteed,
+		},
 	}
 
 	for _, tc := range testCases {
 		assert.Equal(t, tc.expectedOutput, IsTolerationModified(tc.testToleration, tc.qosClass))
+	}
+}
+
+func TestIsTolerationDefault(t *testing.T) {
+	testCases := []struct {
+		testToleration corev1.Toleration
+		expectedOutput bool
+	}{
+		{
+			testToleration: corev1.Toleration{
+				Key: "node.kubernetes.io/test1",
+			},
+			expectedOutput: true,
+		},
+		{
+			testToleration: corev1.Toleration{
+				Key: "this.is.a.test/test1",
+			},
+			expectedOutput: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedOutput, IsTolerationDefault(tc.testToleration))
 	}
 }


### PR DESCRIPTION
Notable changes:
- Switched existing "toleration" test from access-control to lifecycle suite and changed it to a NormativeResult instead of InformativeResult.
- Added test case to existing `TestIsTolerationModified` func for a custom key.
- BONUS: Added two more unit tests in `cnf-certification-test/lifecycle/suite_test.go`.