### PR TITLE
Build KubeConfig byte array

### DIFF
--- a/cnf-certification-test/suite_test.go
+++ b/cnf-certification-test/suite_test.go
@@ -122,14 +122,6 @@ func getGitVersion() string {
 	return gitDisplayRelease + " ( " + GitCommit + " )"
 }
 
-func deleteMergedKubeConfigfile(file string) {
-	log.Infof("Deleting merged kube config file %s", file)
-	err := os.Remove(file)
-	if err != nil {
-		log.Errorf("Failed to delete merged kube config file %s: %s", file, err)
-	}
-}
-
 //nolint:funlen // TestTest invokes the CNF Certification Test Suite.
 func TestTest(t *testing.T) {
 	// When running unit tests, skip the suite
@@ -156,10 +148,7 @@ func TestTest(t *testing.T) {
 	}
 
 	// Set clientsholder singleton with the filenames from the env vars.
-	client := clientsholder.GetClientsHolder(getK8sClientsConfigFileNames()...)
-
-	// Make sure the temp file for the merged kube config is deleted at the end.
-	defer deleteMergedKubeConfigfile(client.MergedKubeConfigFile)
+	_ = clientsholder.GetClientsHolder(getK8sClientsConfigFileNames()...)
 
 	// Deploy the daemonset before getting the environment for the first time
 	err := daemonset.DeployPartnerTestDaemonset()

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -171,7 +171,7 @@ func createTempFile(prefix string) (file *os.File, err error) {
 func createByteArrayKubeConfig(kubeConfig *clientcmdapi.Config) ([]byte, error) {
 	yamlBytes, err := clientcmd.Write(*kubeConfig)
 	if err != nil {
-		return []byte{}, fmt.Errorf("failed to generate yaml bytes from kubeconfig: %w", err)
+		return nil, fmt.Errorf("failed to generate yaml bytes from kubeconfig: %w", err)
 	}
 	return yamlBytes, nil
 }

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -18,8 +18,6 @@ package clientsholder
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"time"
 
 	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
@@ -46,17 +44,17 @@ import (
 )
 
 type ClientsHolder struct {
-	RestConfig           *rest.Config
-	DynamicClient        dynamic.Interface
-	APIExtClient         apiextv1.Interface
-	OlmClient            olmClient.Interface
-	OcpClient            clientconfigv1.ConfigV1Interface
-	K8sClient            kubernetes.Interface
-	K8sNetworkingClient  networkingv1.NetworkingV1Interface
-	MachineCfg           ocpMachine.Interface
-	MergedKubeConfigFile string
-	KubeConfig           []byte
-	ready                bool
+	RestConfig          *rest.Config
+	DynamicClient       dynamic.Interface
+	APIExtClient        apiextv1.Interface
+	OlmClient           olmClient.Interface
+	OcpClient           clientconfigv1.ConfigV1Interface
+	K8sClient           kubernetes.Interface
+	K8sNetworkingClient networkingv1.NetworkingV1Interface
+	MachineCfg          ocpMachine.Interface
+	// MergedKubeConfigFile string
+	KubeConfig []byte
+	ready      bool
 }
 
 var clientsHolder = ClientsHolder{}
@@ -140,61 +138,12 @@ func GetClientsHolder(filenames ...string) *ClientsHolder {
 	return clientsHolder
 }
 
-// createTempFile is a helper function to create a temporary file in the
-// system's tmp folder. If the system doesn't have a tmp folder mounted,
-// as in many containers, use app's directory as a failover.
-func createTempFile(prefix string) (file *os.File, err error) {
-	tmpDir := os.TempDir()
-
-	// Make sure the temp folder exists.
-	_, err = os.Stat(tmpDir)
-	if err != nil {
-		// tmp folder may not exist in this system: use app's directory
-		// as fallthrough.
-		var appPath string
-		appPath, err = os.Executable()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get current app's path: %s", err)
-		}
-		tmpDir = filepath.Dir(appPath)
-		logrus.Debugf("tnf app path: %s", tmpDir)
-	}
-
-	file, err = os.CreateTemp(tmpDir, prefix)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temporary file in %s: %w", tmpDir, err)
-	}
-
-	return file, nil
-}
-
 func createByteArrayKubeConfig(kubeConfig *clientcmdapi.Config) ([]byte, error) {
 	yamlBytes, err := clientcmd.Write(*kubeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate yaml bytes from kubeconfig: %w", err)
 	}
 	return yamlBytes, nil
-}
-
-// createMergedKubeConfigFile creates a merged kube config file in the system's
-// temporary folder, e.g.: /tmp/tnf-merged-kubeconfig-730845179
-func createMergedKubeConfigFile(kubeConfig *clientcmdapi.Config) (filePath string, err error) {
-	yamlBytes, err := createByteArrayKubeConfig(kubeConfig)
-	if err != nil {
-		return "", err
-	}
-
-	file, err := createTempFile("tnf-merged-kubeconfig-*")
-	if err != nil {
-		return "", fmt.Errorf("failed to create temp file: %s", err)
-	}
-
-	_, err = file.Write(yamlBytes)
-	if err != nil {
-		return "", fmt.Errorf("failed to write merged kubeconfig to temp file (%s): %w", file.Name(), err)
-	}
-
-	return file.Name(), nil
 }
 
 // GetClientsHolder instantiate an ocp client
@@ -226,12 +175,6 @@ func newClientsHolder(filenames ...string) (*ClientsHolder, error) { //nolint:fu
 	if err != nil {
 		return nil, fmt.Errorf("failed to get kube raw config: %w", err)
 	}
-
-	clientsHolder.MergedKubeConfigFile, err = createMergedKubeConfigFile(&kubeRawConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create merged kube config file: %w", err)
-	}
-	logrus.Infof("Merged kube config file: %s", clientsHolder.MergedKubeConfigFile)
 
 	clientsHolder.KubeConfig, err = createByteArrayKubeConfig(&kubeRawConfig)
 	if err != nil {

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -52,9 +52,8 @@ type ClientsHolder struct {
 	K8sClient           kubernetes.Interface
 	K8sNetworkingClient networkingv1.NetworkingV1Interface
 	MachineCfg          ocpMachine.Interface
-	// MergedKubeConfigFile string
-	KubeConfig []byte
-	ready      bool
+	KubeConfig          []byte
+	ready               bool
 }
 
 var clientsHolder = ClientsHolder{}


### PR DESCRIPTION
Based on changes from #631 

Adds a `clientsHolder.KubeConfig` byte array variable.

I'm trying to make the preflight lib PR less daunting before the final merge.