### PR TITLE
Create log file by mirroring output in bash script

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -191,6 +191,8 @@ jobs:
             cnf-certification-test/claim.json
             cnf-certification-test/claimjson.js
             cnf-certification-test/results.html
+            cnf-certification-test/tnf-execution.log
+            
 
       # Perform smoke tests using a TNF container.
 
@@ -222,6 +224,7 @@ jobs:
             ${{ env.TNF_OUTPUT_DIR }}/claim.json
             ${{ env.TNF_OUTPUT_DIR }}/claimjson.js
             ${{ env.TNF_OUTPUT_DIR }}/results.html
+            ${{ env.TNF_OUTPUT_DIR }}/tnf-execution.log
 
       # Push the new unstable TNF image to Quay.io.
       - name: (if on main and upstream) Authenticate against Quay.io

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 bin/
 catalog.json
 claim.json
+tnf-execution.log
+cnf-certification-test/tnf-execution.log
 .idea
 vendor
 *.test

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ The purpose of the tests and the framework is to test the interaction of CNF wit
 
 **Features**
 
-* The framework generates a report (named `claim.json`) as the end of test execution.
+* The test suite generates a report (`claim.json`) and saves the test execution log (`tnf-execution.log`) in a configurable output directory.
 
 * The catalog of the existing test cases and test building blocks are available in [CATALOG.md](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md)
 

--- a/docs/test-container.md
+++ b/docs/test-container.md
@@ -33,7 +33,7 @@ In order to get the required information, the test suite does not `ssh` into nod
 **Required arguments**
 
 * `-t` to provide the path of the local directory that contains tnf config files
-* `-o` to provide the path of the local directory that the test results will be available after the container exits.
+* `-o` to provide the path of the local directory where test results (claim.json) and execution logs (tnf-execution.log) will be available from after the container exits.
 
 !!! warning
 

--- a/docs/test-output.md
+++ b/docs/test-output.md
@@ -48,3 +48,6 @@ For more details on the contents of the claim file
 
 * [schema](https://github.com/test-network-function/test-network-function-claim/blob/main/schemas/claim.schema.json).  
 * [Guide](https://redhat-connect.gitbook.io/openshift-badges/badges/cloud-native-network-functions-cnf).
+
+## Execution logs
+The test suite also saves a copy of the execution logs at <test output directory>/tnf-execution.log

--- a/run-cnf-suites.sh
+++ b/run-cnf-suites.sh
@@ -146,6 +146,12 @@ fi
 
 cd ./cnf-certification-test || exit 1
 
+# configuring special pipeline mode
+# The exit status of a pipeline is the exit status of the last command in the pipeline, unless the pipefail option
+# is enabled (see The Set Builtin). If pipefail is enabled, the pipeline's return status is the value of the last (rightmost) 
+# command to exit with a non-zero status, or zero if all commands exit successfully.
+set -o pipefail
+
 # Do not double quote.
 # SC2086: Double quote to prevent globbing and word splitting.
 # shellcheck disable=SC2086
@@ -156,4 +162,10 @@ cd ./cnf-certification-test || exit 1
 	${GINKGO_ARGS} |& tee $OUTPUT_LOC/tnf-execution.log
 
 # preserving the exit status
-exit ${PIPESTATUS[0]}
+RESULT=$?
+
+# revert to normal mode
+set +o pipefail
+
+# exit with retrieved exit status
+exit $RESULT

--- a/run-cnf-suites.sh
+++ b/run-cnf-suites.sh
@@ -153,4 +153,7 @@ cd ./cnf-certification-test || exit 1
 	${FOCUS_STRING} \
 	${SKIP_STRING} \
 	"${LABEL_STRING}" \
-	${GINKGO_ARGS}
+	${GINKGO_ARGS} |& tee $OUTPUT_LOC/tnf-execution.log
+
+# preserving the exit status
+exit ${PIPESTATUS[0]}


### PR DESCRIPTION
This is related to https://github.com/test-network-function/cnf-certification-test/pull/777
This is proposing to use tee to mirror the output and captures all the logs(including those added by Ginkgo) in the cli and container scenarios