### PR TITLE
Dynamically install ginkgo based on go.mod in 'install-tools'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ build-cnf-tests-debug:
 
 # Install build tools and other required software.
 install-tools:
-	go install github.com/onsi/ginkgo/v2/ginkgo@v2.7.0
+	go install "$$(awk '/ginkgo/ {printf "%s/ginkgo@%s", $$1, $$2}' go.mod)"
 
 # Install golangci-lint	
 install-lint:


### PR DESCRIPTION
Instead of having to manually bump the `install-tools` path in the Makefile every time Ginkgo updates, this should dynamically grab the line that installs whatever is in the go.mod.