### PR TITLE
Add legacy branch builder YAML

### DIFF
--- a/.github/workflows/tnf-image-legacy.yaml
+++ b/.github/workflows/tnf-image-legacy.yaml
@@ -1,0 +1,160 @@
+name: 'Publish the `cnf-certification-test` image (latest release only)'
+on:
+  # Run the workflow when a new legacy release gets published
+  release:
+    types: [published]
+  workflow_dispatch:
+defaults:
+  run:
+    shell: bash
+env:
+  REGISTRY: quay.io
+  REGISTRY_LOCAL: localhost
+  RELEASE_LEVEL: '4.11'
+  TNF_IMAGE_NAME: testnetworkfunction/cnf-certification-test
+  IMAGE_TAG: latest
+  TNF_CONTAINER_CLIENT: docker
+  TNF_NON_INTRUSIVE_ONLY: false
+  TNF_MINIKUBE_ONLY: true
+  TNF_DISABLE_CONFIG_AUTODISCOVER: false
+  TNF_CONFIG_DIR: /tmp/tnf/config
+  TNF_OUTPUT_DIR: /tmp/tnf/output
+  TNF_SRC_URL: 'https://github.com/${{ github.repository }}'
+  PARTNER_REPO: test-network-function/cnf-certification-test-partner
+  PARTNER_SRC_URL: 'https://github.com/${PARTNER_REPO}'
+  TESTING_CMD_PARAMS: '-n host -i ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${IMAGE_TAG} -t ${TNF_CONFIG_DIR} -o ${TNF_OUTPUT_DIR}'
+  ON_DEMAND_DEBUG_PODS: false
+
+jobs:
+  test-and-push-tnf-image:
+    name: 'Test and push the `cnf-certification-test` image'
+    runs-on: ubuntu-20.04
+    strategy:
+      max-parallel: 1
+      matrix:
+        branch: [4.0.x] ## Add more versions when needed
+    env:
+      SHELL: /bin/bash
+      KUBECONFIG: '/home/runner/.kube/config'
+      CURRENT_VERSION_GENERIC_BRANCH: ${{ matrix.branch }}
+      TNF_VERSION: ""
+      PARTNER_VERSION: ""
+    steps:
+
+      - name: Checkout generic working branch of the current version
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.CURRENT_VERSION_GENERIC_BRANCH }}
+          fetch-depth: '0'
+
+      - name: Strip the suffix off of the branch (eg. 4.0.x --> 4.0)
+        run: |
+          MINOR_VERSION=${{ env.CURRENT_VERSION_GENERIC_BRANCH%".x" }}
+          echo "::set-output name=minor_version::$MINOR_VERSION"
+        id: set_minor_version
+
+      - name: Get the TNF version from git at the minor version level
+        run: |
+          GIT_RELEASE=$(git tag --points-at HEAD | head -n 1)
+          GIT_PREVIOUS_RELEASE=$(git tag --no-contains HEAD --sort=v:refname | grep ${{ steps.set_minor_version.outputs.minor_version }}| tail -n 1) 
+          GIT_LATEST_RELEASE=$GIT_RELEASE
+          if [ -z "$GIT_RELEASE" ]; then
+            GIT_LATEST_RELEASE=$GIT_PREVIOUS_RELEASE
+          fi
+
+          echo "::set-output name=version_number::$GIT_LATEST_RELEASE"
+        id: set_tnf_version
+
+      - name: Print the latest TNF version from GIT
+        run: |
+          echo Version tag: ${{ steps.set_tnf_version.outputs.version_number }}
+
+      - name: Get contents of the version.json file
+        run: echo "::set-output name=json::$(cat version.json | tr -d '[:space:]')"
+        id: get_version_json_file
+
+      - name: Get the partner version number from file
+        run: |
+          echo Partner version tag: $VERSION_FROM_FILE_PARTNER
+          echo "::set-output name=partner_version_number::$VERSION_FROM_FILE_PARTNER"
+        id: set_partner_version
+        env:
+          VERSION_FROM_FILE_PARTNER: ${{ fromJSON(steps.get_version_json_file.outputs.json).partner_tag }}
+          
+      - name: Update env variables
+        run: |
+          echo "TNF_VERSION=${{ steps.set_tnf_version.outputs.version_number }}" >> $GITHUB_ENV
+          echo "PARTNER_VERSION=${{ steps.set_partner_version.outputs.partner_version_number }}" >> $GITHUB_ENV
+ 
+      - name: Ensure $TNF_VERSION and $IMAGE_TAG are set
+        run: '[[ -n "$TNF_VERSION" ]] && [[ -n "$IMAGE_TAG" ]] && [[ -n "$PARTNER_VERSION" ]]'
+
+      - name: Check whether the version tag exists on remote
+        run: git ls-remote --exit-code $TNF_SRC_URL refs/tags/$TNF_VERSION
+
+      - name: (if tag is missing) Display debug message
+        if: ${{ failure() }}
+        run: echo "Tag '$TNF_VERSION' does not exist on remote $TNF_SRC_URL"
+
+      - name: Check whether the version tag exists on remote
+        run: git ls-remote --exit-code ${{ env.PARTNER_SRC_URL }} refs/tags/$PARTNER_VERSION
+
+      - name: (if partner_tag is missing) Display debug message
+        if: ${{ failure() }}
+        run: echo "Tag '$PARTNER_VERSION' does not exist on remote $PARTNER_SRC_URL"
+
+      - name: Checkout the version tag
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.TNF_VERSION }}
+
+      - name: Build the `cnf-certification-test` image
+        run: |
+          make build-image-tnf
+        env:
+          TNF_VERSION: ${{ github.event.release.tag_name }}
+          IMAGE_TAG: ${IMAGE_TAG}
+
+      # Create a minikube cluster for testing.
+
+      - name: Check out `cnf-certification-test-partner`
+        uses: actions/checkout@v3
+        with:
+          repository: test-network-function/cnf-certification-test-partner
+          path: cnf-certification-test-partner
+          ref: ${{ env.PARTNER_VERSION }}
+          
+      - name: Start the minikube cluster for `local-test-infra`
+        uses: ./cnf-certification-test-partner/.github/actions/start-k8s-cluster
+        with:
+          working_directory: cnf-certification-test-partner
+          
+      - name: Create `local-test-infra` OpenShift resources
+        uses: ./cnf-certification-test-partner/.github/actions/create-local-test-infra-resources
+        with:
+          working_directory: cnf-certification-test-partner
+
+      # Perform tests.
+
+      - name: Create required TNF config files and directories
+        run: |
+          mkdir -p $TNF_CONFIG_DIR $TNF_OUTPUT_DIR
+          cp cnf-certification-test/*.yml $TNF_CONFIG_DIR
+        shell: bash
+
+      - name: 'Test: Run without any TS, just get diagnostic information'
+        run: ./run-tnf-container.sh ${{ env.TESTING_CMD_PARAMS }} 
+
+      # Push the new TNF image to Quay.io.
+
+      - name: Authenticate against Quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          # Use a Robot Account to authenticate against Quay.io
+          # https://docs.quay.io/glossary/robot-accounts.html
+          username: ${{ secrets.QUAY_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Push the newly built image to Quay.io
+        run: docker push --all-tags ${REGISTRY}/${TNF_IMAGE_NAME}


### PR DESCRIPTION
Supports building the 4.0.x branch whenever a new release is published.

Notable differences compared to the tnf-image.yaml:
- Only triggers on 4.0.x branch (currently).
- Does some bash string manipulation to strip off the `.x` from the `4.0.x` to find the latest tag available in the repo.