### PR TITLE
Adjust ginkgo.Skip calls

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -406,7 +406,8 @@ func TestPodRoleBindings(env *provider.TestEnvironment) {
 	for _, put := range env.Pods {
 		ginkgo.By(fmt.Sprintf("Testing role binding for pod: %s namespace: %s", put.Name, put.Namespace))
 		if put.Spec.ServiceAccountName == "" {
-			ginkgo.Skip("Can not test when serviceAccountName is empty. Please check previous tests for failures")
+			logrus.Infof("%s has an empty serviceAccountName, skipping.", put.String())
+			continue
 		}
 
 		// Get any rolebindings that do not belong to the pod namespace.
@@ -434,7 +435,8 @@ func TestPodClusterRoleBindings(env *provider.TestEnvironment) {
 	for _, put := range env.Pods {
 		ginkgo.By(fmt.Sprintf("Testing cluster role binding for pod: %s namespace: %s", put.Name, put.Namespace))
 		if put.Spec.ServiceAccountName == "" {
-			ginkgo.Skip("Can not test when serviceAccountName is empty. Please check previous tests for failures")
+			logrus.Infof("%s has an empty serviceAccountName, skipping.", put.String())
+			continue
 		}
 
 		// Get any clusterrolebindings that do not belong to the pod namespace.

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -53,18 +53,17 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 
 	testID, tags := identifiers.GetGinkgoTestIDAndLabels(identifiers.TestUnalteredBaseImageIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		if provider.IsOCPCluster() {
-			testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
-			testContainersFsDiff(&env)
-		} else {
-			ginkgo.Skip(" non ocp cluster ")
+		if !provider.IsOCPCluster() {
+			ginkgo.Skip("Non-OCP cluster found, skipping testContainersFsDiff")
 		}
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
+		testContainersFsDiff(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestNonTaintedNodeKernelsIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
 		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.DebugPods)
-		testTainted(&env) // minikube tainted kernels are allowed via config
+		testTainted(&env) // Kind tainted kernels are allowed via config
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestIsRedHatReleaseIdentifier)
@@ -75,42 +74,38 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestIsSELinuxEnforcingIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		if provider.IsOCPCluster() {
-			testhelper.SkipIfEmptyAny(ginkgo.Skip, env.DebugPods)
-			testIsSELinuxEnforcing(&env)
-		} else {
-			ginkgo.Skip(" non ocp cluster ")
+		if !provider.IsOCPCluster() {
+			ginkgo.Skip("Non-OCP cluster found, skipping testIsSELinuxEnforcing")
 		}
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.DebugPods)
+		testIsSELinuxEnforcing(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestHugepagesNotManuallyManipulated)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		if provider.IsOCPCluster() {
-			testhelper.SkipIfEmptyAny(ginkgo.Skip, env.DebugPods)
-			testHugepages(&env)
-		} else {
-			ginkgo.Skip(" non ocp cluster ")
+		if !provider.IsOCPCluster() {
+			ginkgo.Skip("Non-OCP cluster found, skipping testHugepages")
 		}
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.DebugPods)
+		testHugepages(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestUnalteredStartupBootParamsIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		if provider.IsOCPCluster() {
-			testhelper.SkipIfEmptyAny(ginkgo.Skip, env.DebugPods)
-			testUnalteredBootParams(&env)
-		} else {
-			ginkgo.Skip(" non ocp cluster ")
+		if !provider.IsOCPCluster() {
+			ginkgo.Skip("Non-OCP cluster found, skipping testUnalteredBootParams")
 		}
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.DebugPods)
+		testUnalteredBootParams(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestSysctlConfigsIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		if provider.IsOCPCluster() {
-			testhelper.SkipIfEmptyAny(ginkgo.Skip, env.DebugPods)
-			testSysctlConfigs(&env)
-		} else {
-			ginkgo.Skip(" non ocp cluster ")
+		if !provider.IsOCPCluster() {
+			ginkgo.Skip("Non-OCP cluster found, skipping testSysctlConfigs")
 		}
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.DebugPods)
+		testSysctlConfigs(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestServiceMeshIdentifier)
@@ -121,32 +116,36 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestOCPLifecycleIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		if provider.IsOCPCluster() {
-			testOCPStatus(&env)
+		if !provider.IsOCPCluster() {
+			ginkgo.Skip("Non-OCP cluster found, skipping testOCPStatus")
 		}
+		testOCPStatus(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestNodeOperatingSystemIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		if provider.IsOCPCluster() {
-			testNodeOperatingSystemStatus(&env)
+		if !provider.IsOCPCluster() {
+			ginkgo.Skip("Non-OCP cluster found, skipping testNodeOperatingSystemStatus")
 		}
+		testNodeOperatingSystemStatus(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestPodHugePages2M)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		if provider.IsOCPCluster() {
-			testhelper.SkipIfEmptyAny(ginkgo.Skip, env.GetHugepagesPods())
-			testPodHugePagesSize(&env, provider.HugePages2Mi)
+		if !provider.IsOCPCluster() {
+			ginkgo.Skip("Non-OCP cluster found, skipping testPodHugePagesSize2M")
 		}
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.GetHugepagesPods())
+		testPodHugePagesSize(&env, provider.HugePages2Mi)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestPodHugePages1G)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		if provider.IsOCPCluster() {
-			testhelper.SkipIfEmptyAny(ginkgo.Skip, env.GetHugepagesPods())
-			testPodHugePagesSize(&env, provider.HugePages1Gi)
+		if !provider.IsOCPCluster() {
+			ginkgo.Skip("Non-OCP cluster found, skipping testPodHugePagesSize1G")
 		}
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.GetHugepagesPods())
+		testPodHugePagesSize(&env, provider.HugePages1Gi)
 	})
 
 })

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -447,7 +447,7 @@ func createNodes(nodes []corev1.Node) map[string]Node {
 		if !IsOCPCluster() {
 			// Avoid getting Mc info for non ocp clusters.
 			wrapperNodes[node.Name] = Node{Data: node}
-			logrus.Warnf("Non OCP cluster detected. MachineConfig retrieval for node %s skipped.", node.Name)
+			logrus.Warnf("Non-OCP cluster detected. MachineConfig retrieval for node %s skipped.", node.Name)
 			continue
 		}
 

--- a/pkg/scheduling/scheduling_test.go
+++ b/pkg/scheduling/scheduling_test.go
@@ -9,8 +9,6 @@ import (
 )
 
 // Monkey patching is used here
-//
-//nolint:funlen
 func TestProcessPidsCPUScheduling(t *testing.T) {
 	testPids := []int{101, 102}
 	testContainer := &provider.Container{}


### PR DESCRIPTION
Changes:
- In `TestPodRoleBindings` and `TestPodClusterRoleBindings`, instead of skipping the entire test because a Pod is missing a `serviceAccountName`, just continue and move on.
- Adjust when `ginkgo.Skip` is called when an OCP cluster is detected