### PR TITLE
Adding an ignore list for services under test

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,6 +87,10 @@ If we want to add another name, we just need to write the name in the yaml file.
 
 for example: if we want to add new protocol - "http4", we add in "tnf_config.yml"  below "validProtocolNames" and then this protocol ("http4") add to map allowedProtocolNames and finally "http4"  will be allow protocol.
 
+## ServicesIgnoreList
+
+This is a list of service names present in the namespace under test and that should not be tested.
+
 ## skipScalingTestDeployments and skipScalingTestStatefulSetNames
 
 This section of the TNF config allows the user to skip the scaling tests that potentially cause known problems with workloads that do not like being scaled up and scaled down.

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -83,6 +83,7 @@ type DiscoveredTestData struct {
 	Nodes                  *corev1.NodeList
 	Istio                  bool
 	ValidProtocolNames     []string
+	ServicesIgnoreList     []string
 }
 
 var data = DiscoveredTestData{}
@@ -160,6 +161,7 @@ func DoAutoDiscover() DiscoveredTestData {
 	}
 	data.Istio = findIstioNamespace(data.AllNamespaces)
 	data.ValidProtocolNames = data.TestData.ValidProtocolNames
+	data.ServicesIgnoreList = data.TestData.ServicesIgnoreList
 
 	// Find the status of the OCP version (pre-ga, end-of-life, maintenance, or generally available)
 	data.OCPStatus = compatibility.DetermineOCPStatus(openshiftVersion, time.Now())
@@ -180,7 +182,7 @@ func DoAutoDiscover() DiscoveredTestData {
 	if err != nil {
 		logrus.Fatalf("Cannot get list of persistent volume claims, error: %v", err)
 	}
-	data.Services, err = getServices(oc.K8sClient.CoreV1(), data.Namespaces)
+	data.Services, err = getServices(oc.K8sClient.CoreV1(), data.Namespaces, data.ServicesIgnoreList)
 	if err != nil {
 		logrus.Fatalf("Cannot get list of services, error: %v", err)
 	}

--- a/pkg/autodiscover/autodiscover_services.go
+++ b/pkg/autodiscover/autodiscover_services.go
@@ -23,14 +23,19 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-func getServices(oc corev1client.CoreV1Interface, namespaces []string) (allServices []*corev1.Service, err error) {
+func getServices(oc corev1client.CoreV1Interface, namespaces, ignoreList []string) (allServices []*corev1.Service, err error) {
 	for _, ns := range namespaces {
 		s, err := oc.Services(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return allServices, err
 		}
 		for i := range s.Items {
-			allServices = append(allServices, &s.Items[i])
+			for _, aService := range ignoreList {
+				if aService == s.Items[i].Name {
+					continue
+				}
+				allServices = append(allServices, &s.Items[i])
+			}
 		}
 	}
 	return allServices, nil

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -119,6 +119,7 @@ type TestConfiguration struct {
 	// CheckDiscoveredContainerCertificationStatus controls whether the container certification test will validate images used by autodiscovered containers, in addition to the configured image list
 	CheckDiscoveredContainerCertificationStatus bool     `yaml:"checkDiscoveredContainerCertificationStatus" json:"checkDiscoveredContainerCertificationStatus"`
 	ValidProtocolNames                          []string `yaml:"validProtocolNames" json:"validProtocolNames"`
+	ServicesIgnoreList                          []string `yaml:"servicesignorelist" json:"servicesignorelist"`
 }
 
 type TestParameters struct {

--- a/pkg/configuration/testdata/tnf_test_config.yml
+++ b/pkg/configuration/testdata/tnf_test_config.yml
@@ -29,3 +29,6 @@ skipScalingTestStatefulSetNames:
 validProtocolNames:
   - "http3"
   - "sctp"
+ServicesIgnoreList:
+  - "hazelcast-platform-controller-manager-service"
+  - "hazelcast-platform-webhook-service"

--- a/pkg/configuration/testdata/tnf_test_config.yml
+++ b/pkg/configuration/testdata/tnf_test_config.yml
@@ -32,3 +32,4 @@ validProtocolNames:
 ServicesIgnoreList:
   - "hazelcast-platform-controller-manager-service"
   - "hazelcast-platform-webhook-service"
+  

--- a/pkg/configuration/testdata/tnf_test_config.yml
+++ b/pkg/configuration/testdata/tnf_test_config.yml
@@ -32,4 +32,3 @@ validProtocolNames:
 ServicesIgnoreList:
   - "hazelcast-platform-controller-manager-service"
   - "hazelcast-platform-webhook-service"
-  


### PR DESCRIPTION
This is to skip testing the hazelcast 5.6.0 services which are not compliant with the dual stack / ipv6 test.
related to https://github.com/test-network-function/cnf-certification-test-partner/pull/204
upgrading hazelcast to 5.6.0 is needed to pass Redhat Certification test. this PR will allow passing the ipv6/dual stack test 