### PR TITLE
Refactor for the kernel taints test case

### DIFF
--- a/cnf-certification-test/platform/nodetainted/nodetainted.go
+++ b/cnf-certification-test/platform/nodetainted/nodetainted.go
@@ -24,13 +24,13 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
-	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
-	"github.com/test-network-function/cnf-certification-test/pkg/stringhelper"
+	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
 )
 
 // NodeTainted holds information about tainted nodes.
 type NodeTainted struct {
-	ctx *clientsholder.Context
+	ctx  *clientsholder.Context
+	node string
 }
 
 var runCommand = func(ctx *clientsholder.Context, cmd string) (string, error) {
@@ -48,9 +48,10 @@ var runCommand = func(ctx *clientsholder.Context, cmd string) (string, error) {
 }
 
 // NewNodeTainted creates a new NodeTainted tester
-func NewNodeTaintedTester(context *clientsholder.Context) *NodeTainted {
+func NewNodeTaintedTester(context *clientsholder.Context, node string) *NodeTainted {
 	return &NodeTainted{
-		ctx: context,
+		ctx:  context,
+		node: node,
 	}
 }
 
@@ -63,29 +64,13 @@ func (nt *NodeTainted) GetKernelTaintsMask() (uint64, error) {
 	output = strings.ReplaceAll(output, "\r", "")
 	output = strings.ReplaceAll(output, "\t", "")
 
-	// Convert o number.
+	// Convert to number.
 	taintsMask, err := strconv.ParseUint(output, 10, 64) // base 10 and uint64
 	if err != nil {
 		return 0, fmt.Errorf("failed to decode taints mask %q: %w", output, err)
 	}
 
 	return taintsMask, nil
-}
-
-func (nt *NodeTainted) GetModulesFromNode() []string {
-	// Get the 1st column list of the modules running on the node.
-	// Split on the return/newline and get the list of the modules back.
-	command := `chroot /host lsmod | awk '{ print $1 }' | grep -v Module`
-	output, _ := runCommand(nt.ctx, command)
-	output = strings.ReplaceAll(output, "\t", "")
-	moduleList := strings.Split(strings.ReplaceAll(output, "\r\n", "\n"), "\n")
-	return stringhelper.RemoveEmptyStrings(moduleList)
-}
-
-func (nt *NodeTainted) ModuleInTree(moduleName string) bool {
-	command := `chroot /host cat /sys/module/` + moduleName + `/taint`
-	cmdOutput, _ := runCommand(nt.ctx, command)
-	return !strings.Contains(cmdOutput, "O")
 }
 
 type KernelTaint struct {
@@ -107,7 +92,7 @@ var kernelTaints = map[int]KernelTaint{
 	9:  {"kernel issued warning", "W"},
 	10: {"staging driver was loaded", "C"},
 	11: {"workaround for bug in platform firmware applied", "I"},
-	12: {"externally-built (“out-of-tree”) module was loaded", "O"},
+	12: {"externally-built (\"out-of-tree\") module was loaded", "O"},
 	13: {"unsigned module was loaded", "E"},
 	14: {"soft lockup occurred", "L"},
 	15: {"kernel has been live patched", "K"},
@@ -132,10 +117,10 @@ func getTaintMsg(bit int) string {
 	return fmt.Sprintf("reserved (tainted bit %d)", bit)
 }
 
-func DecodeKernelTaints(bitmap uint64) []string {
+func DecodeKernelTaintsFromBitMask(bitmask uint64) []string {
 	taints := []string{}
 	for i := 0; i < 64; i++ {
-		bit := (bitmap >> i) & 1
+		bit := (bitmask >> i) & 1
 		if bit == 1 {
 			taints = append(taints, getTaintMsg(i))
 		}
@@ -143,7 +128,39 @@ func DecodeKernelTaints(bitmap uint64) []string {
 	return taints
 }
 
-func GetBitPosFromLetter(letter string) (int, error) {
+func DecodeKernelTaintsFromLetters(letters string) []string {
+	taints := []string{}
+
+	for _, l := range letters {
+		taintLetter := string(l)
+		found := false
+
+		for i := range kernelTaints {
+			kernelTaint := kernelTaints[i]
+			if strings.Contains(kernelTaint.Letters, taintLetter) {
+				taints = append(taints, fmt.Sprintf("%s (taint letter:%s, bit:%d)",
+					kernelTaint.Description, taintLetter, i))
+				found = true
+				break
+			}
+		}
+
+		// The letter doesn't belong to any known (yet) taint...
+		if !found {
+			taints = append(taints, fmt.Sprintf("unknown taint (letter %s)", taintLetter))
+		}
+	}
+
+	return taints
+}
+
+// getBitPosFromLetter returns the kernel taint bit position (base index 0) of the letter that
+// represents a module's taint.
+func getBitPosFromLetter(letter string) (int, error) {
+	if letter == "" || len(letter) > 1 {
+		return 0, fmt.Errorf("input string must contain one letter")
+	}
+
 	for bit, taint := range kernelTaints {
 		if strings.Contains(taint.Letters, letter) {
 			return bit, nil
@@ -161,7 +178,7 @@ func GetTaintedBitsByModules(tainters map[string]string) (map[int]bool, error) {
 		// Save taint bits from this module.
 		for i := range letters {
 			letter := string(letters[i])
-			bit, err := GetBitPosFromLetter(letter)
+			bit, err := getBitPosFromLetter(letter)
 			if err != nil {
 				return nil, fmt.Errorf("module %s has invalid taint letter %s: %w", tainter, letter, err)
 			}
@@ -190,17 +207,17 @@ func GetOtherTaintedBits(taintsMask uint64, taintedBitsByModules map[int]bool) [
 	return otherTaintedBits
 }
 
-// GetTainterModules runs a command in the node to get all the modules that
-// have set a taint bit. The resturn value maps a module to a string of taint
-// letters. Each letter maps to a single bit in the taint mask.
-func (nt *NodeTainted) GetTainterModules() (map[string]string, error) {
+func (nt *NodeTainted) getAllTainterModules() (map[string]string, error) {
 	const (
+		command = "modules=`ls /sys/module`; for module_name in $modules; do taint_file=/sys/module/$module_name/taint; " +
+			"if [ -f $taint_file ]; then taints=`cat $taint_file`; " +
+			"if [[ ${#taints} -gt 0 ]]; then echo \"$module_name `cat $taint_file`\"; fi; fi; done"
+
 		numFields       = 2
 		posModuleName   = 0
 		posModuleTaints = 1
 	)
 
-	command := "modules=`ls /sys/module`; for module_name in $modules; do taint_file=/sys/module/$module_name/taint; if [ -f $taint_file ]; then taints=`cat $taint_file`; if [[ ${#taints} -gt 0 ]]; then echo \"$module_name `cat $taint_file`\"; fi; fi; done"
 	cmdOutput, err := runCommand(nt.ctx, command)
 	if err != nil {
 		return nil, fmt.Errorf("failed to run command: %w", err)
@@ -224,44 +241,50 @@ func (nt *NodeTainted) GetTainterModules() (map[string]string, error) {
 		moduleName := elems[posModuleName]
 		moduleTaints := elems[posModuleTaints]
 
-		if _, exist := tainters[moduleName]; exist {
-			return nil, fmt.Errorf("module %s (taints %s) has already been parsed", moduleName, moduleTaints)
+		// Save to the all tainters list.
+		if taints, exist := tainters[moduleName]; exist {
+			return nil, fmt.Errorf("module %s (taints %s) has already been parsed (taints %s)",
+				moduleName, moduleTaints, taints)
 		}
 
-		logrus.Infof("module %s has taints %s", moduleName, moduleTaints)
 		tainters[moduleName] = moduleTaints
 	}
 
 	return tainters, nil
 }
 
-func (nt *NodeTainted) GetOutOfTreeModules(modules []string) []string {
-	taintedModules := []string{}
-	for _, module := range modules {
-		logrus.Debug(fmt.Sprintf("Looking for module in tree: %s", module))
-		if !nt.ModuleInTree(module) {
-			taintedModules = append(taintedModules, module)
+// GetTainterModules runs a command in the node to get all the modules that
+// have set a kernel taint bit. Returns:
+//   - tainters: maps a module to a string of taints letters. Each letter maps
+//     to a single bit in the taint mask. Tainters that appear in the whitelist won't
+//     be added to this map.
+//   - taintBits: bits (pos) of kernel taints caused by all modules (included the whitelisted ones).
+func (nt *NodeTainted) GetTainterModules(whiteList map[string]bool) (tainters map[string]string, taintBits map[int]bool, err error) {
+	// First, get all the modules that are tainting the kernel in this node.
+	allTainters, err := nt.getAllTainterModules()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get tainter modules: %w", err)
+	}
+
+	filteredTainters := map[string]string{}
+	for moduleName, moduleTaintsLetters := range allTainters {
+		moduleTaints := DecodeKernelTaintsFromLetters(moduleTaintsLetters)
+		logrus.Debugf("%s: Module %s has taints (%s): %s", nt.node, moduleName, moduleTaintsLetters, moduleTaints)
+
+		// Apply whitelist.
+		if whiteList[moduleName] {
+			tnf.ClaimFilePrintf("%s module %s is tainting the kernel but it has been whitelisted (taints: %v)",
+				nt.node, moduleName, moduleTaints)
+		} else {
+			filteredTainters[moduleName] = moduleTaintsLetters
 		}
 	}
-	return taintedModules
-}
 
-func TaintsAccepted(confTaints []configuration.AcceptedKernelTaintsInfo, taintedModules []string) bool {
-	for _, taintedModule := range taintedModules {
-		found := false
-		logrus.Debug("Accepted Taints from Config: ", confTaints)
-		for _, confTaint := range confTaints {
-			logrus.Debug(fmt.Sprintf("Comparing confTaint: %s to taintedModule: %s", confTaint.Module, taintedModule))
-			if confTaint.Module == taintedModule {
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			// Tainted modules were not found to be in the allow-list.
-			return false
-		}
+	// Finally, get all the bits that all the modules have set.
+	taintBits, err = GetTaintedBitsByModules(allTainters)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get taint bits by modules: %w", err)
 	}
-	return true
+
+	return filteredTainters, taintBits, nil
 }

--- a/cnf-certification-test/platform/nodetainted/nodetainted_test.go
+++ b/cnf-certification-test/platform/nodetainted/nodetainted_test.go
@@ -22,48 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
-	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 )
-
-func TestTaintsAccepted(t *testing.T) {
-	testCases := []struct {
-		confTaints     []configuration.AcceptedKernelTaintsInfo
-		taintedModules []string
-		expected       bool
-	}{
-		{
-			confTaints: []configuration.AcceptedKernelTaintsInfo{
-				{
-					Module: "taint1",
-				},
-			},
-			taintedModules: []string{
-				"taint1",
-			},
-			expected: true,
-		},
-		{
-			confTaints: []configuration.AcceptedKernelTaintsInfo{}, // no accepted modules
-			taintedModules: []string{
-				"taint1",
-			},
-			expected: false,
-		},
-		{ // We have no tainted modules, so the configuration does not matter.
-			confTaints: []configuration.AcceptedKernelTaintsInfo{
-				{
-					Module: "taint1",
-				},
-			},
-			taintedModules: []string{},
-			expected:       true,
-		},
-	}
-
-	for _, tc := range testCases {
-		assert.Equal(t, tc.expected, TaintsAccepted(tc.confTaints, tc.taintedModules))
-	}
-}
 
 //nolint:funlen
 func TestDecodeKernelTaints(t *testing.T) {
@@ -130,83 +89,125 @@ func TestDecodeKernelTaints(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		taints := DecodeKernelTaints(tc.taintsBitMask)
+		taints := DecodeKernelTaintsFromBitMask(tc.taintsBitMask)
 		assert.Equal(t, tc.expectedTaints, taints)
 	}
 }
 
-func TestGetOutOfTreeModules(t *testing.T) {
+func TestDecodeKernelTaintsFromLetters(t *testing.T) {
 	testCases := []struct {
-		testModules            []string
-		expectedTaintedModules []string
-		runCommandOutput       string
+		letters           string
+		expectedTaintBits []string
 	}{
-		{ // output is O
-			testModules:            []string{"module1"},
-			expectedTaintedModules: []string{"module1"},
-			runCommandOutput:       "O", // O means out-of-tree
+		{
+			letters:           "G",
+			expectedTaintBits: []string{"proprietary module was loaded (taint letter:G, bit:0)"},
 		},
-		{ // output is 1 (could be anything)
-			testModules:            []string{"module2"},
-			expectedTaintedModules: []string{},
-			runCommandOutput:       "1",
+		{
+			letters:           "E",
+			expectedTaintBits: []string{"unsigned module was loaded (taint letter:E, bit:13)"},
+		},
+		{
+			letters: "OX",
+			expectedTaintBits: []string{"externally-built (\"out-of-tree\") module was loaded (taint letter:O, bit:12)",
+				"auxiliary taint, defined for and used by distros (taint letter:X, bit:16)"},
+		},
+		// Unknown letter
+		{
+			letters:           "n",
+			expectedTaintBits: []string{"unknown taint (letter n)"},
 		},
 	}
 
 	for _, tc := range testCases {
-		origFunc := runCommand
-		runCommand = func(ctx *clientsholder.Context, cmd string) (string, error) {
-			return tc.runCommandOutput, nil
+		bits := DecodeKernelTaintsFromLetters(tc.letters)
+		assert.Equal(t, tc.expectedTaintBits, bits)
+	}
+}
+
+func TestGetBitPosFromLetter(t *testing.T) {
+	testCases := []struct {
+		letter        string
+		expectedPos   int
+		expectedError string
+	}{
+		{
+			letter:      "G",
+			expectedPos: 0,
+		},
+		{
+			letter:      "E",
+			expectedPos: 13,
+		},
+		{
+			letter:      "O",
+			expectedPos: 12,
+		},
+		{
+			letter:        "OE",
+			expectedError: "input string must contain one letter",
+		},
+		{
+			letter:        "",
+			expectedError: "input string must contain one letter",
+		},
+	}
+
+	for _, tc := range testCases {
+		bitPos, err := getBitPosFromLetter(tc.letter)
+		if err != nil {
+			assert.Equal(t, tc.expectedError, err.Error())
+		} else {
+			assert.Equal(t, tc.expectedError, "")
 		}
-		nt := NewNodeTaintedTester(nil)
-		assert.Equal(t, tc.expectedTaintedModules, nt.GetOutOfTreeModules(tc.testModules))
-		runCommand = origFunc
+		assert.Equal(t, tc.expectedPos, bitPos)
 	}
 }
 
 //nolint:funlen
-func TestGetKernelTaintInfo(t *testing.T) {
+func TestGetKernelTaintsMask(t *testing.T) {
 	testCases := []struct {
 		runCommandOutput   string
 		runCommandError    error
 		expectedTaintsMask uint64
-		expectedError      error
+		expectedErrorMsg   string
 	}{
 		{
 			runCommandOutput:   "0",
 			runCommandError:    nil,
 			expectedTaintsMask: 0,
-			expectedError:      nil,
 		},
 		{
 			runCommandOutput:   "0\n",
 			runCommandError:    nil,
 			expectedTaintsMask: 0,
-			expectedError:      nil,
 		},
 		{
 			runCommandOutput:   "0\r\t",
 			runCommandError:    nil,
 			expectedTaintsMask: 0,
-			expectedError:      nil,
 		},
 		{
 			runCommandOutput:   "1024",
 			runCommandError:    nil,
 			expectedTaintsMask: 1024,
-			expectedError:      nil,
 		},
 		{
 			runCommandOutput:   "65536",
 			runCommandError:    nil,
 			expectedTaintsMask: 65536,
-			expectedError:      nil,
 		},
 		{
 			runCommandOutput:   "test1",
 			runCommandError:    errors.New("this is an error"),
 			expectedTaintsMask: 0,
-			expectedError:      errors.New("this is an error"),
+			expectedErrorMsg:   "this is an error",
+		},
+		{
+			runCommandOutput:   "-1",
+			runCommandError:    nil,
+			expectedTaintsMask: 0,
+			expectedErrorMsg:   "failed to decode taints mask \"-1\": strconv.ParseUint: parsing \"-1\": invalid syntax",
 		},
 	}
 
@@ -215,74 +216,58 @@ func TestGetKernelTaintInfo(t *testing.T) {
 		runCommand = func(ctx *clientsholder.Context, cmd string) (string, error) {
 			return tc.runCommandOutput, tc.runCommandError
 		}
-		nt := NewNodeTaintedTester(nil)
+		nt := NewNodeTaintedTester(nil, "fake-node-name")
 		result, err := nt.GetKernelTaintsMask()
 		assert.Equal(t, tc.expectedTaintsMask, result)
-		assert.Equal(t, err, tc.expectedError)
-		runCommand = origFunc
-	}
-}
-
-func TestGetModulesFromNode(t *testing.T) {
-	testCases := []struct {
-		runCommandOutput string
-		runCommandError  error
-		expectedOutput   []string
-	}{
-		{
-			runCommandOutput: "module1\nmodule2\nmodule3",
-			runCommandError:  nil,
-			expectedOutput:   []string{"module1", "module2", "module3"},
-		},
-		{
-			runCommandOutput: "\tmodule1\nmodule2",
-			runCommandError:  nil,
-			expectedOutput:   []string{"module1", "module2"},
-		},
-	}
-
-	for _, tc := range testCases {
-		origFunc := runCommand
-		runCommand = func(ctx *clientsholder.Context, cmd string) (string, error) {
-			return tc.runCommandOutput, tc.runCommandError
+		if err != nil {
+			assert.Equal(t, tc.expectedErrorMsg, err.Error())
+		} else {
+			assert.Equal(t, tc.expectedErrorMsg, "")
 		}
-		nt := NewNodeTaintedTester(nil)
-		assert.Equal(t, tc.expectedOutput, nt.GetModulesFromNode())
 
 		runCommand = origFunc
 	}
 }
 
-func TestGetTainterModules(t *testing.T) {
+//nolint:funlen
+func TestGetAllTainterModules(t *testing.T) {
 	testCases := []struct {
 		runCommandOutput string
 		runCommandError  error
-		expectedOutput   map[string]string
+		expectedTainters map[string]string
+		expectedErrorMsg string
 	}{
 		{
 			runCommandOutput: "module1 O",
-			runCommandError:  nil,
-			expectedOutput:   map[string]string{"module1": "O"},
+			expectedTainters: map[string]string{"module1": "O"},
 		},
 		{
-			runCommandOutput: "module1 O\nmodule2 E\n",
-			runCommandError:  nil,
-			expectedOutput:   map[string]string{"module1": "O", "module2": "E"},
+			runCommandOutput: "module1 O\nmodule2 E",
+			expectedTainters: map[string]string{"module1": "O", "module2": "E"},
 		},
 		{
-			runCommandOutput: "module1 OE\nmodule2 O\nmodule3 E",
-			runCommandError:  nil,
-			expectedOutput:   map[string]string{"module1": "OE", "module2": "O", "module3": "E"},
-		},
-		{
-			runCommandOutput: "",
-			runCommandError:  nil,
-			expectedOutput:   map[string]string{},
+			runCommandOutput: "module1 OE\nmodule2 E",
+			expectedTainters: map[string]string{"module1": "OE", "module2": "E"},
 		},
 		{
 			runCommandOutput: "\n",
-			runCommandError:  nil,
-			expectedOutput:   map[string]string{},
+			expectedTainters: map[string]string{},
+		},
+		{
+			runCommandOutput: "",
+			expectedTainters: map[string]string{},
+		},
+		{
+			runCommandOutput: "module1",
+			expectedErrorMsg: "failed to parse line \"module1\" (output=module1)",
+		},
+		{
+			runCommandOutput: "moduleAppearsTwice E\nmoduleAppearsTwice O",
+			expectedErrorMsg: "module moduleAppearsTwice (taints O) has already been parsed (taints E)",
+		},
+		{
+			runCommandError:  errors.New("fake error running command in container"),
+			expectedErrorMsg: "failed to run command: fake error running command in container",
 		},
 	}
 
@@ -291,11 +276,204 @@ func TestGetTainterModules(t *testing.T) {
 		runCommand = func(ctx *clientsholder.Context, cmd string) (string, error) {
 			return tc.runCommandOutput, tc.runCommandError
 		}
-		nt := NewNodeTaintedTester(nil)
-		tainters, err := nt.GetTainterModules()
-		assert.Nil(t, err)
-		assert.Equal(t, tc.expectedOutput, tainters)
+		nt := NewNodeTaintedTester(nil, "fake-node-name")
+		tainters, err := nt.getAllTainterModules()
+		if err != nil {
+			assert.Equal(t, tc.expectedErrorMsg, err.Error())
+		} else {
+			assert.Equal(t, tc.expectedErrorMsg, "")
+		}
+		assert.Equal(t, tc.expectedTainters, tainters)
 
 		runCommand = origFunc
+	}
+}
+
+//nolint:funlen
+func TestGetTainterModules(t *testing.T) {
+	testCases := []struct {
+		runCommandOutput  string
+		whiteList         map[string]bool
+		expectedTainters  map[string]string
+		expectedTaintBits map[int]bool
+		expectedErrorMsg  string
+	}{
+		{
+			runCommandOutput:  "module1 O",
+			expectedTainters:  map[string]string{"module1": "O"},
+			expectedTaintBits: map[int]bool{12: true},
+		},
+		{
+			runCommandOutput:  "module1 O\nmodule2 E\n",
+			expectedTainters:  map[string]string{"module1": "O", "module2": "E"},
+			expectedTaintBits: map[int]bool{12: true, 13: true},
+		},
+		{
+			runCommandOutput:  "module1 OE\nmodule2 O\nmodule3 E",
+			expectedTainters:  map[string]string{"module1": "OE", "module2": "O", "module3": "E"},
+			expectedTaintBits: map[int]bool{12: true, 13: true},
+		},
+		{
+			runCommandOutput:  "module1 OE\nmodule2 O\nmodule3 E",
+			expectedTainters:  map[string]string{"module1": "OE", "module2": "O", "module3": "E"},
+			expectedTaintBits: map[int]bool{12: true, 13: true},
+		},
+		// Whitelist usage 1
+		{
+			runCommandOutput:  "module1 OE\nmodule2 O\nmodule3 E",
+			whiteList:         map[string]bool{"module2": true},
+			expectedTainters:  map[string]string{"module1": "OE", "module3": "E"},
+			expectedTaintBits: map[int]bool{12: true, 13: true},
+		},
+		// Whitelist usage 2
+		{
+			runCommandOutput:  "module2 O\nmodule3 E",
+			whiteList:         map[string]bool{"module2": true, "module3": true},
+			expectedTainters:  map[string]string{},
+			expectedTaintBits: map[int]bool{12: true, 13: true},
+		},
+		{
+			runCommandOutput:  "",
+			expectedTainters:  map[string]string{},
+			expectedTaintBits: map[int]bool{},
+		},
+		{
+			runCommandOutput:  "\n",
+			expectedTainters:  map[string]string{},
+			expectedTaintBits: map[int]bool{},
+		},
+		// Error checking
+		{
+			runCommandOutput: "module1",
+			expectedErrorMsg: "failed to get tainter modules: failed to parse line \"module1\" (output=module1)",
+		},
+		{
+			runCommandOutput: "module1 E\nmodule2 J",
+			expectedErrorMsg: "failed to get taint bits by modules: module module2 has invalid taint letter J: letter J does not belong to any known kernel taint",
+		},
+	}
+
+	for _, tc := range testCases {
+		origFunc := runCommand
+		runCommand = func(ctx *clientsholder.Context, cmd string) (string, error) {
+			// Make the command to never return error.
+			return tc.runCommandOutput, nil
+		}
+		nt := NewNodeTaintedTester(nil, "fake-node-name")
+		tainters, taintBitsByAllModules, err := nt.GetTainterModules(tc.whiteList)
+		if err != nil {
+			assert.Equal(t, tc.expectedErrorMsg, err.Error())
+		} else {
+			assert.Equal(t, tc.expectedErrorMsg, "")
+		}
+		assert.Equal(t, tc.expectedTainters, tainters)
+		assert.Equal(t, tc.expectedTaintBits, taintBitsByAllModules)
+
+		runCommand = origFunc
+	}
+}
+
+//nolint:funlen
+func TestGetTaintedBitsByModules(t *testing.T) {
+	testCases := []struct {
+		modules           map[string]string
+		expectedTaintBits map[int]bool
+		expectedError     string
+	}{
+		// Bit 0 (G)
+		{
+			modules:           map[string]string{"module1": "G"},
+			expectedTaintBits: map[int]bool{0: true},
+		},
+		{
+			modules:           map[string]string{"module1": "P"},
+			expectedTaintBits: map[int]bool{0: true},
+		},
+		// Bit 12 (O)
+		{
+			modules:           map[string]string{"module1": "O"},
+			expectedTaintBits: map[int]bool{12: true},
+		},
+		// Bits 0 & 12
+		{
+			modules:           map[string]string{"module1": "GO"},
+			expectedTaintBits: map[int]bool{0: true, 12: true},
+		},
+		// Bits 0 & 12 from two modules.
+		{
+			modules:           map[string]string{"module1": "GO", "module2": "O"},
+			expectedTaintBits: map[int]bool{0: true, 12: true},
+		},
+		// Bits 0 & 12 from two modules, plus bit 15 (K)
+		{
+			modules:           map[string]string{"module1": "GO", "module2": "O", "module3": "K"},
+			expectedTaintBits: map[int]bool{0: true, 12: true, 15: true},
+		},
+		// Unknown letter.
+		{
+			modules:           map[string]string{"module1": "n"},
+			expectedTaintBits: nil,
+			expectedError:     "module module1 has invalid taint letter n: letter n does not belong to any known kernel taint",
+		},
+		// RH's tech preview bit 29 (T)
+		{
+			modules:           map[string]string{"rhModule": "H"},
+			expectedTaintBits: map[int]bool{28: true},
+		},
+	}
+
+	for _, tc := range testCases {
+		bits, err := GetTaintedBitsByModules(tc.modules)
+		if err != nil {
+			assert.Equal(t, tc.expectedError, err.Error())
+		} else {
+			assert.Equal(t, tc.expectedError, "")
+		}
+		assert.Equal(t, tc.expectedTaintBits, bits)
+	}
+}
+
+func TestGetOtherTaintedBits(t *testing.T) {
+	testCases := []struct {
+		taintsMask           uint64
+		taintedBitsByModules map[int]bool
+		expectedBits         []int
+	}{
+		{
+			taintsMask:           0,
+			taintedBitsByModules: map[int]bool{},
+			expectedBits:         []int{},
+		},
+		{
+			taintsMask:           1 << 0,
+			taintedBitsByModules: map[int]bool{0: true},
+			expectedBits:         []int{},
+		},
+		// Bits tainted by modules: 0
+		// Bits not tainted by modules: 1
+		{
+			taintsMask:           (1 << 0) | (1 << 1),
+			taintedBitsByModules: map[int]bool{0: true},
+			expectedBits:         []int{1},
+		},
+		// Bits tainted by modules: 0, 1
+		// Bits not tainted by modules: 2
+		{
+			taintsMask:           (1 << 0) | (1 << 1) | (1 << 2),
+			taintedBitsByModules: map[int]bool{0: true, 1: true},
+			expectedBits:         []int{2},
+		},
+		// Bits tainted by modules: none
+		// Bits not tainted by modules: 0, 1, 2
+		{
+			taintsMask:           (1 << 0) | (1 << 1) | (1 << 2),
+			taintedBitsByModules: map[int]bool{},
+			expectedBits:         []int{0, 1, 2},
+		},
+	}
+
+	for _, tc := range testCases {
+		bits := GetOtherTaintedBits(tc.taintsMask, tc.taintedBitsByModules)
+		assert.Equal(t, tc.expectedBits, bits)
 	}
 }

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -18,7 +18,6 @@ package platform
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -207,100 +206,97 @@ func testContainersFsDiff(env *provider.TestEnvironment) {
 
 //nolint:funlen
 func testTainted(env *provider.TestEnvironment) {
-	var taintedNodes []string
-	var errNodes []string
+	// errNodes has nodes that failed some operation while checking kernel taints.
+	errNodes := []string{}
+	// badModules maps node names to list of "bad"/offending modules.
+	badModules := map[string][]string{}
+	// otherTaints maps a node to a list of taint bits that haven't been set by any module.
+	otherTaints := map[string][]int{}
 
 	// Loop through the debug pods that are tied to each node.
 	for _, dp := range env.DebugPods {
-		// Create OCP context to pass around
+		nodeName := dp.Spec.NodeName
+
 		ocpContext := clientsholder.NewContext(dp.Namespace, dp.Name, dp.Spec.Containers[0].Name)
 		tf := nodetainted.NewNodeTaintedTester(&ocpContext)
 
-		// Get the taint information from the node kernel
-		taintInfo, err := tf.GetKernelTaintInfo()
+		// Get the taints mask from the node kernel
+		taintsMask, err := tf.GetKernelTaintsMask()
 		if err != nil {
-			logrus.Error("failed to retrieve kernel taint information from debug pod/host")
-			tnf.ClaimFilePrintf("failed to retrieve kernel taint information from debug pod/host")
-			errNodes = append(errNodes, dp.Name)
-			break
-		}
-		tnf.ClaimFilePrintf(fmt.Sprintf("Namespace: %s Pod: %s taintInfo retrieved: %s", dp.Namespace, dp.Name, taintInfo))
-
-		var taintedBitmap uint64
-		nodeTaintsAccepted := true
-		taintedBitmap, err = strconv.ParseUint(taintInfo, 10, 64) // base 10 and uint64
-
-		if err != nil {
-			logrus.Errorf("failed to parse uint with: %s", err)
-			tnf.ClaimFilePrintf("Could not decode tainted kernel causes (code=%d) for node %s\n", taintedBitmap, dp.Name)
-			errNodes = append(errNodes, dp.Name)
-			break
+			tnf.ClaimFilePrintf("Failed to retrieve kernel taint information from node %s: %v", nodeName, err)
+			errNodes = append(errNodes, nodeName)
+			continue
 		}
 
-		taints := nodetainted.DecodeKernelTaints(taintedBitmap)
-		// Count how many taints come from `module was loaded` taints versus `other`
-		logrus.Debug("Checking for 'module was loaded' taints")
-		logrus.Debugf("Taints found: %v", taints)
-		moduleTaintsFound := false
-		otherTaintsFound := false
+		if taintsMask == 0 {
+			tnf.ClaimFilePrintf("Node %s has no kernel taints.", nodeName)
+			// This node has no taints.
+			continue
+		}
 
-		otherTaints := []string{}
-		for _, it := range taints {
-			if strings.Contains(it, `module was loaded`) {
-				moduleTaintsFound = true
-			} else {
-				otherTaintsFound = true
-				otherTaints = append(otherTaints, it)
+		tnf.ClaimFilePrintf("Node %s kernel is tainted. Taints mask=%d - Decoded taints: %v",
+			nodeName, taintsMask, nodetainted.DecodeKernelTaints(taintsMask))
+
+		// Check the white list. If empty, mark this node as failed.
+		if len(env.Config.AcceptedKernelTaints) == 0 {
+			errNodes = append(errNodes, nodeName)
+			continue
+		}
+
+		// White list check.
+		// Get the list of modules (tainters) that have set a taint bit.
+		//   - 1. Each module should appear in the white list.
+		//   - 2. All kernel taint bits (1 bit - 1 letter) should have been set by at least
+		//        one tainter module.
+		tainters, err := tf.GetTainterModules()
+		if err != nil {
+			tnf.ClaimFilePrintf("failed to get tainter modules from node %s: %v", nodeName, err)
+			errNodes = append(errNodes, nodeName)
+			continue
+		}
+
+		// helper map to make the checks easier.
+		whiteListedModules := map[string]bool{}
+		for _, module := range env.Config.AcceptedKernelTaints {
+			whiteListedModules[module.Module] = true
+		}
+
+		badNodeModules := []string{}
+		for tainter := range tainters {
+			// If module is not in the whitelist, mark it as offender.
+			if _, exist := whiteListedModules[tainter]; !exist {
+				badNodeModules = append(badNodeModules, tainter)
 			}
 		}
 
-		if otherTaintsFound {
-			nodeTaintsAccepted = false
-
-			// Surface more information about tainted kernel failures that have nothing to do with modules.
-			tnf.ClaimFilePrintf("Please note that taints other than 'module was loaded' were found on node %s.", dp.Spec.NodeName)
-			logrus.Debugf("Please note that taints other than 'module was loaded' were found on node %s.", dp.Spec.NodeName)
-			for _, ot := range otherTaints {
-				tnf.ClaimFilePrintf("Taint causing failure: %s on node: %s", ot, dp.Spec.NodeName)
-				logrus.Debugf("Taint causing failure: %s on node: %s", ot, dp.Spec.NodeName)
-			}
-		} else if moduleTaintsFound {
-			// Retrieve the modules from the node (via the debug pod)
-			modules := tf.GetModulesFromNode()
-			logrus.Debugf("Got the modules from node %s: %v", dp.Name, modules)
-
-			// Retrieve all of the out of tree modules.
-			taintedModules := tf.GetOutOfTreeModules(modules)
-			logrus.Debug("Collected all of the tainted modules: ", taintedModules)
-			logrus.Debug("Modules allowed via configuration: ", env.Config.AcceptedKernelTaints)
-
-			// Looks through the accepted taints listed in the tnf-config file.
-			// If all of the tainted modules show up in the configuration file, do not fail the test.
-			nodeTaintsAccepted = nodetainted.TaintsAccepted(env.Config.AcceptedKernelTaints, taintedModules)
+		if len(badNodeModules) > 0 {
+			badModules[nodeName] = badNodeModules
 		}
 
-		// Only add the tainted node to the slice if the taint is acceptable.
-		if !nodeTaintsAccepted {
-			taintedNodes = append(taintedNodes, dp.Name)
+		taintedBitsByModules, err := nodetainted.GetTaintedBitsByModules(tainters)
+		if err != nil {
+			tnf.ClaimFilePrintf("failed to get tainter modules from node %s: %v", nodeName, err)
+			errNodes = append(errNodes, nodeName)
+			continue
 		}
 
-		// Only print the message if there is something to report failure or tainted node wise.
-		if len(taintedNodes) != 0 || len(errNodes) != 0 {
-			tnf.ClaimFilePrintf("Decoded tainted kernel causes (code=%d) for node %s : %s\n", taintedBitmap, dp.Name, strings.Join(taints, ","))
+		// Lastly, check that all kernel taint bits come from modules.
+		otherTaints[nodeName] = nodetainted.GetOtherTaintedBits(taintsMask, taintedBitsByModules)
+		for _, taintedBit := range otherTaints[nodeName] {
+			tnf.ClaimFilePrintf("Node %s - taint bit %d is set but it's not caused by any module.", nodeName, taintedBit)
 		}
 	}
 
-	// We are expecting tainted nodes to be Nil, but only if:
-	// 1) The reason for the tainted node is contains(`module was loaded`)
-	// 2) The modules loaded are all whitelisted.
-	if len(taintedNodes) > 0 {
-		tnf.ClaimFilePrintf("Nodes have been found to be tainted: %v", taintedNodes)
-		ginkgo.Fail("Nodes have been found to be tainted.")
-	}
+	logrus.Infof("Nodes with errors: %+v", errNodes)
+	logrus.Infof("Bad Modules: %+v", badModules)
+	logrus.Infof("Taints not related to any module: %+v", otherTaints)
 
 	if len(errNodes) > 0 {
-		tnf.ClaimFilePrintf("Nodes have been found to be tainted: %v", taintedNodes)
-		ginkgo.Fail("Nodes have been found to be tainted.")
+		ginkgo.Fail(fmt.Sprintf("Failed to get kernel taints from some nodes: %+v", errNodes))
+	}
+
+	if len(badModules) > 0 || len(otherTaints) > 0 {
+		ginkgo.Fail("Nodes have been found to be tainted. Check claim log for more details.")
 	}
 }
 


### PR DESCRIPTION
This is a proposal to make the whitelist for kernel taints more flexible.

The whitelist in the previous implementation was for taints related to out-of-tree modules. This commit tries to make the whitelist to work for any bit, including the RedHat's ones.

First, I get the list of modules that have any taint letter, reading the /sys/module/module_name/taint files. When the module is responsible for a taint bit, that module will have a string letters associated to the taints. If any of those modules doesn't appear in the whitelist, the test fails.

Finally, we need to make sure there are no other taint bits active, because some of them can be active for other reasons not related to kernel modules (e.g. bit 11).

Also, updated description for taint bit 31.