### PR TITLE
Prepare for v4.1.3 release

### DIFF
--- a/docs/test-container.md
+++ b/docs/test-container.md
@@ -98,8 +98,8 @@ export TNF_CONTAINER_CLIENT=docker
 ### Build locally
 
 ```shell
-podman build -t cnf-certification-test:v4.1.2 \
-  --build-arg TNF_VERSION=v4.1.2 \
+podman build -t cnf-certification-test:v4.1.3 \
+  --build-arg TNF_VERSION=v4.1.3 \
 ```
 
   - `TNF_VERSION` value is set to a branch, a tag, or a hash of a commit that will be installed into the image
@@ -112,8 +112,8 @@ The unofficial source could be a fork of the TNF repository.
 Use the `TNF_SRC_URL` build argument to override the URL to a source repository.
 
 ```shell
-podman build -t cnf-certification-test:v4.1.2 \
-  --build-arg TNF_VERSION=v4.1.2 \
+podman build -t cnf-certification-test:v4.1.3 \
+  --build-arg TNF_VERSION=v4.1.3 \
   --build-arg TNF_SRC_URL=https://github.com/test-network-function/cnf-certification-test .
 ```
 
@@ -122,7 +122,7 @@ podman build -t cnf-certification-test:v4.1.2 \
 Specify the custom TNF image using the `-i` parameter.
 
 ```shell
-./run-tnf-container.sh -i cnf-certification-test:v4.1.2
+./run-tnf-container.sh -i cnf-certification-test:v4.1.3
 -t ~/tnf/config -o ~/tnf/output -l "networking,access-control"
 ```
  Note: see [General tests](test-spec.md#general-tests) for a list of available keywords.

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "partner_tag": "v4.1.2"
+  "partner_tag": "v4.1.3"
 }


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test-partner/releases/tag/v4.1.3