### PR TITLE
Remove unused var

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -9,7 +9,6 @@ on:
 env:
   REGISTRY: quay.io
   REGISTRY_LOCAL: localhost
-  RELEASE_LEVEL: '4.11'
   TNF_IMAGE_NAME: testnetworkfunction/cnf-certification-test
   TNF_IMAGE_TAG: unstable
   OCT_IMAGE_NAME: testnetworkfunction/oct


### PR DESCRIPTION
`RELEASE_LEVEL` is unused the pre-main.yaml and can be removed.  It is however still used in the tnf-image.yaml because the 4.0.x (legacy) release support still uses it.