### PR TITLE
Add more unit test coverage

### DIFF
--- a/cnf-certification-test/accesscontrol/resources/resources.go
+++ b/cnf-certification-test/accesscontrol/resources/resources.go
@@ -12,12 +12,12 @@ func HasRequestsAndLimitsSet(cut *provider.Container) bool {
 		tnf.ClaimFilePrintf("Container has been found missing resource limits: %s", cut.String())
 		passed = false
 	} else {
-		if cut.Resources.Limits.Cpu().Value() == 0 {
+		if cut.Resources.Limits.Cpu().IsZero() {
 			tnf.ClaimFilePrintf("Container has been found missing CPU limits: %s", cut.String())
 			passed = false
 		}
 
-		if cut.Resources.Limits.Memory().Value() == 0 {
+		if cut.Resources.Limits.Memory().IsZero() {
 			tnf.ClaimFilePrintf("Container has been found missing memory limits: %s", cut.String())
 			passed = false
 		}
@@ -28,12 +28,12 @@ func HasRequestsAndLimitsSet(cut *provider.Container) bool {
 		tnf.ClaimFilePrintf("Container has been found missing resource requests: %s", cut.String())
 		passed = false
 	} else {
-		if cut.Resources.Requests.Cpu().Value() == 0 {
+		if cut.Resources.Requests.Cpu().IsZero() {
 			tnf.ClaimFilePrintf("Container has been found missing CPU requests: %s", cut.String())
 			passed = false
 		}
 
-		if cut.Resources.Requests.Memory().Value() == 0 {
+		if cut.Resources.Requests.Memory().IsZero() {
 			tnf.ClaimFilePrintf("Container has been found missing memory requests: %s", cut.String())
 			passed = false
 		}
@@ -41,7 +41,7 @@ func HasRequestsAndLimitsSet(cut *provider.Container) bool {
 	return passed
 }
 
-// For more info on cpu mgmt polcies see https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/.
+// For more info on cpu management policies see https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/.
 func HasExclusiveCPUsAssigned(cut *provider.Container) bool {
 	cpuLimits := cut.Resources.Limits.Cpu()
 	memLimits := cut.Resources.Limits.Memory()

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -162,7 +162,7 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestCPUIsolationIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.GetGuaranteedPodsWithExlusiveCPUs())
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.GetGuaranteedPodsWithExclusiveCPUs())
 		testCPUIsolation(&env)
 	})
 
@@ -542,7 +542,7 @@ func testCPUIsolation(env *provider.TestEnvironment) {
 
 	podsMissingIsolationRequirements := make(map[string]bool)
 
-	for _, put := range env.GetGuaranteedPodsWithExlusiveCPUs() {
+	for _, put := range env.GetGuaranteedPodsWithExclusiveCPUs() {
 		if !put.IsCPUIsolationCompliant() {
 			podsMissingIsolationRequirements[put.Name] = true
 		}

--- a/pkg/provider/events_test.go
+++ b/pkg/provider/events_test.go
@@ -15,3 +15,24 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewEvent(t *testing.T) {
+	testEvent := corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testEvent",
+		},
+		Reason: "this is a test",
+	}
+
+	outputEvent := NewEvent(&testEvent)
+	assert.Equal(t, "testEvent", outputEvent.Name)
+	assert.Contains(t, outputEvent.String(), "reason=this is a test")
+}

--- a/pkg/provider/filters.go
+++ b/pkg/provider/filters.go
@@ -24,7 +24,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 )
 
-func (env *TestEnvironment) GetGuaranteedPodsWithExlusiveCPUs() []*Pod {
+func (env *TestEnvironment) GetGuaranteedPodsWithExclusiveCPUs() []*Pod {
 	var filteredPods []*Pod
 	for _, p := range env.Pods {
 		if p.IsPodGuaranteedWithExclusiveCPUs() {
@@ -85,7 +85,7 @@ func (env *TestEnvironment) GetHugepagesPods() []*Pod {
 }
 
 func (env *TestEnvironment) GetCPUPinningPodsWithDpdk() []*Pod {
-	return filterDPDKRunningPods(env.GetGuaranteedPodsWithExlusiveCPUs())
+	return filterDPDKRunningPods(env.GetGuaranteedPodsWithExclusiveCPUs())
 }
 
 func (env *TestEnvironment) GetNonGuaranteedPodContainers() []*Container {

--- a/pkg/provider/filters_test.go
+++ b/pkg/provider/filters_test.go
@@ -15,3 +15,280 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/cnf-certification-test/pkg/stringhelper"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+//nolint:funlen
+func TestGetGuaranteedPodsWithExclusiveCPUs(t *testing.T) {
+	generateEnv := func(cpuLimit, cpuRequest, memLimit, memRequest, podName string) *TestEnvironment {
+		return &TestEnvironment{
+			Pods: []*Pod{
+				{
+					Containers: []*Container{
+						{
+							Container: &corev1.Container{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"cpu":    resource.MustParse(cpuRequest),
+										"memory": resource.MustParse(memRequest),
+									},
+									Limits: corev1.ResourceList{
+										"cpu":    resource.MustParse(cpuLimit),
+										"memory": resource.MustParse(memLimit),
+									},
+								},
+							},
+						},
+					},
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: podName,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		testEnv      *TestEnvironment
+		expectedPods []string
+	}{
+		{
+			testEnv:      generateEnv(validCPULimit, validCPULimit, validMemLimit, validMemLimit, "pod1"),
+			expectedPods: []string{"pod1"},
+		},
+		{
+			testEnv:      generateEnv(invalidCPULimit1, validCPULimit, validMemLimit, validMemLimit, "pod1"), // invalid CPU limit
+			expectedPods: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		returnedPods := tc.testEnv.GetGuaranteedPodsWithExclusiveCPUs()
+		for _, r := range returnedPods {
+			assert.True(t, stringhelper.StringInSlice(tc.expectedPods, r.Name, false))
+		}
+
+		nonGuaranteedPods := tc.testEnv.GetNonGuaranteedPods()
+		for _, r := range nonGuaranteedPods {
+			assert.False(t, stringhelper.StringInSlice(tc.expectedPods, r.Name, false))
+		}
+	}
+}
+
+func TestGetGuaranteedPods(t *testing.T) {
+	generateEnv := func(cpuLimit, cpuRequest, memLimit, memRequest, podName string) *TestEnvironment {
+		return &TestEnvironment{
+			Pods: []*Pod{
+				{
+					Containers: []*Container{
+						{
+							Container: &corev1.Container{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"cpu":    resource.MustParse(cpuRequest),
+										"memory": resource.MustParse(memRequest),
+									},
+									Limits: corev1.ResourceList{
+										"cpu":    resource.MustParse(cpuLimit),
+										"memory": resource.MustParse(memLimit),
+									},
+								},
+							},
+						},
+					},
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: podName,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		testEnv      *TestEnvironment
+		expectedPods []string
+	}{
+		{
+			testEnv:      generateEnv(validCPULimit, validCPULimit, validMemLimit, validMemLimit, "pod1"),
+			expectedPods: []string{"pod1"},
+		},
+		{
+			testEnv:      generateEnv(invalidCPULimit1, validCPULimit, validMemLimit, validMemLimit, "pod1"), // invalid CPU limit
+			expectedPods: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		returnedPods := tc.testEnv.GetGuaranteedPods()
+		for _, r := range returnedPods {
+			assert.True(t, stringhelper.StringInSlice(tc.expectedPods, r.Name, false))
+		}
+	}
+}
+
+func TestAffinityRequiredFilters(t *testing.T) {
+	generateEnv := func(affinityRequiredVal, podName string) *TestEnvironment {
+		return &TestEnvironment{
+			Pods: []*Pod{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: podName,
+							Labels: map[string]string{
+								"AffinityRequired": affinityRequiredVal,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		testEnv      *TestEnvironment
+		expectedPods []string
+	}{
+		{
+			testEnv:      generateEnv("true", "pod1"),
+			expectedPods: []string{"pod1"},
+		},
+		{
+			testEnv:      generateEnv("false", "pod1"),
+			expectedPods: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		returnedPods := tc.testEnv.GetAffinityRequiredPods()
+		for _, r := range returnedPods {
+			assert.True(t, stringhelper.StringInSlice(tc.expectedPods, r.Name, false))
+		}
+
+		p := tc.testEnv.GetPodsWithoutAffinityRequiredLabel()
+		for _, r := range p {
+			assert.False(t, stringhelper.StringInSlice(tc.expectedPods, r.Name, false))
+		}
+	}
+}
+
+func TestGetShareProcessNamespacePods(t *testing.T) {
+	generateEnv := func(spn *bool, podName string) *TestEnvironment {
+		return &TestEnvironment{
+			Pods: []*Pod{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: podName,
+						},
+						Spec: corev1.PodSpec{
+							ShareProcessNamespace: spn,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	trueVar := true
+	falseVar := false
+
+	testCases := []struct {
+		testEnv      *TestEnvironment
+		expectedPods []string
+	}{
+		{
+			testEnv:      generateEnv(nil, "pod1"),
+			expectedPods: []string{},
+		},
+		{
+			testEnv:      generateEnv(&trueVar, "pod1"),
+			expectedPods: []string{"pod1"},
+		},
+		{
+			testEnv:      generateEnv(&falseVar, "pod1"),
+			expectedPods: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		returnedPods := tc.testEnv.GetShareProcessNamespacePods()
+		for _, r := range returnedPods {
+			assert.True(t, stringhelper.StringInSlice(tc.expectedPods, r.Name, false))
+		}
+	}
+}
+
+//nolint:funlen
+func TestGetHugepagesPods(t *testing.T) {
+	generateEnv := func(podName string, resources, limits bool) *TestEnvironment {
+		testEnv := &TestEnvironment{
+			Pods: []*Pod{
+				{
+					Containers: []*Container{
+						{
+							Container: &corev1.Container{
+								Name: "container1",
+							},
+						},
+					},
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: podName,
+						},
+					},
+				},
+			},
+		}
+
+		if resources {
+			testEnv.Pods[0].Containers[0].Resources.Requests = corev1.ResourceList{
+				"hugepages": resource.MustParse(validCPULimit),
+			}
+		}
+
+		if limits {
+			testEnv.Pods[0].Containers[0].Resources.Limits = corev1.ResourceList{
+				"hugepages": resource.MustParse(validCPULimit),
+			}
+		}
+
+		return testEnv
+	}
+
+	testCases := []struct {
+		testEnv      *TestEnvironment
+		expectedPods []string
+	}{
+		{
+			testEnv:      generateEnv("pod1", false, false),
+			expectedPods: []string{},
+		},
+		{
+			testEnv:      generateEnv("pod1", true, false),
+			expectedPods: []string{"pod1"},
+		},
+		{
+			testEnv:      generateEnv("pod1", false, true),
+			expectedPods: []string{"pod1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		returnedPods := tc.testEnv.GetHugepagesPods()
+		for _, r := range returnedPods {
+			assert.True(t, stringhelper.StringInSlice(tc.expectedPods, r.Name, false))
+		}
+	}
+}

--- a/pkg/provider/isolation.go
+++ b/pkg/provider/isolation.go
@@ -36,13 +36,13 @@ func AreResourcesIdentical(p *Pod) bool {
 		memoryLimits := cut.Resources.Limits.Memory()
 
 		// Check for mismatches
-		if cpuRequests.Value() != cpuLimits.Value() {
-			logrus.Debugf("%s has CPU requests %d and limits %d that do not match.", cut.String(), cpuRequests.Value(), cpuLimits.Value())
+		if !cpuRequests.Equal(*cpuLimits) {
+			logrus.Debugf("%s has CPU requests %f and limits %f that do not match.", cut.String(), cpuRequests.AsApproximateFloat64(), cpuLimits.AsApproximateFloat64())
 			return false
 		}
 
-		if memoryRequests.Value() != memoryLimits.Value() {
-			logrus.Debugf("%s has memory requests %d and limits %d that do not match.", cut.String(), memoryRequests.Value(), memoryLimits.Value())
+		if !memoryRequests.Equal(*memoryLimits) {
+			logrus.Debugf("%s has memory requests %f and limits %f that do not match.", cut.String(), memoryRequests.AsApproximateFloat64(), memoryLimits.AsApproximateFloat64())
 			return false
 		}
 	}


### PR DESCRIPTION
Changed the references from `.Value()` to `IsZero()` in the requests/limits checks.

Adds some new unit tests in:
- pkg/provider/events_test.go
- pkg/provider/filters_test.go

Previously, there was no unit test coverage in either of these files.