### PR TITLE
Add check for nodeSelectors in pod-recreation test

### DIFF
--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -452,9 +452,11 @@ func testPodsRecreation(env *provider.TestEnvironment) { //nolint:funlen
 	// Filter out pods with Node Assignments present and FAIL them.
 	// We run into problems with this test when there are nodeSelectors assigned affecting where
 	// pods are scheduled.  Also, they are not allowed in general, see the node-selector test case.
+	// Skip the safeguard for any pods that are using a runtimeClassName.  This is potentially
+	// because pods that are derived from a performance profile might have a built-in nodeSelector.
 	var podsWithNodeAssignement []*provider.Pod
 	for _, put := range env.Pods {
-		if put.HasNodeSelector() {
+		if !put.IsRuntimeClassNameSpecified() && put.HasNodeSelector() {
 			podsWithNodeAssignement = append(podsWithNodeAssignement, put)
 			logrus.Errorf("%s has been found with node selector(s): %v", put.String(), put.Spec.NodeSelector)
 		}

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -280,8 +280,8 @@ func testPodsOwnerReference(env *provider.TestEnvironment) {
 func testPodNodeSelectorAndAffinityBestPractices(testPods []*provider.Pod) {
 	var badPods []*corev1.Pod
 	for _, put := range testPods {
-		if put.HasNodeAssignment() {
-			tnf.ClaimFilePrintf("ERROR: %s has a node assignment. Node selector: %v Node Name: %s", put, &put.Spec.NodeSelector, put.Spec.NodeName)
+		if put.HasNodeSelector() {
+			tnf.ClaimFilePrintf("ERROR: %s has a node selector. Node selector: %v", put, &put.Spec.NodeSelector)
 			badPods = append(badPods, put.Pod)
 		}
 		if put.Spec.Affinity != nil && put.Spec.Affinity.NodeAffinity != nil {
@@ -450,12 +450,13 @@ func testPodsRecreation(env *provider.TestEnvironment) { //nolint:funlen
 	}
 
 	// Filter out pods with Node Assignments present and FAIL them.
-	// We run into problems with this test when there are nodeSelectors or node names assigned affecting where
+	// We run into problems with this test when there are nodeSelectors assigned affecting where
 	// pods are scheduled.  Also, they are not allowed in general, see the node-selector test case.
 	var podsWithNodeAssignement []*provider.Pod
 	for _, put := range env.Pods {
-		if put.HasNodeAssignment() {
+		if put.HasNodeSelector() {
 			podsWithNodeAssignement = append(podsWithNodeAssignement, put)
+			logrus.Errorf("%s has been found with node selector(s): %v", put.String(), put.Spec.NodeSelector)
 		}
 	}
 	if len(podsWithNodeAssignement) > 0 {

--- a/pkg/provider/isolation.go
+++ b/pkg/provider/isolation.go
@@ -80,10 +80,6 @@ func AreCPUResourcesWholeUnits(p *Pod) bool {
 	return true
 }
 
-func IsRuntimeClassNameSpecified(p *Pod) bool {
-	return p.Spec.RuntimeClassName != nil
-}
-
 func LoadBalancingDisabled(p *Pod) bool {
 	const (
 		disableVar = "disable"

--- a/pkg/provider/isolation_test.go
+++ b/pkg/provider/isolation_test.go
@@ -224,7 +224,7 @@ func TestCPUIsolation(t *testing.T) {
 	for _, tc := range testCases {
 		assert.Equal(t, tc.resourcesIdenticalResult, AreResourcesIdentical(tc.testPod))
 		assert.Equal(t, tc.wholeUnitsResult, AreCPUResourcesWholeUnits(tc.testPod))
-		assert.Equal(t, tc.runtimeClassNameResult, IsRuntimeClassNameSpecified(tc.testPod))
+		assert.Equal(t, tc.runtimeClassNameResult, tc.testPod.IsRuntimeClassNameSpecified())
 		assert.Equal(t, tc.loadBalancingResult, LoadBalancingDisabled(tc.testPod))
 	}
 }

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -203,7 +203,10 @@ func (p *Pod) CreatedByDeploymentConfig() (bool, error) {
 	return false, nil
 }
 
-func (p *Pod) HasNodeAssignment() bool {
+func (p *Pod) HasNodeSelector() bool {
 	// Checks whether or not the pod has a nodeSelector or a NodeName supplied
-	return p.Spec.NodeSelector != nil || p.Spec.NodeName != ""
+	if p.Spec.NodeSelector == nil || len(p.Spec.NodeSelector) == 0 {
+		return false
+	}
+	return true
 }

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -92,7 +92,7 @@ func (p *Pod) IsCPUIsolationCompliant() bool {
 		isCPUIsolated = false
 	}
 
-	if !IsRuntimeClassNameSpecified(p) {
+	if !p.IsRuntimeClassNameSpecified() {
 		errMsg := fmt.Sprintf("%s has been found to not have runtimeClassName specified.", p.String())
 		logrus.Debugf(errMsg)
 		tnf.ClaimFilePrintf(errMsg)
@@ -209,4 +209,8 @@ func (p *Pod) HasNodeSelector() bool {
 		return false
 	}
 	return true
+}
+
+func (p *Pod) IsRuntimeClassNameSpecified() bool {
+	return p.Spec.RuntimeClassName != nil
 }

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -202,3 +202,8 @@ func (p *Pod) CreatedByDeploymentConfig() (bool, error) {
 	}
 	return false, nil
 }
+
+func (p *Pod) HasNodeAssignment() bool {
+	// Checks whether or not the pod has a nodeSelector or a NodeName supplied
+	return p.Spec.NodeSelector != nil || p.Spec.NodeName != ""
+}

--- a/pkg/provider/pods_test.go
+++ b/pkg/provider/pods_test.go
@@ -231,7 +231,7 @@ func TestContainsIstioProxy(t *testing.T) {
 	}
 }
 
-func TestHasNodeAssignment(t *testing.T) {
+func TestHasNodeSelector(t *testing.T) {
 	testCases := []struct {
 		testPod        Pod
 		expectedOutput bool
@@ -259,19 +259,19 @@ func TestHasNodeAssignment(t *testing.T) {
 			},
 			expectedOutput: true,
 		},
-		{ // Test #3 - Has a nodename, fail
+		{ // Test #3 - Has a nodeSelector initialized but it is empty, pass
 			testPod: Pod{
 				Pod: &corev1.Pod{
 					Spec: corev1.PodSpec{
-						NodeName: "node1",
+						NodeSelector: map[string]string{},
 					},
 				},
 			},
-			expectedOutput: true,
+			expectedOutput: false,
 		},
 	}
 
 	for _, tc := range testCases {
-		assert.Equal(t, tc.expectedOutput, tc.testPod.HasNodeAssignment())
+		assert.Equal(t, tc.expectedOutput, tc.testPod.HasNodeSelector())
 	}
 }

--- a/pkg/provider/pods_test.go
+++ b/pkg/provider/pods_test.go
@@ -230,3 +230,48 @@ func TestContainsIstioProxy(t *testing.T) {
 		assert.Equal(t, tc.expectedOutput, tc.testPod.ContainsIstioProxy())
 	}
 }
+
+func TestHasNodeAssignment(t *testing.T) {
+	testCases := []struct {
+		testPod        Pod
+		expectedOutput bool
+	}{
+		{ // Test #1 - Has a nil node selector and no NodeName, pass
+			testPod: Pod{
+				Pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						NodeSelector: nil,
+						NodeName:     "",
+					},
+				},
+			},
+			expectedOutput: false,
+		},
+		{ // Test #2 - Has a nodeSelector, fail
+			testPod: Pod{
+				Pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						NodeSelector: map[string]string{
+							"test1": "value1",
+						},
+					},
+				},
+			},
+			expectedOutput: true,
+		},
+		{ // Test #3 - Has a nodename, fail
+			testPod: Pod{
+				Pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						NodeName: "node1",
+					},
+				},
+			},
+			expectedOutput: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedOutput, tc.testPod.HasNodeAssignment())
+	}
+}


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test/issues/762

The pod-recreation test case falls over because _sometimes_ there can be nodeSelectors attached to pods.  This is not allowed, per best practice requirement guidelines but that doesn't stop the test from attempting to run.  The test is now modified to check for these nodeSelectors prior to entering the loop that does the `cordon`.

Notable changes:
- Added `pod.HasNodeSelector()` func and appropriate changes.
- Added logic into the `pod-recreation` test to utilize the above `HasNodeSelector` func and detect any possible failures this test could encounter early.
- Changed `IsRuntimeClassNameSpecified` into a `Pod` struct func because it is used outside of the `isolation` file.