### PR TITLE
Manual update ginkgo to v2.7.0

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -155,7 +155,7 @@ jobs:
           docker run -v ${GITHUB_WORKSPACE}/offline-db:/tmp/dump:Z --env OCT_DUMP_ONLY=true ${REGISTRY}/${OCT_IMAGE_NAME}:${OCT_IMAGE_TAG}
 
       - name: Install ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
+        run: make install-tools
 
       - name: Execute `make build`
         run: make build

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ build-cnf-tests-debug:
 
 # Install build tools and other required software.
 install-tools:
-	go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
+	go install github.com/onsi/ginkgo/v2/ginkgo@v2.7.0
 
 # Install golangci-lint	
 install-lint:


### PR DESCRIPTION
Follow up to: https://github.com/test-network-function/cnf-certification-test/pull/775

Changes the github workflow to call `make install-tools` to remove the multiple entry changes for this type of change in the future.