### PR TITLE
Change log level from error to info when a deployment is not ready yet

### DIFF
--- a/cnf-certification-test/lifecycle/podsets/podsets.go
+++ b/cnf-certification-test/lifecycle/podsets/podsets.go
@@ -39,7 +39,7 @@ var WaitForDeploymentSetReady = func(ns, name string, timeout time.Duration) boo
 		if err != nil {
 			logrus.Errorf("Error while getting deployment %s (ns: %s), err: %v", name, ns, err)
 		} else if !dp.IsDeploymentReady() {
-			logrus.Errorf("%s is not ready yet", dp.ToString())
+			logrus.Infof("%s is not ready yet", dp.ToString())
 		} else {
 			logrus.Tracef("%s is ready!", dp.ToString())
 			return true


### PR DESCRIPTION
Waiting for a Deployment to be ready should not be logged with error level.