### PR TITLE
Add unit test for 'scheduling' package

### DIFF
--- a/pkg/scheduling/scheduling.go
+++ b/pkg/scheduling/scheduling.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2023 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
 package scheduling
 
 import (

--- a/pkg/scheduling/scheduling_test.go
+++ b/pkg/scheduling/scheduling_test.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2023 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
 package scheduling
 
 import (
@@ -153,5 +169,29 @@ func TestExistsSchedulingPolicyAndPriority(t *testing.T) {
 		assert.Equal(t, policy, tc.expectedPolicy)
 		assert.Equal(t, priority, tc.expectedPriority)
 		assert.Equal(t, err, tc.expectedError)
+	}
+}
+
+func TestPolicyIsRT(t *testing.T) {
+	testCases := []struct {
+		testPolicy     string
+		expectedOutput bool
+	}{
+		{
+			testPolicy:     "SCHED_FIFO",
+			expectedOutput: true,
+		},
+		{
+			testPolicy:     "SCHED_RR",
+			expectedOutput: true,
+		},
+		{
+			testPolicy:     "",
+			expectedOutput: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedOutput, PolicyIsRT(tc.testPolicy))
 	}
 }


### PR DESCRIPTION
Follow up to #803 

Adds a quick test for `PolicyIsRT()`.

Bonus: Adds some copyright blocks.