### PR TITLE
Safeguard against empty variable

### DIFF
--- a/script/run-container.sh
+++ b/script/run-container.sh
@@ -125,6 +125,11 @@ container_tnf_kubeconfig_volumes_cmd_args=$(printf -- "-v %s " "${container_tnf_
 CONTAINER_TNF_DOCKERCFG=$(join_paths "${container_tnf_dockercfg_paths[@]}")
 container_tnf_dockercfg_volumes_cmd_args=$(printf -- "-v %s " "${container_tnf_dockercfg_volume_bindings[@]}")
 
+# Safeguard against an empty variable
+if [ -z "$CONTAINER_TNF_DOCKERCFG" ]; then
+	CONTAINER_TNF_DOCKERCFG=NA
+fi
+
 if [ -n "${LOCAL_TNF_CONFIG}" ]; then
 	CONFIG_VOLUME_MOUNT_ARG="-v $LOCAL_TNF_CONFIG:$CONTAINER_TNF_DIR/config:Z"
 fi


### PR DESCRIPTION
If `CONTAINER_TNF_DOCKERCFG` is unset after the discovery phase, just use a default string of `NA`.

#631 will require an actual docker config being created/supplied but as of right now it isn't merged yet.

Related to: #804 