### PR TITLE
POC: Add Failure Reason to claim.json

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -648,17 +648,19 @@ func test1337UIDs(env *provider.TestEnvironment) {
 // an allowed one will pass the test
 
 func testContainerSCC(env *provider.TestEnvironment) {
-	var compliantObjects []*testhelper.ObjectOut
-	var nonCompliantObjects []*testhelper.ObjectOut
+	var compliantObjects []*testhelper.ReportObject
+	var nonCompliantObjects []*testhelper.ReportObject
 	highLevelCat := securitycontextcontainer.CategoryID1
 	for _, pod := range env.Pods {
 		listCategory := securitycontextcontainer.CheckPod(pod)
 		for _, cat := range listCategory {
 			if cat.Category > securitycontextcontainer.CategoryID1NoUID0 {
-				aContainerOut := testhelper.NewContainerObjectOutBase(cat.NameSpace, cat.Podname, cat.Containername, "container category is NOT category 1 or category NoUID0", false).AddField(testhelper.Category, cat.Category.String())
+				aContainerOut := testhelper.NewContainerReportObject(cat.NameSpace, cat.Podname, cat.Containername, "container category is NOT category 1 or category NoUID0", false).
+					SetType(testhelper.ContainerCategory).
+					AddField(testhelper.Category, cat.Category.String())
 				nonCompliantObjects = append(nonCompliantObjects, aContainerOut)
 			} else {
-				aContainerOut := testhelper.NewContainerObjectOutBase(cat.NameSpace, cat.Podname, cat.Containername, "container category is category 1 or category NoUID0", false).AddField(testhelper.Category, cat.Category.String())
+				aContainerOut := testhelper.NewContainerReportObject(cat.NameSpace, cat.Podname, cat.Containername, "container category is category 1 or category NoUID0", false).AddField(testhelper.Category, cat.Category.String())
 				compliantObjects = append(compliantObjects, aContainerOut)
 			}
 			if cat.Category > highLevelCat {
@@ -666,7 +668,7 @@ func testContainerSCC(env *provider.TestEnvironment) {
 			}
 		}
 	}
-	aCNFOut := testhelper.New("Overall Pod category", false).SetType(testhelper.CnfType).AddField(testhelper.Category, highLevelCat.String())
+	aCNFOut := testhelper.NewReportObject("Overall CNF category", testhelper.CnfType, false).AddField(testhelper.Category, highLevelCat.String())
 	compliantObjects = append(compliantObjects, aCNFOut)
 	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, ginkgo.Fail)
 }

--- a/cnf-certification-test/performance/suite.go
+++ b/cnf-certification-test/performance/suite.go
@@ -121,7 +121,7 @@ func testSchedulingPolicyInCPUPool(env *provider.TestEnvironment,
 
 		if err != nil {
 			nonCompliantContainersPids = append(nonCompliantContainersPids,
-				testhelper.NewContainerObjectOut(testContainer, fmt.Sprintf("Internal error, err=%s", err), false))
+				testhelper.NewContainerReportObject(testContainer.Namespace, testContainer.Podname, testContainer.Name, fmt.Sprintf("Internal error, err=%s", err), false))
 		}
 
 		compliantPids, nonCompliantPids := scheduling.ProcessPidsCPUScheduling(processes, testContainer, schedulingType)

--- a/pkg/scheduling/scheduling.go
+++ b/pkg/scheduling/scheduling.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/internal/crclient"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
+	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
 )
 
@@ -78,12 +79,17 @@ func parseSchedulingPolicyAndPriority(chrtCommandOutput string) (schedPolicy str
 	return schedPolicy, schedPriority, nil
 }
 
-func ProcessPidsCPUScheduling(pids []int, testContainer *provider.Container, nonCompliantContainers map[*provider.Container][]int, check string) (hasCPUSchedulingConditionSuccess bool) {
-	for _, pid := range pids {
-		schedulePolicy, schedulePriority, err := GetProcessCPUSchedulingFn(pid, testContainer)
+var schedulingRequirements = map[string]string{SharedCPUScheduling: "SHARED_CPU_SCHEDULING: scheduling priority == 0",
+	ExclusiveCPUScheduling: "EXCLUSIVE_CPU_SCHEDULING: scheduling priority < 10 and scheduling policy == SCHED_RR or SCHED_FIFO",
+	IsolatedCPUScheduling:  "ISOLATED_CPU_SCHEDULING: scheduling policy == SCHED_RR or SCHED_FIFO"}
+
+func ProcessPidsCPUScheduling(processes []*crclient.Process, testContainer *provider.Container, check string) (compliantContainerPids, nonCompliantContainerPids []*testhelper.ObjectOut) {
+	hasCPUSchedulingConditionSuccess := false
+	for _, process := range processes {
+		schedulePolicy, schedulePriority, err := GetProcessCPUSchedulingFn(process.Pid, testContainer)
 		if err != nil {
 			logrus.Errorf("error getting the scheduling policy and priority : %v", err)
-			return hasCPUSchedulingConditionSuccess
+			return compliantContainerPids, nonCompliantContainerPids
 		}
 
 		switch check {
@@ -96,17 +102,16 @@ func ProcessPidsCPUScheduling(pids []int, testContainer *provider.Container, non
 		}
 
 		if !hasCPUSchedulingConditionSuccess {
-			tnf.ClaimFilePrintf("pid=%d in %v with cpu scheduling policy=%s, priority=%s did not satisfy cpu scheduling requirements", pid, testContainer, schedulePolicy, schedulePriority)
-			nonCompliantProcessIds, ok := nonCompliantContainers[testContainer]
-			if !ok {
-				nonCompliantContainers[testContainer] = []int{pid}
-			} else {
-				nonCompliantProcessIds = append(nonCompliantProcessIds, pid)
-				nonCompliantContainers[testContainer] = nonCompliantProcessIds
-			}
+			tnf.ClaimFilePrintf("pid=%d in %s with cpu scheduling policy=%s, priority=%s did not satisfy cpu scheduling requirements", process.Pid, testContainer, schedulePolicy, schedulePriority)
+			aPidOut := testhelper.NewProcessObjectOut(testhelper.NewContainerObjectOut(testContainer, "process does not satisfy: "+schedulingRequirements[check], false), schedulePolicy, fmt.Sprint(schedulePriority), process.Args)
+			nonCompliantContainerPids = append(nonCompliantContainerPids, aPidOut)
+			continue
 		}
+		tnf.ClaimFilePrintf("pid=%d in %s with cpu scheduling policy=%s, priority=%s satisfies cpu scheduling requirements", process.Pid, testContainer, schedulePolicy, schedulePriority)
+		aPidOut := testhelper.NewProcessObjectOut(testhelper.NewContainerObjectOut(testContainer, "process satisfies: "+schedulingRequirements[check], true), schedulePolicy, fmt.Sprint(schedulePriority), process.Args)
+		compliantContainerPids = append(compliantContainerPids, aPidOut)
 	}
-	return hasCPUSchedulingConditionSuccess
+	return compliantContainerPids, nonCompliantContainerPids
 }
 
 func GetProcessCPUScheduling(pid int, testContainer *provider.Container) (schedulePolicy string, schedulePriority int, err error) {

--- a/pkg/scheduling/scheduling_test.go
+++ b/pkg/scheduling/scheduling_test.go
@@ -35,14 +35,14 @@ func TestProcessPidsCPUScheduling(t *testing.T) {
 	testCases := []struct {
 		mockGetProcessCPUScheduling func(int, *provider.Container) (string, int, error)
 		check                       string
-		compliant, nonCompliant     []testhelper.ObjectOut
+		compliant, nonCompliant     []testhelper.ReportObject
 	}{
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_OTHER", 0, nil
 			},
 			check: SharedCPUScheduling,
-			compliant: []testhelper.ObjectOut{
+			compliant: []testhelper.ReportObject{
 				{
 					ObjectType: "ContainerProcess",
 					ObjectFields: map[string]string{
@@ -65,14 +65,14 @@ func TestProcessPidsCPUScheduling(t *testing.T) {
 				},
 			},
 
-			nonCompliant: []testhelper.ObjectOut{},
+			nonCompliant: []testhelper.ReportObject{},
 		},
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_RR", 90, nil
 			},
 			check: SharedCPUScheduling,
-			nonCompliant: []testhelper.ObjectOut{
+			nonCompliant: []testhelper.ReportObject{
 				{
 					ObjectType: "ContainerProcess",
 					ObjectFields: map[string]string{
@@ -95,13 +95,13 @@ func TestProcessPidsCPUScheduling(t *testing.T) {
 				},
 			},
 
-			compliant: []testhelper.ObjectOut{}},
+			compliant: []testhelper.ReportObject{}},
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_FIFO", 9, nil
 			},
 			check: ExclusiveCPUScheduling,
-			compliant: []testhelper.ObjectOut{
+			compliant: []testhelper.ReportObject{
 				{
 					ObjectType: "ContainerProcess",
 					ObjectFields: map[string]string{
@@ -124,13 +124,13 @@ func TestProcessPidsCPUScheduling(t *testing.T) {
 				},
 			},
 
-			nonCompliant: []testhelper.ObjectOut{}},
+			nonCompliant: []testhelper.ReportObject{}},
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_FIFO", 11, nil
 			},
 			check: ExclusiveCPUScheduling,
-			nonCompliant: []testhelper.ObjectOut{
+			nonCompliant: []testhelper.ReportObject{
 				{
 					ObjectType: "ContainerProcess",
 					ObjectFields: map[string]string{
@@ -153,13 +153,13 @@ func TestProcessPidsCPUScheduling(t *testing.T) {
 				},
 			},
 
-			compliant: []testhelper.ObjectOut{}},
+			compliant: []testhelper.ReportObject{}},
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_FIFO", 50, nil
 			},
 			check: IsolatedCPUScheduling,
-			compliant: []testhelper.ObjectOut{
+			compliant: []testhelper.ReportObject{
 				{
 					ObjectType: "ContainerProcess",
 					ObjectFields: map[string]string{
@@ -182,13 +182,13 @@ func TestProcessPidsCPUScheduling(t *testing.T) {
 				},
 			},
 
-			nonCompliant: []testhelper.ObjectOut{}},
+			nonCompliant: []testhelper.ReportObject{}},
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_RR", 99, nil
 			},
 			check: IsolatedCPUScheduling,
-			compliant: []testhelper.ObjectOut{
+			compliant: []testhelper.ReportObject{
 				{
 					ObjectType: "ContainerProcess",
 					ObjectFields: map[string]string{
@@ -211,13 +211,13 @@ func TestProcessPidsCPUScheduling(t *testing.T) {
 				},
 			},
 
-			nonCompliant: []testhelper.ObjectOut{}},
+			nonCompliant: []testhelper.ReportObject{}},
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_OTHER", 0, nil
 			},
 			check: IsolatedCPUScheduling,
-			nonCompliant: []testhelper.ObjectOut{
+			nonCompliant: []testhelper.ReportObject{
 				{
 					ObjectType: "ContainerProcess",
 					ObjectFields: map[string]string{
@@ -240,7 +240,7 @@ func TestProcessPidsCPUScheduling(t *testing.T) {
 				},
 			},
 
-			compliant: []testhelper.ObjectOut{}},
+			compliant: []testhelper.ReportObject{}},
 	}
 	for _, tc := range testCases {
 		GetProcessCPUSchedulingFn = tc.mockGetProcessCPUScheduling

--- a/pkg/scheduling/scheduling_test.go
+++ b/pkg/scheduling/scheduling_test.go
@@ -21,72 +21,239 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/cnf-certification-test/internal/crclient"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
+	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestProcessPidsCPUScheduling(t *testing.T) {
-	testPids := []int{101, 102}
+	testPids := []*crclient.Process{{PidNs: 2, Pid: 101, Args: "tbd command line"}, {PidNs: 3, Pid: 102, Args: "tbd command line"}}
 	testContainer := &provider.Container{}
+	testContainer.Container = &corev1.Container{}
 
 	testCases := []struct {
-		mockGetProcessCPUScheduling           func(int, *provider.Container) (string, int, error)
-		check                                 string
-		expectedCPUSchedulingConditionSuccess bool
+		mockGetProcessCPUScheduling func(int, *provider.Container) (string, int, error)
+		check                       string
+		compliant, nonCompliant     []testhelper.ObjectOut
 	}{
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_OTHER", 0, nil
 			},
-			check:                                 SharedCPUScheduling,
-			expectedCPUSchedulingConditionSuccess: true,
+			check: SharedCPUScheduling,
+			compliant: []testhelper.ObjectOut{
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFields: map[string]string{
+						"ContainerName":       "",
+						"Namespace":           "",
+						"PodName":             "",
+						"ReasonForCompliance": "process satisfies: SHARED_CPU_SCHEDULING: scheduling priority == 0",
+						"SchedulingPolicy":    "SCHED_OTHER", "SchedulingPriority": "0", "ProcessCommandLine": "tbd command line",
+					},
+				},
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFields: map[string]string{
+						"ContainerName":       "",
+						"Namespace":           "",
+						"PodName":             "",
+						"ReasonForCompliance": "process satisfies: SHARED_CPU_SCHEDULING: scheduling priority == 0",
+						"SchedulingPolicy":    "SCHED_OTHER", "SchedulingPriority": "0", "ProcessCommandLine": "tbd command line",
+					},
+				},
+			},
+
+			nonCompliant: []testhelper.ObjectOut{},
 		},
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_RR", 90, nil
 			},
-			check:                                 SharedCPUScheduling,
-			expectedCPUSchedulingConditionSuccess: false,
-		},
+			check: SharedCPUScheduling,
+			nonCompliant: []testhelper.ObjectOut{
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFields: map[string]string{
+						"ContainerName":          "",
+						"Namespace":              "",
+						"PodName":                "",
+						"ReasonForNonCompliance": "process does not satisfy: SHARED_CPU_SCHEDULING: scheduling priority == 0",
+						"SchedulingPolicy":       "SCHED_RR", "SchedulingPriority": "90", "ProcessCommandLine": "tbd command line",
+					},
+				},
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFields: map[string]string{
+						"ContainerName":          "",
+						"Namespace":              "",
+						"PodName":                "",
+						"ReasonForNonCompliance": "process does not satisfy: SHARED_CPU_SCHEDULING: scheduling priority == 0",
+						"SchedulingPolicy":       "SCHED_RR", "SchedulingPriority": "90", "ProcessCommandLine": "tbd command line",
+					},
+				},
+			},
+
+			compliant: []testhelper.ObjectOut{}},
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_FIFO", 9, nil
 			},
-			check:                                 ExclusiveCPUScheduling,
-			expectedCPUSchedulingConditionSuccess: true,
-		},
+			check: ExclusiveCPUScheduling,
+			compliant: []testhelper.ObjectOut{
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFields: map[string]string{
+						"ContainerName":       "",
+						"Namespace":           "",
+						"PodName":             "",
+						"ReasonForCompliance": "process satisfies: EXCLUSIVE_CPU_SCHEDULING: scheduling priority < 10 and scheduling policy == SCHED_RR or SCHED_FIFO",
+						"SchedulingPolicy":    "SCHED_FIFO", "SchedulingPriority": "9", "ProcessCommandLine": "tbd command line",
+					},
+				},
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFields: map[string]string{
+						"ContainerName":       "",
+						"Namespace":           "",
+						"PodName":             "",
+						"ReasonForCompliance": "process satisfies: EXCLUSIVE_CPU_SCHEDULING: scheduling priority < 10 and scheduling policy == SCHED_RR or SCHED_FIFO",
+						"SchedulingPolicy":    "SCHED_FIFO", "SchedulingPriority": "9", "ProcessCommandLine": "tbd command line",
+					},
+				},
+			},
+
+			nonCompliant: []testhelper.ObjectOut{}},
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_FIFO", 11, nil
 			},
-			check:                                 ExclusiveCPUScheduling,
-			expectedCPUSchedulingConditionSuccess: false,
-		},
+			check: ExclusiveCPUScheduling,
+			nonCompliant: []testhelper.ObjectOut{
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFields: map[string]string{
+						"ContainerName":          "",
+						"Namespace":              "",
+						"PodName":                "",
+						"ReasonForNonCompliance": "process does not satisfy: EXCLUSIVE_CPU_SCHEDULING: scheduling priority < 10 and scheduling policy == SCHED_RR or SCHED_FIFO",
+						"SchedulingPolicy":       "SCHED_FIFO", "SchedulingPriority": "11", "ProcessCommandLine": "tbd command line",
+					},
+				},
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFields: map[string]string{
+						"ContainerName":          "",
+						"Namespace":              "",
+						"PodName":                "",
+						"ReasonForNonCompliance": "process does not satisfy: EXCLUSIVE_CPU_SCHEDULING: scheduling priority < 10 and scheduling policy == SCHED_RR or SCHED_FIFO",
+						"SchedulingPolicy":       "SCHED_FIFO", "SchedulingPriority": "11", "ProcessCommandLine": "tbd command line",
+					},
+				},
+			},
+
+			compliant: []testhelper.ObjectOut{}},
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_FIFO", 50, nil
 			},
-			check:                                 IsolatedCPUScheduling,
-			expectedCPUSchedulingConditionSuccess: true,
-		},
+			check: IsolatedCPUScheduling,
+			compliant: []testhelper.ObjectOut{
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFields: map[string]string{
+						"ContainerName":       "",
+						"Namespace":           "",
+						"PodName":             "",
+						"ReasonForCompliance": "process satisfies: ISOLATED_CPU_SCHEDULING: scheduling policy == SCHED_RR or SCHED_FIFO",
+						"SchedulingPolicy":    "SCHED_FIFO", "SchedulingPriority": "50", "ProcessCommandLine": "tbd command line",
+					},
+				},
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFields: map[string]string{
+						"ContainerName":       "",
+						"Namespace":           "",
+						"PodName":             "",
+						"ReasonForCompliance": "process satisfies: ISOLATED_CPU_SCHEDULING: scheduling policy == SCHED_RR or SCHED_FIFO",
+						"SchedulingPolicy":    "SCHED_FIFO", "SchedulingPriority": "50", "ProcessCommandLine": "tbd command line",
+					},
+				},
+			},
+
+			nonCompliant: []testhelper.ObjectOut{}},
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_RR", 99, nil
 			},
-			check:                                 IsolatedCPUScheduling,
-			expectedCPUSchedulingConditionSuccess: true,
-		},
+			check: IsolatedCPUScheduling,
+			compliant: []testhelper.ObjectOut{
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFields: map[string]string{
+						"ContainerName":       "",
+						"Namespace":           "",
+						"PodName":             "",
+						"ReasonForCompliance": "process satisfies: ISOLATED_CPU_SCHEDULING: scheduling policy == SCHED_RR or SCHED_FIFO",
+						"SchedulingPolicy":    "SCHED_RR", "SchedulingPriority": "99", "ProcessCommandLine": "tbd command line",
+					},
+				},
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFields: map[string]string{
+						"ContainerName":       "",
+						"Namespace":           "",
+						"PodName":             "",
+						"ReasonForCompliance": "process satisfies: ISOLATED_CPU_SCHEDULING: scheduling policy == SCHED_RR or SCHED_FIFO",
+						"SchedulingPolicy":    "SCHED_RR", "SchedulingPriority": "99", "ProcessCommandLine": "tbd command line",
+					},
+				},
+			},
+
+			nonCompliant: []testhelper.ObjectOut{}},
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_OTHER", 0, nil
 			},
-			check:                                 IsolatedCPUScheduling,
-			expectedCPUSchedulingConditionSuccess: false,
-		},
+			check: IsolatedCPUScheduling,
+			nonCompliant: []testhelper.ObjectOut{
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFields: map[string]string{
+						"ContainerName":          "",
+						"Namespace":              "",
+						"PodName":                "",
+						"ReasonForNonCompliance": "process does not satisfy: ISOLATED_CPU_SCHEDULING: scheduling policy == SCHED_RR or SCHED_FIFO",
+						"SchedulingPolicy":       "SCHED_OTHER", "SchedulingPriority": "0", "ProcessCommandLine": "tbd command line",
+					},
+				},
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFields: map[string]string{
+						"ContainerName":          "",
+						"Namespace":              "",
+						"PodName":                "",
+						"ReasonForNonCompliance": "process does not satisfy: ISOLATED_CPU_SCHEDULING: scheduling policy == SCHED_RR or SCHED_FIFO",
+						"SchedulingPolicy":       "SCHED_OTHER", "SchedulingPriority": "0", "ProcessCommandLine": "tbd command line",
+					},
+				},
+			},
+
+			compliant: []testhelper.ObjectOut{}},
 	}
 	for _, tc := range testCases {
 		GetProcessCPUSchedulingFn = tc.mockGetProcessCPUScheduling
-		isCheckSuccessful := ProcessPidsCPUScheduling(testPids, testContainer, make(map[*provider.Container][]int), tc.check)
-		assert.Equal(t, isCheckSuccessful, tc.expectedCPUSchedulingConditionSuccess)
+		compliant, nonCompliant := ProcessPidsCPUScheduling(testPids, testContainer, tc.check)
+
+		assert.Equal(t, len(compliant), len(tc.compliant))
+		assert.Equal(t, len(nonCompliant), len(tc.nonCompliant))
+		for i := range compliant {
+			assert.Equal(t, tc.compliant[i], *compliant[i])
+		}
+		for i := range nonCompliant {
+			assert.Equal(t, tc.nonCompliant[i], *nonCompliant[i])
+		}
 	}
 }
 

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -51,9 +51,12 @@ const (
 	SchedulingPriority     = "SchedulingPriority"
 	ReasonForNonCompliance = "ReasonForNonCompliance"
 	ReasonForCompliance    = "ReasonForCompliance"
+	Category               = "Category"
 )
 
 const (
+	UndefinedType        = "Undefined Type"
+	CnfType              = "Cnf"
 	PodType              = "Pod"
 	ContainerType        = "Container"
 	ContainerProcessType = "ContainerProcess"
@@ -69,33 +72,47 @@ func NewProcessObjectOut(aContainer *ObjectOut, aPolicy, aPriority, aCommandLine
 }
 
 func NewContainerObjectOut(aContainer *provider.Container, aReason string, isCompliant bool) (out *ObjectOut) {
-	out = &ObjectOut{}
-	out.ObjectType = ContainerType
-	out.ObjectFields = make(map[string]string)
-	out.ObjectFields[Namespace] = aContainer.Namespace
-	out.ObjectFields[PodName] = aContainer.Podname
-	out.ObjectFields[ContainerName] = aContainer.Name
-	if isCompliant {
-		out.ObjectFields[ReasonForCompliance] = aReason
-	} else {
-		out.ObjectFields[ReasonForNonCompliance] = aReason
-	}
+	return NewContainerObjectOutBase(aContainer.Namespace, aContainer.Podname, aContainer.Name, aReason, isCompliant)
+}
 
+func NewContainerObjectOutBase(aNamespace, aPodName, aContainerName, aReason string, isCompliant bool) (out *ObjectOut) {
+	out = New(aReason, isCompliant)
+	out.ObjectType = ContainerType
+	out.ObjectFields[Namespace] = aNamespace
+	out.ObjectFields[PodName] = aPodName
+	out.ObjectFields[ContainerName] = aContainerName
 	return out
 }
 
-func NewPodObjectOut(aPod *provider.Pod, aReason string, isCompliant bool) (out *ObjectOut) {
-	out = &ObjectOut{}
+func NewPodObjectOut(aPod *provider.Pod, aCategory, aReason string, isCompliant bool) (out *ObjectOut) {
+	out = New(aReason, isCompliant)
 	out.ObjectType = PodType
-	out.ObjectFields = make(map[string]string)
 	out.ObjectFields[Namespace] = aPod.Namespace
 	out.ObjectFields[PodName] = aPod.Name
+	out.ObjectFields[Category] = aCategory
+	return out
+}
+
+func New(aReason string, isCompliant bool) (out *ObjectOut) {
+	out = &ObjectOut{}
+	out.ObjectType = UndefinedType
+	out.ObjectFields = make(map[string]string)
 	if isCompliant {
 		out.ObjectFields[ReasonForCompliance] = aReason
 	} else {
 		out.ObjectFields[ReasonForNonCompliance] = aReason
 	}
 	return out
+}
+
+func (obj *ObjectOut) AddField(aKey, aString string) (out *ObjectOut) {
+	obj.ObjectFields[aKey] = aString
+	return obj
+}
+
+func (obj *ObjectOut) SetType(aType string) (out *ObjectOut) {
+	obj.ObjectType = aType
+	return obj
 }
 
 func ResultToString(result int) (str string) {


### PR DESCRIPTION
This is a proof of concept to add a more meaningful "Failure Reason" to the claim.json results section. 
Example FailureReason field output format. 
When the test succeeds, the reason is at the end of the test log. This is because there is no function equivalent to gingko.Fail for passing test with a reason.
Also using regex to parse the ps command output to retrieve also the command args (to add more context to this particular reason ).

This is just for illustration, in the successful case
 ```
{
  "CompliantObjectsOut": [
    {
      "ObjectType": "ContainerProcess",
      "ObjectFields": {
        "ContainerName": "task-pv-container",
        "Namespace": "tnf",
        "PodName": "task-pv-pod",
        "ProcessCommandLine": "sleep 30",
        "ReasonForCompliance": "process satisfies: SHARED_CPU_SCHEDULING: scheduling priority == 0",
        "SchedulingPolicy": "SCHED_OTHER",
        "SchedulingPriority": "0"
      }
    },
    {
      "ObjectType": "ContainerProcess",
      "ObjectFields": {
        "ContainerName": "task-pv-container",
        "Namespace": "tnf",
        "PodName": "task-pv-pod",
        "ProcessCommandLine": "/bin/bash -c -- while true; do sleep 30; done;",
        "ReasonForCompliance": "process satisfies: SHARED_CPU_SCHEDULING: scheduling priority == 0",
        "SchedulingPolicy": "SCHED_OTHER",
        "SchedulingPriority": "0"
      }
    }
  ],
  "NonCompliantObjectsOut": null
}

}


```
Internal error happening during the testcase are also recorded in the non-compliant list at the level at which it happened (in this case at container level):
```
{
  "CompliantObjectsOut": null,
  "NonCompliantObjectsOut": [
    {
      "ObjectType": "Container",
      "ObjectFields": {
        "ContainerName": "task-pv-container",
        "Namespace": "tnf",
        "PodName": "task-pv-pod",
        "ReasonForNonCompliance": "Internal error, err=unable to run nsenter due to : cannot execute command: \" ps -e -o pidns,pid,args \"  on container: task-pv-container pod: task-pv-pod ns: tnf err:command terminated with exit code 1"
      }
    }
  ]
}
```
Another example for the SCC test highlighting new flexible fields:
```
{
  "CompliantObjectsOut": [
    {
      "ObjectType": "Container",
      "ObjectFields": {
        "Category": "CategoryID1(limited access granted automatically)",
        "ContainerName": "task-pv-container",
        "Namespace": "tnf",
        "PodName": "task-pv-pod",
        "ReasonForNonCompliance": "container category is category 1 or category NoUID0"
      }
    },
    {
      "ObjectType": "Container",
      "ObjectFields": {
        "Category": "CategoryID1(limited access granted automatically)",
        "ContainerName": "test",
        "Namespace": "tnf",
        "PodName": "test-0",
        "ReasonForNonCompliance": "container category is category 1 or category NoUID0"
      }
    },
    {
      "ObjectType": "Container",
      "ObjectFields": {
        "Category": "CategoryID1(limited access granted automatically)",
        "ContainerName": "test",
        "Namespace": "tnf",
        "PodName": "test-1",
        "ReasonForNonCompliance": "container category is category 1 or category NoUID0"
      }
    },
    {
      "ObjectType": "Container",
      "ObjectFields": {
        "Category": "CategoryID1(limited access granted automatically)",
        "ContainerName": "test",
        "Namespace": "tnf",
        "PodName": "test-5c99f464d8-jd7mt",
        "ReasonForNonCompliance": "container category is category 1 or category NoUID0"
      }
    },
    {
      "ObjectType": "Container",
      "ObjectFields": {
        "Category": "CategoryID1(limited access granted automatically)",
        "ContainerName": "test",
        "Namespace": "tnf",
        "PodName": "test-5c99f464d8-nxfpj",
        "ReasonForNonCompliance": "container category is category 1 or category NoUID0"
      }
    },
    {
      "ObjectType": "Cnf",
      "ObjectFields": {
        "Category": "CategoryID1(limited access granted automatically)",
        "ReasonForNonCompliance": "Overall Pod category"
      }
    }
  ],
  "NonCompliantObjectsOut": null

```