### PR TITLE
Split capabilities test up into separate tests

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -205,60 +205,33 @@ var _ = ginkgo.Describe(common.AccessControlTestKey, func() {
 	})
 })
 
-func TestSysAdminCapability(env *provider.TestEnvironment) {
+func checkForbiddenCapability(containers []*provider.Container, capability string) []string {
 	var badContainers []string
-	for _, cut := range env.Containers {
+	for _, cut := range containers {
 		if cut.SecurityContext != nil && cut.SecurityContext.Capabilities != nil {
-			if strings.Contains(cut.SecurityContext.Capabilities.String(), "SYS_ADMIN") {
-				tnf.ClaimFilePrintf("Non compliant SYS_ADMIN capability detected in container %s. All container caps: %s", cut.String(), cut.SecurityContext.Capabilities.String())
+			if strings.Contains(cut.SecurityContext.Capabilities.String(), capability) {
+				tnf.ClaimFilePrintf("Non compliant %s capability detected in container %s. All container caps: %s", capability, cut.String(), cut.SecurityContext.Capabilities.String())
 				badContainers = append(badContainers, cut.String())
 			}
 		}
 	}
+	return badContainers
+}
 
-	testhelper.AddTestResultLog("Non-compliant", badContainers, tnf.ClaimFilePrintf, ginkgo.Fail)
+func TestSysAdminCapability(env *provider.TestEnvironment) {
+	testhelper.AddTestResultLog("Non-compliant", checkForbiddenCapability(env.Containers, "SYS_ADMIN"), tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 func TestNetAdminCapability(env *provider.TestEnvironment) {
-	var badContainers []string
-	for _, cut := range env.Containers {
-		if cut.SecurityContext != nil && cut.SecurityContext.Capabilities != nil {
-			if strings.Contains(cut.SecurityContext.Capabilities.String(), "NET_ADMIN") {
-				tnf.ClaimFilePrintf("Non compliant NET_ADMIN capability detected in container %s. All container caps: %s", cut.String(), cut.SecurityContext.Capabilities.String())
-				badContainers = append(badContainers, cut.String())
-			}
-		}
-	}
-
-	testhelper.AddTestResultLog("Non-compliant", badContainers, tnf.ClaimFilePrintf, ginkgo.Fail)
+	testhelper.AddTestResultLog("Non-compliant", checkForbiddenCapability(env.Containers, "NET_ADMIN"), tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 func TestNetRawCapability(env *provider.TestEnvironment) {
-	var badContainers []string
-	for _, cut := range env.Containers {
-		if cut.SecurityContext != nil && cut.SecurityContext.Capabilities != nil {
-			if strings.Contains(cut.SecurityContext.Capabilities.String(), "NET_RAW") {
-				tnf.ClaimFilePrintf("Non compliant NET_RAW capability detected in container %s. All container caps: %s", cut.String(), cut.SecurityContext.Capabilities.String())
-				badContainers = append(badContainers, cut.String())
-			}
-		}
-	}
-
-	testhelper.AddTestResultLog("Non-compliant", badContainers, tnf.ClaimFilePrintf, ginkgo.Fail)
+	testhelper.AddTestResultLog("Non-compliant", checkForbiddenCapability(env.Containers, "NET_RAW"), tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 func TestIpcLockCapability(env *provider.TestEnvironment) {
-	var badContainers []string
-	for _, cut := range env.Containers {
-		if cut.SecurityContext != nil && cut.SecurityContext.Capabilities != nil {
-			if strings.Contains(cut.SecurityContext.Capabilities.String(), "IPC_LOCK") {
-				tnf.ClaimFilePrintf("Non compliant IPC_LOCK capability detected in container %s. All container caps: %s", cut.String(), cut.SecurityContext.Capabilities.String())
-				badContainers = append(badContainers, cut.String())
-			}
-		}
-	}
-
-	testhelper.AddTestResultLog("Non-compliant", badContainers, tnf.ClaimFilePrintf, ginkgo.Fail)
+	testhelper.AddTestResultLog("Non-compliant", checkForbiddenCapability(env.Containers, "IPC_LOCK"), tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 // TestSecConRootUser verifies that the container is not running as root

--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -39,7 +39,6 @@ import (
 )
 
 var (
-	nonCompliantCapabilities = []string{"NET_ADMIN", "SYS_ADMIN", "NET_RAW", "IPC_LOCK"}
 	invalidNamespacePrefixes = []string{
 		"default",
 		"openshift-",
@@ -61,13 +60,34 @@ var _ = ginkgo.Describe(common.AccessControlTestKey, func() {
 		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
 		testContainerSCC(&env)
 	})
-	// Security Context: non-compliant capabilities
-	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestSecConCapabilitiesIdentifier)
+
+	// Security Context: non-compliant capabilities (SYS_ADMIN)
+	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestSysAdminIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
 		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
-		TestSecConCapabilities(&env)
+		TestSysAdminCapability(&env)
 	})
-	// container security context: check if it match one of the 4 categories
+
+	// Security Context: non-compliant capabilities (NET_ADMIN)
+	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestNetAdminIdentifier)
+	ginkgo.It(testID, ginkgo.Label(tags...), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
+		TestNetAdminCapability(&env)
+	})
+
+	// Security Context: non-compliant capabilities (NET_RAW)
+	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestNetRawIdentifier)
+	ginkgo.It(testID, ginkgo.Label(tags...), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
+		TestNetRawCapability(&env)
+	})
+
+	// Security Context: non-compliant capabilities (IPC_LOCK)
+	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestIpcLockIdentifier)
+	ginkgo.It(testID, ginkgo.Label(tags...), func() {
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
+		TestIpcLockCapability(&env)
+	})
 
 	// container security context: non-root user
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestSecConNonRootUserIdentifier)
@@ -185,16 +205,55 @@ var _ = ginkgo.Describe(common.AccessControlTestKey, func() {
 	})
 })
 
-// TestSecConCapabilities verifies that non compliant capabilities are not present
-func TestSecConCapabilities(env *provider.TestEnvironment) {
+func TestSysAdminCapability(env *provider.TestEnvironment) {
 	var badContainers []string
 	for _, cut := range env.Containers {
 		if cut.SecurityContext != nil && cut.SecurityContext.Capabilities != nil {
-			for _, ncc := range nonCompliantCapabilities {
-				if strings.Contains(cut.SecurityContext.Capabilities.String(), ncc) {
-					tnf.ClaimFilePrintf("Non compliant %s capability detected in container %s. All container caps: %s", ncc, cut.String(), cut.SecurityContext.Capabilities.String())
-					badContainers = append(badContainers, cut.String())
-				}
+			if strings.Contains(cut.SecurityContext.Capabilities.String(), "SYS_ADMIN") {
+				tnf.ClaimFilePrintf("Non compliant SYS_ADMIN capability detected in container %s. All container caps: %s", cut.String(), cut.SecurityContext.Capabilities.String())
+				badContainers = append(badContainers, cut.String())
+			}
+		}
+	}
+
+	testhelper.AddTestResultLog("Non-compliant", badContainers, tnf.ClaimFilePrintf, ginkgo.Fail)
+}
+
+func TestNetAdminCapability(env *provider.TestEnvironment) {
+	var badContainers []string
+	for _, cut := range env.Containers {
+		if cut.SecurityContext != nil && cut.SecurityContext.Capabilities != nil {
+			if strings.Contains(cut.SecurityContext.Capabilities.String(), "NET_ADMIN") {
+				tnf.ClaimFilePrintf("Non compliant NET_ADMIN capability detected in container %s. All container caps: %s", cut.String(), cut.SecurityContext.Capabilities.String())
+				badContainers = append(badContainers, cut.String())
+			}
+		}
+	}
+
+	testhelper.AddTestResultLog("Non-compliant", badContainers, tnf.ClaimFilePrintf, ginkgo.Fail)
+}
+
+func TestNetRawCapability(env *provider.TestEnvironment) {
+	var badContainers []string
+	for _, cut := range env.Containers {
+		if cut.SecurityContext != nil && cut.SecurityContext.Capabilities != nil {
+			if strings.Contains(cut.SecurityContext.Capabilities.String(), "NET_RAW") {
+				tnf.ClaimFilePrintf("Non compliant NET_RAW capability detected in container %s. All container caps: %s", cut.String(), cut.SecurityContext.Capabilities.String())
+				badContainers = append(badContainers, cut.String())
+			}
+		}
+	}
+
+	testhelper.AddTestResultLog("Non-compliant", badContainers, tnf.ClaimFilePrintf, ginkgo.Fail)
+}
+
+func TestIpcLockCapability(env *provider.TestEnvironment) {
+	var badContainers []string
+	for _, cut := range env.Containers {
+		if cut.SecurityContext != nil && cut.SecurityContext.Capabilities != nil {
+			if strings.Contains(cut.SecurityContext.Capabilities.String(), "IPC_LOCK") {
+				tnf.ClaimFilePrintf("Non compliant IPC_LOCK capability detected in container %s. All container caps: %s", cut.String(), cut.SecurityContext.Capabilities.String())
+				badContainers = append(badContainers, cut.String())
 			}
 		}
 	}

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -120,6 +120,10 @@ var (
 	TestStartupIdentifier                    claim.Identifier
 	TestShutdownIdentifier                   claim.Identifier
 	TestDpdkCPUPinningExecProbe              claim.Identifier
+	TestSysAdminIdentifier                   claim.Identifier
+	TestNetAdminIdentifier                   claim.Identifier
+	TestNetRawIdentifier                     claim.Identifier
+	TestIpcLockIdentifier                    claim.Identifier
 )
 
 //nolint:funlen
@@ -245,6 +249,50 @@ https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks`,
 		bestPracticeDocV1dot4URL+" Section 4.6.24",
 		TagExtended)
 
+	TestNetAdminIdentifier = AddCatalogEntry(
+		"net-admin-capability-check",
+		common.LifecycleTestKey,
+		`Ensures that containers do not use NET_ADMIN capability`,
+		SecConRemediation,
+		NormativeResult,
+		SecConCapabilitiesExceptionProcess,
+		VersionOne,
+		bestPracticeDocV1dot3URL+" Section 5.2",
+		TagCommon)
+
+	TestSysAdminIdentifier = AddCatalogEntry(
+		"sys-admin-capability-check",
+		common.LifecycleTestKey,
+		`Ensures that containers do not use SYS_ADMIN capability`,
+		SecConRemediation,
+		NormativeResult,
+		SecConCapabilitiesExceptionProcess,
+		VersionOne,
+		bestPracticeDocV1dot3URL+" Section 5.2",
+		TagCommon)
+
+	TestIpcLockIdentifier = AddCatalogEntry(
+		"ipc-lock-capability-check",
+		common.LifecycleTestKey,
+		`Ensures that containers do not use IPC_LOCK capability`,
+		SecConRemediation,
+		NormativeResult,
+		SecConCapabilitiesExceptionProcess,
+		VersionOne,
+		bestPracticeDocV1dot3URL+" Section 5.2",
+		TagCommon)
+
+	TestNetRawIdentifier = AddCatalogEntry(
+		"net-raw-capability-check",
+		common.LifecycleTestKey,
+		`Ensures that containers do not use NET_RAW capability`,
+		SecConRemediation,
+		NormativeResult,
+		SecConCapabilitiesExceptionProcess,
+		VersionOne,
+		bestPracticeDocV1dot3URL+" Section 5.2",
+		TagCommon)
+
 	return Catalog
 }
 
@@ -262,12 +310,6 @@ var (
 	// BaseDomain for the test cases
 	TestIDBaseDomain = url
 
-	// TestSecConCapabilitiesIdentifier tests for non compliant security context capabilities
-	TestSecConCapabilitiesIdentifier = claim.Identifier{
-		Tags:    formTestTags(TagCommon),
-		Url:     formTestURL(common.AccessControlTestKey, "security-context-capabilities-check"),
-		Version: VersionOne,
-	}
 	// TestSecConNonRootUserIdentifier tests that pods or containers are not running with root permissions
 	TestSecConNonRootUserIdentifier = claim.Identifier{
 		Tags:    formTestTags(TagCommon),
@@ -726,29 +768,6 @@ var Catalog = map[claim.Identifier]TestCaseDescription{
 		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
 		Tags:                  TestStateFulSetScalingIdentifier.Tags,
 	},
-	TestSecConCapabilitiesIdentifier: {
-		Identifier:       TestSecConCapabilitiesIdentifier,
-		Type:             NormativeResult,
-		Remediation:      SecConCapabilitiesRemediation,
-		ExceptionProcess: SecConCapabilitiesExceptionProcess,
-		Description: formDescription(TestSecConCapabilitiesIdentifier,
-			`Tests that the following capabilities are not granted:
-			- NET_ADMIN
-			- SYS_ADMIN
-			- NET_RAW
-			- IPC_LOCK
-`),
-		BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
-		Tags:                  TestSecConCapabilitiesIdentifier.Tags,
-	},
-	// TestPodDeleteIdentifier: {
-	// 	Identifier:  TestPodDeleteIdentifier,
-	// 	Type:        NormativeResult,
-	// 	Remediation: `Make sure that the pods can be recreated successfully after deleting them`,
-	// 	Description: formDescription(TestPodDeleteIdentifier,
-	// 		`Using the litmus chaos operator, this test checks that pods are recreated successfully after deleting them.`),
-	// 	BestPracticeReference: bestPracticeDocV1dot3URL + " Section 5.2",
-	// },
 	TestSecConNonRootUserIdentifier: {
 		Identifier:       TestSecConNonRootUserIdentifier,
 		Type:             NormativeResult,


### PR DESCRIPTION
Remove the original test `TestSecConCapabilities` which tested all of the security context capabilities at once, and split them into individual tests.