### PR TITLE
Modify scripts to mount docker config

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -132,6 +132,7 @@ jobs:
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.kube/config'
+      PFLT_DOCKERCONFIG: '/home/runner/.docker/config'
 
     steps:
       - name: Set up Go 1.19.5

--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -40,6 +40,7 @@ jobs:
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.kube/config'
+      PFLT_DOCKERCONFIG: '/home/runner/.docker/config'
       CURRENT_VERSION_GENERIC_BRANCH: main
       TNF_VERSION: ""
       PARTNER_VERSION: ""

--- a/run-tnf-container.sh
+++ b/run-tnf-container.sh
@@ -75,6 +75,16 @@ usage() {
 	  run the access-control and networking tests, and save the test results into the '~/tnf/output' directory
 	  on the host.
 
+	  Because -c is omitted, $(basename "$0") will first try to autodiscover local docker config files.
+	  If it succeeds, the networking and access-control tests will be run using the autodiscovered configuration.
+	  The test results will be saved to the '~/tnf/output' directory on the host.
+
+	  $0 -c ~/.docker/conf1:~/.docker/conf2 -t ~/tnf/config -o ~/tnf/output -l "access-control,networking"
+
+	  The command will bind two docker config files (~/.docker/conf1 and ~/.docker/conf2) to the TNF container,
+	  run the access-control and networking tests, and save the test results into the '~/tnf/output' directory
+	  on the host.
+
 	  $0 -i custom-tnf-image:v1.2-dev -t ~/tnf/config -o ~/tnf/output -l "access-control,networking"
 
 	  The command will run the access-control and networking tests as implemented in the custom-tnf-image:v1.2-dev

--- a/run-tnf-container.sh
+++ b/run-tnf-container.sh
@@ -14,10 +14,9 @@
 #   KUBECONFIG=/usr/tnf/kubeconfig/config:/usr/tnf/kubeconfig/config.2
 
 export REQUIRED_NUM_OF_ARGS=5
-export REQUIRED_VARS=('LOCAL_KUBECONFIG' 'LOCAL_TNF_CONFIG' 'OUTPUT_LOC' 'LOCAL_DOCKERCFG')
+export REQUIRED_VARS=('LOCAL_KUBECONFIG' 'LOCAL_TNF_CONFIG' 'OUTPUT_LOC')
 export REQUIRED_VARS_ERROR_MESSAGES=(
 	'KUBECONFIG is invalid or not given. Use the -k option to provide path to one or more kubeconfig files.'
-	'DOCKERCFG is invalid or not given. Use the -c option to provide path to one or more dockercfg files.'
 	'TNFCONFIG is required. Use the -t option to specify the directory containing the TNF configuration files.'
 	'OUTPUT_LOC is required. Use the -o option to specify the output location for the test results.'
 )
@@ -130,6 +129,8 @@ perform_kubeconfig_autodiscovery() {
 }
 
 perform_dockercfg_autodiscovery() {
+  # As of now, the Docker Config is an optional variable to be supplied as the only test suite that
+  # requires it is the preflight suite.
   # See the openshift-preflight documentation about environment variables
   # https://github.com/redhat-openshift-ecosystem/openshift-preflight/blob/main/docs/CONFIG.md#container-policy-configuration
   if [[ -n "$PFLT_DOCKERCONFIG" ]]; then


### PR DESCRIPTION
Broken out from #631 

Using the `PFLT_DOCKERCONFIG` variable from preflight (found [here](https://github.com/redhat-openshift-ecosystem/openshift-preflight/blob/main/docs/CONFIG.md)) as a prerequisite for running the preflight library.

This change is in the PR #631 but I wanted to make it a separate change for reviewing sake.

If merged, nothing functionally changes it just has a new env variable available in the container.

build-depends: 27115