### PR TITLE
Update YAML to v3 for vulnerability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -208,7 +208,6 @@ require (
 	github.com/deckarep/golang-set/v2 v2.1.0
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/stdr v1.2.2
-	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
 	github.com/openshift/machine-config-operator v0.0.0-00010101000000-000000000000
 	github.com/redhat-openshift-ecosystem/openshift-preflight v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -417,8 +417,6 @@ github.com/go-toolsmith/pkgload v0.0.0-20181119091011-e9e65178eee8/go.mod h1:WoM
 github.com/go-toolsmith/pkgload v1.0.0/go.mod h1:5eFArkbO80v7Z0kdngIxsRXRMTaX4Ilcwuh3clNrQJc=
 github.com/go-toolsmith/strparse v1.0.0/go.mod h1:YI2nUKP9YGZnL/L1/DLFBfixrcjslWct4wyljWhSRy8=
 github.com/go-toolsmith/typep v1.0.0/go.mod h1:JSQCQMUPdRlMZFswiq3TGpNp1GMktqkR2Ns5AIQkATU=
-github.com/go-yaml/yaml v2.1.0+incompatible h1:RYi2hDdss1u4YE7GwixGzWwVo47T8UQwnTLB6vQiq+o=
-github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
 github.com/gobuffalo/logger v1.0.6 h1:nnZNpxYo0zx+Aj9RfMPBm+x9zAU2OayFh/xrAWi34HU=
 github.com/gobuffalo/logger v1.0.6/go.mod h1:J31TBEHR1QLV2683OXTAItYIg8pv2JMHnF/quuAbMjs=
 github.com/gobuffalo/packd v1.0.1 h1:U2wXfRr4E9DH8IdsDLlRFwTZTK7hLfq9qT/QHXGVe/0=

--- a/internal/certdb/onlinecheck/onlinecheck.go
+++ b/internal/certdb/onlinecheck/onlinecheck.go
@@ -23,10 +23,10 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/go-yaml/yaml"
 	log "github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/internal/certdb/offlinecheck"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
+	yaml "gopkg.in/yaml.v3"
 	"helm.sh/helm/v3/pkg/release"
 )
 


### PR DESCRIPTION
Updating our YAML package to v3.0.1.

https://github.com/go-yaml/yaml/releases/tag/v3.0.1

Interestingly enough, the go.mod was already in #256 but the line still remained:
`github.com/go-yaml/yaml v2.1.0+incompatible`

