### PR TITLE
VCP CNF Requirement: PODs must NOT place persistent volumes on local storage

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -503,6 +503,20 @@ Suggested Remediation|Add a liveness probe to deployed containers
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.16, 12.1 and 12.5
 Exception Process|There is no documented exception process for this.
 Tags|common,telco
+#### no-pvs-on-localstorage
+
+Property|Description
+---|---
+Test Case Name|no-pvs-on-localstorage
+Test Case Label|lifecycle-no-pvs-on-localstorage
+Unique ID|http://test-network-function.com/testcases/lifecycle/no-pvs-on-localstorage
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/lifecycle/no-pvs-on-localstorage Checks that pods do not place persistent volumes on local storage.
+Result Type|informative
+Suggested Remediation|If the kind of pods is StatefulSet, so we need to make sure that servicename is not local-storage.
+Best Practice Reference|https://TODO Section 4.6.24
+Exception Process|There is no documented exception process for this.
+Tags|extended
 #### persistent-volume-reclaim-policy
 
 Property|Description

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -255,6 +255,18 @@ The label value is not important, only its presence.`,
 		false,
 		TagExtended)
 
+	TestStorageRequiredPods = AddCatalogEntry(
+		"no-pvs-on-localstorage",
+		common.LifecycleTestKey,
+		`Checks that pods do not place persistent volumes on local storage.`,
+		StorageRequiredPods,
+		InformativeResult,
+		NoDocumentedProcess,
+		VersionOne,
+		bestPracticeDocV1dot4URL+" Section 4.6.24",
+		false,
+		TagExtended)
+
 	TestStartupIdentifier = AddCatalogEntry(
 		"container-startup",
 		common.LifecycleTestKey,

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -582,7 +582,7 @@ func TestPodTolerationBypass(env *provider.TestEnvironment) {
 }
 func testStorageRequiredPods(env *provider.TestEnvironment) {
 	var podsWithLocalStorage []string
-	var StorageClasses = env.StorageClasses
+	var StorageClasses = env.StorageList
 	var Pvc = env.PersistentVolumeClaims
 	for _, put := range env.Pods {
 		for pvIndex := range put.Spec.Volumes {

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -582,7 +582,7 @@ func TestPodTolerationBypass(env *provider.TestEnvironment) {
 }
 func testStorageRequiredPods(env *provider.TestEnvironment) {
 	var podsWithLocalStorage []string
-	var StorageClasses = env.StorageList
+	var StorageClasses = env.StorageClassList
 	var Pvc = env.PersistentVolumeClaims
 	for _, put := range env.Pods {
 		for pvIndex := range put.Spec.Volumes {
@@ -597,12 +597,12 @@ func testStorageRequiredPods(env *provider.TestEnvironment) {
 				if Pvc[i].Name == put.Spec.Volumes[pvIndex].PersistentVolumeClaim.ClaimName && Pvc[i].Namespace == put.Namespace {
 					for j := range StorageClasses {
 						if Pvc[i].Spec.StorageClassName != nil && StorageClasses[j].Name == *Pvc[i].Spec.StorageClassName {
-							tnf.ClaimFilePrintf("%s has been found to use a local storage enabled storageClass.\n Pvc_name: %s, Storageclass_name : %s, Provisionner_name: %s", put.String(), put.Spec.Volumes[pvIndex].PersistentVolumeClaim.ClaimName,
+							tnf.ClaimFilePrintf("%s has been found to use a local storage enabled storageClass.\n Pvc_name: %s, Storageclass_name : %s, Provisioner_name: %s", put.String(), put.Spec.Volumes[pvIndex].PersistentVolumeClaim.ClaimName,
 								StorageClasses[j].Name, StorageClasses[j].Provisioner)
 							podsWithLocalStorage = append(podsWithLocalStorage, put.String())
 							break
 						}
-						tnf.ClaimFilePrintf("%s has been not found to use a local storage enabled storageClass.\n Pvc_name: %s, Storageclass_name : %s, Provisionner_name: %s", put.String(), put.Spec.Volumes[pvIndex].PersistentVolumeClaim.ClaimName,
+						tnf.ClaimFilePrintf("%s has been not found to use a local storage enabled storageClass.\n Pvc_name: %s, Storageclass_name : %s, Provisioner_name: %s", put.String(), put.Spec.Volumes[pvIndex].PersistentVolumeClaim.ClaimName,
 							StorageClasses[j].Name, StorageClasses[j].Provisioner)
 					}
 				}

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -594,7 +594,7 @@ func testStorageRequiredPods(env *provider.TestEnvironment) {
 			// We have the list of pods/volumes/claims.
 			// Look through the storageClass list for a match.
 			for i := range Pvc {
-				if Pvc[i].Name == put.Spec.Volumes[pvIndex].PersistentVolumeClaim.ClaimName {
+				if Pvc[i].Name == put.Spec.Volumes[pvIndex].PersistentVolumeClaim.ClaimName && Pvc[i].Namespace == put.Namespace {
 					for j := range StorageClasses {
 						if Pvc[i].Spec.StorageClassName != nil && StorageClasses[j].Name == *Pvc[i].Spec.StorageClassName {
 							tnf.ClaimFilePrintf("%s has been found to use a local storage enabled storageClass.\n Pvc_name: %s, Storageclass_name : %s, Provisionner_name: %s", put.String(), put.Spec.Volumes[pvIndex].PersistentVolumeClaim.ClaimName,

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -35,6 +35,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -83,6 +84,7 @@ type DiscoveredTestData struct {
 	Nodes                  *corev1.NodeList
 	Istio                  bool
 	ValidProtocolNames     []string
+	StorageClasses         []storagev1.StorageClass
 	ServicesIgnoreList     []string
 }
 
@@ -120,6 +122,10 @@ func DoAutoDiscover() DiscoveredTestData {
 		logrus.Fatalf("Cannot load configuration, error: %v", err)
 	}
 	oc := clientsholder.GetClientsHolder()
+	data.StorageClasses, err = getAllStorageClasses()
+	if err != nil {
+		logrus.Fatalf("Failed to retrieve storageClasses - err: %v", err)
+	}
 	data.AllNamespaces, _ = getAllNamespaces(oc.K8sClient.CoreV1())
 	data.AllSubscriptions = findSubscriptions(oc.OlmClient, []string{""})
 	data.AllCsvs = getAllOperators(oc.OlmClient)

--- a/pkg/autodiscover/autodiscover_pv.go
+++ b/pkg/autodiscover/autodiscover_pv.go
@@ -19,7 +19,10 @@ package autodiscover
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
@@ -38,4 +41,14 @@ func getPersistentVolumeClaims(oc corev1client.CoreV1Interface) ([]corev1.Persis
 		return nil, err
 	}
 	return pvcs.Items, nil
+}
+
+func getAllStorageClasses() ([]storagev1.StorageClass, error) {
+	o := clientsholder.GetClientsHolder()
+	storageclasslist, err := o.K8sClient.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		logrus.Errorln("Error when listing", "err: ", err)
+		return nil, err
+	}
+	return storageclasslist.Items, nil
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -109,7 +109,7 @@ type TestEnvironment struct { // rename this with testTarget
 	IstioServiceMesh       bool
 	ValidProtocolNames     []string
 	DaemonsetFailedToSpawn bool
-	StorageList            []string
+	StorageList            []storagev1.StorageClass
 }
 
 type MachineConfig struct {
@@ -261,7 +261,7 @@ func buildTestEnvironment() { //nolint:funlen
 		env.StatefulSets = append(env.StatefulSets, aNewStatefulSet)
 	}
 	env.HorizontalScaler = data.Hpas
-	env.StorageClasses = data.StorageClasses
+	env.StorageList = data.StorageClasses
 
 	operators := createOperators(data.Csvs, data.Subscriptions, data.AllInstallPlans, data.AllCatalogSources, false, false, true)
 	env.Operators = operators

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -39,6 +39,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -108,6 +109,7 @@ type TestEnvironment struct { // rename this with testTarget
 	IstioServiceMesh       bool
 	ValidProtocolNames     []string
 	DaemonsetFailedToSpawn bool
+	StorageList            []string
 }
 
 type MachineConfig struct {
@@ -196,10 +198,8 @@ func buildTestEnvironment() { //nolint:funlen
 	}
 
 	data := autodiscover.DoAutoDiscover()
-
 	// OpenshiftVersion needs to be set asap, as other helper functions will use it here.
 	env.OpenshiftVersion = data.OpenshiftVersion
-
 	env.Config = data.TestData
 	env.Crds = data.Crds
 	env.AllInstallPlans = data.AllInstallPlans
@@ -261,6 +261,7 @@ func buildTestEnvironment() { //nolint:funlen
 		env.StatefulSets = append(env.StatefulSets, aNewStatefulSet)
 	}
 	env.HorizontalScaler = data.Hpas
+	env.StorageClasses = data.StorageClasses
 
 	operators := createOperators(data.Csvs, data.Subscriptions, data.AllInstallPlans, data.AllCatalogSources, false, false, true)
 	env.Operators = operators

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -109,7 +109,7 @@ type TestEnvironment struct { // rename this with testTarget
 	IstioServiceMesh       bool
 	ValidProtocolNames     []string
 	DaemonsetFailedToSpawn bool
-	StorageList            []storagev1.StorageClass
+	StorageClassList             []storagev1.StorageClass
 }
 
 type MachineConfig struct {
@@ -261,7 +261,7 @@ func buildTestEnvironment() { //nolint:funlen
 		env.StatefulSets = append(env.StatefulSets, aNewStatefulSet)
 	}
 	env.HorizontalScaler = data.Hpas
-	env.StorageList = data.StorageClasses
+	env.StorageClassList = data.StorageClasses
 
 	operators := createOperators(data.Csvs, data.Subscriptions, data.AllInstallPlans, data.AllCatalogSources, false, false, true)
 	env.Operators = operators

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -109,7 +109,7 @@ type TestEnvironment struct { // rename this with testTarget
 	IstioServiceMesh       bool
 	ValidProtocolNames     []string
 	DaemonsetFailedToSpawn bool
-	StorageClassList             []storagev1.StorageClass
+	StorageClassList       []storagev1.StorageClass
 }
 
 type MachineConfig struct {

--- a/pkg/scheduling/scheduling_test.go
+++ b/pkg/scheduling/scheduling_test.go
@@ -8,14 +8,6 @@ import (
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
 )
 
-// Monkey patching is used here
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-//
->>>>>>> 2d68348 (Adding more details about the pods and removed the boolean variable)
-=======
->>>>>>> 963e22f (Fixed the file scheduling_test.go to be gofmt)
 func TestProcessPidsCPUScheduling(t *testing.T) {
 	testPids := []int{101, 102}
 	testContainer := &provider.Container{}

--- a/pkg/scheduling/scheduling_test.go
+++ b/pkg/scheduling/scheduling_test.go
@@ -9,6 +9,13 @@ import (
 )
 
 // Monkey patching is used here
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+//
+>>>>>>> 2d68348 (Adding more details about the pods and removed the boolean variable)
+=======
+>>>>>>> 963e22f (Fixed the file scheduling_test.go to be gofmt)
 func TestProcessPidsCPUScheduling(t *testing.T) {
 	testPids := []int{101, 102}
 	testContainer := &provider.Container{}


### PR DESCRIPTION
build-depends: https://github.com/dci-labs/dallas-pipelines/pull/646

VCP CNF Requirement: PODs must NOT place persistent volumes on local storage.

We following pod by pod and check:
1) if PVC is not exist : we don't have what to check and we finished the test.
2) if name of PVC is equal to PVC of the pod:
-we check if provisioner of StorageClasees equal to"kubernetes.io/no-provisioner":
if yes, we found pod that use a local storage enabled storageClass and we add to list of pods that have local storage("podWithLocalStorage")

we check all volumes in all pods under test to see if they are used. If a pod is using a volume that is using a local StorageClass, we should fail the test.

The purpose is to find pods that have PVC&&PV and to use a local storage enabled StorageClasses.