### PR TITLE
Point logrus logs to file

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -191,6 +191,7 @@ jobs:
             cnf-certification-test/claim.json
             cnf-certification-test/claimjson.js
             cnf-certification-test/results.html
+            cnf-certification-test/tnf-execution.log
 
       # Perform smoke tests using a TNF container.
 
@@ -222,6 +223,7 @@ jobs:
             ${{ env.TNF_OUTPUT_DIR }}/claim.json
             ${{ env.TNF_OUTPUT_DIR }}/claimjson.js
             ${{ env.TNF_OUTPUT_DIR }}/results.html
+            ${{ env.TNF_OUTPUT_DIR }}/tnf-execution.log
 
       # Push the new unstable TNF image to Quay.io.
       - name: (if on main and upstream) Authenticate against Quay.io

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ test-network-function_junit.xml
 cover.out
 cover.out.tmp
 cnf-certification-test/cnf-certification-tests_junit.xml
+cnf-certification-test/tnf-execution.log
 cnf-certification-tests_junit.xml
 cnftests-junit.xml
 setup_junit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 bin/
 catalog.json
 claim.json
+tnf-execution.log
 .idea
 vendor
 *.test

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ clean:
 	rm -f test-out.json
 	rm -f cover.out
 	rm -f claim.json
+	rm -f tnf-execution.log
 	rm -f all-releases.txt
 
 # Run configured linters

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ clean:
 	rm -f ./cnf-certification-test/claimjson.js
 	rm -f ./cnf-certification-test/results.html
 	rm -f ./cnf-certification-test/cnf-certification-tests_junit.xml
+	rm -f ./cnf-certification-test/tnf-execution.log
 	rm -f ./tnf
 	rm -f latest-release-tag.txt
 	rm -f release-tag.txt

--- a/cnf-certification-test/suite_test.go
+++ b/cnf-certification-test/suite_test.go
@@ -136,10 +136,9 @@ func TestTest(t *testing.T) {
 	}
 
 	defer f.Close()
-	log.SetOutput(f)
 
 	// Set hooks for logger
-	loghelper.SetHooks()
+	loghelper.SetHooks(f)
 
 	// Set logging level
 	loghelper.SetLogLevel()

--- a/cnf-certification-test/suite_test.go
+++ b/cnf-certification-test/suite_test.go
@@ -50,18 +50,22 @@ import (
 const (
 	claimFileName                 = "claim.json"
 	claimPathFlagKey              = "claimloc"
+	executionLogPathFlagKey       = "execlogloc"
 	CnfCertificationTestSuiteName = "CNF Certification Test Suite"
 	defaultClaimPath              = ".."
+	defaultExecutionLogPath       = ".."
 	defaultCliArgValue            = ""
 	junitFlagKey                  = "junit"
 	TNFJunitXMLFileName           = "cnf-certification-tests_junit.xml"
 	TNFReportKey                  = "cnf-certification-test"
 	extraInfoKey                  = "testsExtraInfo"
+	execLogFile                   = "tnf-execution.log"
 )
 
 var (
-	claimPath *string
-	junitPath *string
+	claimPath   *string
+	junitPath   *string
+	execLogPath *string
 	// GitCommit is the latest commit in the current git branch
 	GitCommit string
 	// GitRelease is the list of tags (if any) applied to the latest commit
@@ -80,6 +84,8 @@ func init() {
 		"the path where the claimfile will be output")
 	junitPath = flag.String(junitFlagKey, defaultCliArgValue,
 		"the path for the junit format report")
+	execLogPath = flag.String(executionLogPathFlagKey, defaultExecutionLogPath,
+		"the path for the execution log")
 }
 
 func getK8sClientsConfigFileNames() []string {
@@ -119,9 +125,8 @@ func TestTest(t *testing.T) {
 	loghelper.SetLogFormat()
 
 	// Delete execution log (if any) prior to run
-	logFile := "tnf-execution.log"
-	_, fileErr := os.Stat(logFile)
-	if os.IsExist(fileErr) {
+	logFile := filepath.Join(*execLogPath, execLogFile)
+	if _, fileErr := os.Stat(logFile); os.IsExist(fileErr) {
 		e := os.Remove(logFile)
 		if e != nil {
 			panic(e)

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -38,4 +38,4 @@ export TNF_NON_INTRUSIVE_ONLY=true
     TNF_LOG_LEVEL=trace
     ```
 
-    The choices are: trace, debug, info, warn, error, fatal, panic.  The default is debug.
+    The choices are: trace, debug, info, warn, error, fatal, panic.  The default is info.

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -3,7 +3,7 @@
 To test the newly added test / existing tests locally, follow the steps
 
 
--  Clone the repo
+- Clone the repo
 
 - Set runtime environment variables, as per the requirement.
 
@@ -31,3 +31,11 @@ export TNF_NON_INTRUSIVE_ONLY=true
     ```shell
     ./script/development.sh networking
     ```
+
+- Modify the logging levels to show trace level with the following:
+
+    ```shell
+    TNF_LOG_LEVEL=trace
+    ```
+
+    The choices are: trace, debug, info, warn, error, fatal, panic.  The default is debug.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,8 @@ The purpose of the tests and the framework is to test the interaction of CNF wit
 
 * The framework generates a report (named `claim.json`) as the end of test execution.
 
+* The execution log is also saved in `cnf-certification-test/tnf-execution.log`.
+
 * The catalog of the existing test cases and test building blocks are available in [CATALOG.md](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md)
 
 

--- a/pkg/loghelper/loghelper.go
+++ b/pkg/loghelper/loghelper.go
@@ -88,8 +88,8 @@ func SetLogLevel() {
 
 	var logLevel, err = logrus.ParseLevel(params.LogLevel)
 	if err != nil {
-		logrus.Error("TNF_LOG_LEVEL environment set with an invalid value, defaulting to debug \n Valid values are: trace, debug, info, warn, error, fatal, panic")
-		logLevel = logrus.DebugLevel
+		logrus.Error("TNF_LOG_LEVEL environment set with an invalid value, defaulting to info \n Valid values are: trace, debug, info, warn, error, fatal, panic")
+		logLevel = logrus.InfoLevel
 	}
 
 	logrus.Infof("Log level set to: %v", logLevel)

--- a/pkg/loghelper/loghelper.go
+++ b/pkg/loghelper/loghelper.go
@@ -88,10 +88,10 @@ func SetLogLevel() {
 
 	var logLevel, err = logrus.ParseLevel(params.LogLevel)
 	if err != nil {
-		logrus.Error("TNF_LOG_LEVEL environment set with an invalid value, defaulting to DEBUG \n Valid values are:  trace, debug, info, warn, error, fatal, panic")
+		logrus.Error("TNF_LOG_LEVEL environment set with an invalid value, defaulting to debug \n Valid values are: trace, debug, info, warn, error, fatal, panic")
 		logLevel = logrus.DebugLevel
 	}
 
-	logrus.Info("Log level set to: ", logLevel)
+	logrus.Infof("Log level set to: %v", logLevel)
 	logrus.SetLevel(logLevel)
 }

--- a/pkg/loghelper/loghelper.go
+++ b/pkg/loghelper/loghelper.go
@@ -67,21 +67,17 @@ func SetLogFormat() {
 	logrus.SetFormatter(customFormatter)
 }
 
-func SetHooks() {
-	logrus.AddHook(&writer.Hook{ // Send logs with level higher than warning to stderr
-		Writer: os.Stderr,
+func SetHooks(f *os.File) {
+	logrus.AddHook(&writer.Hook{ // Send all logs to file
+		Writer: f,
 		LogLevels: []logrus.Level{
 			logrus.PanicLevel,
 			logrus.FatalLevel,
 			logrus.ErrorLevel,
 			logrus.WarnLevel,
-		},
-	})
-	logrus.AddHook(&writer.Hook{ // Send info and debug logs to stdout
-		Writer: os.Stdout,
-		LogLevels: []logrus.Level{
 			logrus.InfoLevel,
 			logrus.DebugLevel,
+			logrus.TraceLevel,
 		},
 	})
 }

--- a/run-cnf-suites.sh
+++ b/run-cnf-suites.sh
@@ -96,6 +96,7 @@ GINKGO_ARGS="\
 --ginkgo.timeout=$TIMEOUT \
 -junit $OUTPUT_LOC \
 -claimloc $OUTPUT_LOC \
+-execlogloc $OUTPUT_LOC \
 --ginkgo.junit-report $OUTPUT_LOC/cnf-certification-tests_junit.xml \
 -ginkgo.v \
 -test.v\


### PR DESCRIPTION
* Adds a new log file `cnf-certification-test/tnf-execution.log`.
* Deletes this log file at the beginning of every run (if it exists).
* Adds documentation and gitignore references to this new file.