### PR TITLE
Far Edge TC: check restart-on-reboot label for sriov pods.

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -845,6 +845,20 @@ Suggested Remediation|Ensure ports are not being used that are reserved by our p
 Best Practice Reference|https://TODO Section 4.6.24
 Exception Process|There is no documented exception process for this.
 Tags|extended
+#### restart-on-reboot-sriov-pod
+
+Property|Description
+---|---
+Test Case Name|restart-on-reboot-sriov-pod
+Test Case Label|networking-restart-on-reboot-sriov-pod
+Unique ID|http://test-network-function.com/testcases/networking/restart-on-reboot-sriov-pod
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/networking/restart-on-reboot-sriov-pod Ensures that the label restart-on-reboot exists on pods that use SRIOV network interfaces.
+Result Type|normative
+Suggested Remediation|Ensure that the label restart-on-reboot exists on pods that use SRIOV network interfaces.
+Best Practice Reference|https://TODO
+Exception Process|There is no documented exception process for this.
+Tags|faredge
 #### service-type
 
 Property|Description

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -137,6 +137,7 @@ var (
 	TestExclusiveCPUPoolSchedulingPolicy     claim.Identifier
 	TestIsolatedCPUPoolSchedulingPolicy      claim.Identifier
 	TestRtAppNoExecProbes                    claim.Identifier
+	TestRestartOnRebootLabelOnPodsUsingSRIOV claim.Identifier
 )
 
 //nolint:funlen
@@ -398,6 +399,18 @@ https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks`,
 		common.PerformanceTestKey,
 		`Ensures that if one container runs a real time application exec probes are not used`,
 		RtAppNoExecProbesRemediation,
+		NormativeResult,
+		NoDocumentedProcess,
+		VersionOne,
+		bestPracticeDocV1dot4URL, // TODO: link Far Edge spec document
+		false,
+		TagFarEdge)
+
+	TestRestartOnRebootLabelOnPodsUsingSRIOV = AddCatalogEntry(
+		"restart-on-reboot-sriov-pod",
+		common.NetworkingTestKey,
+		`Ensures that the label restart-on-reboot exists on pods that use SRIOV network interfaces.`,
+		SRIOVPodsRestartOnRebootLabelRemediation,
 		NormativeResult,
 		NoDocumentedProcess,
 		VersionOne,

--- a/cnf-certification-test/identifiers/remediation.go
+++ b/cnf-certification-test/identifiers/remediation.go
@@ -203,4 +203,6 @@ const (
 	IsolatedCPUPoolSchedulingPolicyRemediation = `Ensure that the workload running in an application-isolated exclusive CPU pool selects a RT CPU scheduling policy (such as SCHED_FIFO/SCHED_RR)`
 
 	RtAppNoExecProbesRemediation = `Ensure that if one container runs a real time application exec probes are not used`
+
+	SRIOVPodsRestartOnRebootLabelRemediation = `Ensure that the label restart-on-reboot exists on pods that use SRIOV network interfaces.`
 )

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -423,7 +423,6 @@ func testRestartOnRebootLabelOnPodsUsingSriov(sriovPods []*provider.Pod) {
 		if labelValue != "true" {
 			tnf.ClaimFilePrintf("Pod %s is using SRIOV but the %s label value is not true.", pod, restartOnRebootLabel)
 			nonCompliantPods = append(nonCompliantPods, pod.String())
-			continue
 		}
 	}
 

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -127,6 +127,15 @@ var _ = ginkgo.Describe(common.NetworkingTestKey, func() {
 		testhelper.SkipIfEmptyAny(ginkgo.Skip, dpdkPods)
 		testExecProbDenyAtCPUPinning(dpdkPods)
 	})
+	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestRestartOnRebootLabelOnPodsUsingSRIOV)
+	ginkgo.It(testID, ginkgo.Label(tags...), func() {
+		sriovPods, err := env.GetPodsUsingSRIOV()
+		if err != nil {
+			ginkgo.Fail(fmt.Sprintf("Failure getting pods using SRIOV: %v", err))
+		}
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, sriovPods)
+		testRestartOnRebootLabelOnPodsUsingSriov(sriovPods)
+	})
 })
 
 func testExecProbDenyAtCPUPinning(dpdkPods []*provider.Pod) {
@@ -393,4 +402,30 @@ func testNetworkPolicyDenyAll(env *provider.TestEnvironment) {
 	}
 
 	testhelper.AddTestResultLog("Non-compliant", podsMissingDenyAllDefaultPolicies, tnf.ClaimFilePrintf, ginkgo.Fail)
+}
+
+func testRestartOnRebootLabelOnPodsUsingSriov(sriovPods []*provider.Pod) {
+	const (
+		restartOnRebootLabel = "restart-on-reboot"
+	)
+
+	nonCompliantPods := []string{}
+	for _, pod := range sriovPods {
+		logrus.Debugf("Pod %s uses SRIOV network/s. Checking label %s existence & value.", pod, restartOnRebootLabel)
+
+		labelValue, exist := pod.GetLabels()[restartOnRebootLabel]
+		if !exist {
+			tnf.ClaimFilePrintf("Pod %s is using SRIOV but the label %s was not found.", pod, restartOnRebootLabel)
+			nonCompliantPods = append(nonCompliantPods, pod.String())
+			continue
+		}
+
+		if labelValue != "true" {
+			tnf.ClaimFilePrintf("Pod %s is using SRIOV but the %s label value is not true.", pod, restartOnRebootLabel)
+			nonCompliantPods = append(nonCompliantPods, pod.String())
+			continue
+		}
+	}
+
+	testhelper.AddTestResultLog("Non-compliant", nonCompliantPods, tnf.ClaimFilePrintf, ginkgo.Fail)
 }

--- a/go.mod
+++ b/go.mod
@@ -156,6 +156,7 @@ require (
 require (
 	github.com/deckarep/golang-set/v2 v2.1.0
 	github.com/go-yaml/yaml v2.1.0+incompatible
+	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
 	github.com/openshift/machine-config-operator v0.0.0-00010101000000-000000000000
 	github.com/test-network-function/cnfextensions v0.0.0-20230117151237-387530df5a0a
 	github.com/test-network-function/privileged-daemonset v0.0.7

--- a/go.sum
+++ b/go.sum
@@ -611,6 +611,8 @@ github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVY
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0 h1:VzM3TYHDgqPkettiP6I6q2jOeQFL4nrJM+UcAc4f6Fs=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0/go.mod h1:nqCI7aelBJU61wiBeeZWJ6oi4bJy5nrjkM6lWIMA4j0=
 github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
+	cncfNetworkAttachmentv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
 	ocpMachine "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -44,16 +45,17 @@ import (
 )
 
 type ClientsHolder struct {
-	RestConfig          *rest.Config
-	DynamicClient       dynamic.Interface
-	APIExtClient        apiextv1.Interface
-	OlmClient           olmClient.Interface
-	OcpClient           clientconfigv1.ConfigV1Interface
-	K8sClient           kubernetes.Interface
-	K8sNetworkingClient networkingv1.NetworkingV1Interface
-	MachineCfg          ocpMachine.Interface
-	KubeConfig          []byte
-	ready               bool
+	RestConfig           *rest.Config
+	DynamicClient        dynamic.Interface
+	APIExtClient         apiextv1.Interface
+	OlmClient            olmClient.Interface
+	OcpClient            clientconfigv1.ConfigV1Interface
+	K8sClient            kubernetes.Interface
+	K8sNetworkingClient  networkingv1.NetworkingV1Interface
+	CNCFNetworkingClient cncfNetworkAttachmentv1.K8sCniCncfIoV1Interface
+	MachineCfg           ocpMachine.Interface
+	KubeConfig           []byte
+	ready                bool
 }
 
 var clientsHolder = ClientsHolder{}
@@ -212,6 +214,11 @@ func newClientsHolder(filenames ...string) (*ClientsHolder, error) { //nolint:fu
 	if err != nil {
 		return nil, fmt.Errorf("cannot instantiate k8s networking client: %s", err)
 	}
+	clientsHolder.CNCFNetworkingClient, err = cncfNetworkAttachmentv1.NewForConfig(clientsHolder.RestConfig)
+	if err != nil {
+		return nil, fmt.Errorf("cannot instantiate CNCF networking client")
+	}
+
 	clientsHolder.ready = true
 	return &clientsHolder, nil
 }

--- a/pkg/provider/filters.go
+++ b/pkg/provider/filters.go
@@ -156,3 +156,18 @@ func (env *TestEnvironment) GetShareProcessNamespacePods() []*Pod {
 	}
 	return filteredPods
 }
+
+func (env *TestEnvironment) GetPodsUsingSRIOV() ([]*Pod, error) {
+	var filteredPods []*Pod
+	for _, p := range env.Pods {
+		usesSRIOV, err := p.IsUsingSRIOV()
+		if err != nil {
+			return nil, fmt.Errorf("failed to check sriov usage for pod %s: %v", p, err)
+		}
+
+		if usesSRIOV {
+			filteredPods = append(filteredPods, p)
+		}
+	}
+	return filteredPods, nil
+}


### PR DESCRIPTION
Added pod method to return whether a pod is using any sriov interface or not. Reads CNCF's networks annotation on each pod and check if any of the CNIs of that network is sriov type.