### PR TITLE
Fix the testID in the results output

### DIFF
--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -1173,10 +1173,8 @@ var (
 func GetGinkgoTestIDAndLabels(identifier claim.Identifier) (testID string, tags []string) {
 	tags = strings.Split(identifier.Tags, ",")
 	tags = append(tags, identifier.Id, identifier.Suite)
-
-	TestIDToClaimID[testID] = identifier
-
-	return testID, tags
+	TestIDToClaimID[identifier.Id] = identifier
+	return identifier.Id, tags
 }
 
 // Catalog is the JUnit testcase catalog of tests.

--- a/cnf-certification-test/identifiers/identifiers_test.go
+++ b/cnf-certification-test/identifiers/identifiers_test.go
@@ -16,3 +16,46 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package identifiers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/cnf-certification-test/pkg/stringhelper"
+	"github.com/test-network-function/test-network-function-claim/pkg/claim"
+)
+
+func TestGetGinkgoTestIDAndLabels(t *testing.T) {
+	testCases := []struct {
+		testIdentifier     claim.Identifier
+		expectedIDOutput   string
+		expectedTagsOutput []string
+	}{
+		{
+			testIdentifier: claim.Identifier{
+				Id:    "test-id-1",
+				Suite: "test-suite",
+				Tags:  "tag1",
+			},
+			expectedIDOutput:   "test-id-1",
+			expectedTagsOutput: []string{"tag1", "test-suite"},
+		},
+		{
+			testIdentifier: claim.Identifier{
+				Id:    "test-id-2",
+				Suite: "test-suite2",
+				Tags:  "tag1,tag2,tag3",
+			},
+			expectedIDOutput:   "test-id-2",
+			expectedTagsOutput: []string{"tag1", "tag2", "tag3", "test-suite2"},
+		},
+	}
+
+	for _, tc := range testCases {
+		resultID, resultTags := GetGinkgoTestIDAndLabels(tc.testIdentifier)
+		assert.Equal(t, tc.expectedIDOutput, resultID)
+		for _, e := range tc.expectedTagsOutput {
+			assert.True(t, stringhelper.StringInSlice(resultTags, e, false))
+		}
+	}
+}


### PR DESCRIPTION
Follow up to #843 

`GetGinkgoTestIDAndLabels` was broken in #843 and needed to properly set the testID into the results map.