### PR TITLE
Improve the Istio Service Mesh detection

### DIFF
--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -170,7 +170,7 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 
 func TestServiceMesh(env *provider.TestEnvironment) {
 	// check if istio is installed
-	if !env.IstioServiceMesh {
+	if !env.IstioServiceMeshFound {
 		tnf.ClaimFilePrintf("Istio is not installed")
 		ginkgo.Skip("No service mesh detected.")
 	}

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -82,7 +82,7 @@ type DiscoveredTestData struct {
 	OpenshiftVersion       string
 	OCPStatus              string
 	Nodes                  *corev1.NodeList
-	Istio                  bool
+	IstioServiceMeshFound  bool
 	ValidProtocolNames     []string
 	StorageClasses         []storagev1.StorageClass
 	ServicesIgnoreList     []string
@@ -165,7 +165,7 @@ func DoAutoDiscover() DiscoveredTestData {
 	if err != nil {
 		logrus.Fatalf("Cannot get the K8s version, error: %v", err)
 	}
-	data.Istio = findIstioNamespace(data.AllNamespaces)
+	data.IstioServiceMeshFound = isIstioServiceMeshInstalled(data.AllNamespaces)
 	data.ValidProtocolNames = data.TestData.ValidProtocolNames
 	data.ServicesIgnoreList = data.TestData.ServicesIgnoreList
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -106,7 +106,7 @@ type TestEnvironment struct { // rename this with testTarget
 	NetworkPolicies        []networkingv1.NetworkPolicy
 	AllInstallPlans        []*olmv1Alpha.InstallPlan   `json:"-"`
 	AllCatalogSources      []*olmv1Alpha.CatalogSource `json:"-"`
-	IstioServiceMesh       bool
+	IstioServiceMeshFound  bool
 	ValidProtocolNames     []string
 	DaemonsetFailedToSpawn bool
 	StorageClassList       []storagev1.StorageClass
@@ -209,7 +209,7 @@ func buildTestEnvironment() { //nolint:funlen
 	env.Namespaces = data.Namespaces
 	env.variables = data.Env
 	env.Nodes = createNodes(data.Nodes.Items)
-	env.IstioServiceMesh = data.Istio
+	env.IstioServiceMeshFound = data.IstioServiceMeshFound
 	env.ValidProtocolNames = append(env.ValidProtocolNames, data.ValidProtocolNames...)
 	for i := range data.AbnormalEvents {
 		aEvent := NewEvent(&data.AbnormalEvents[i])


### PR DESCRIPTION
Besides verifying that the Istio namespace exists, the presence of the Istio CR related to the installation is also taken into account when deciding if the Istio Service Mesh is active in the cluster.