### PR TITLE
Make docker config optional

### DIFF
--- a/cnf-certification-test/preflight/suite.go
+++ b/cnf-certification-test/preflight/suite.go
@@ -36,6 +36,12 @@ var _ = ginkgo.Describe(common.PreflightTestKey, func() {
 	})
 	ginkgo.ReportAfterEach(results.RecordResult)
 
+	// Add safeguard against running the tests if the docker config doesn't exist.
+	if env.GetDockerConfigFile() == "" {
+		logrus.Debug("Skipping the preflight suite because the Docker Config file is not provided.")
+		return
+	}
+
 	testPreflightContainers(&env)
 	if provider.IsOCPCluster() {
 		logrus.Debugf("OCP cluster detected, allowing operator tests to run")

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -130,5 +130,5 @@ type TestParameters struct {
 	LogLevel               string `default:"debug" split_words:"true"`
 	OfflineDB              string `split_words:"true"`
 	AllowPreflightInsecure bool   `split_words:"true"`
-	PfltDockerconfig       string `split_words:"true" required:"true" envconfig:"PFLT_DOCKERCONFIG"`
+	PfltDockerconfig       string `split_words:"true" envconfig:"PFLT_DOCKERCONFIG"`
 }

--- a/pkg/provider/containers.go
+++ b/pkg/provider/containers.go
@@ -86,14 +86,7 @@ func (c *Container) SetPreflightResults(preflightImageCache map[string]plibRunti
 
 	var results plibRuntime.Results
 	opts := []plibContainer.Option{}
-
-	// Check to make sure that the environment variable is set
-	if len(env.GetDockerConfigFile()) > 0 {
-		opts = append(opts, plibContainer.WithDockerConfigJSONFromFile(env.GetDockerConfigFile()))
-	} else {
-		logrus.Errorf("Container func SetPreflightResults has failed due to missing PFLT_DOCKERCONFIG environment variable")
-		return nil
-	}
+	opts = append(opts, plibContainer.WithDockerConfigJSONFromFile(env.GetDockerConfigFile()))
 	if env.IsPreflightInsecureAllowed() {
 		logrus.Info("Insecure connections are being allowed to preflight")
 		opts = append(opts, plibContainer.WithInsecureConnection())

--- a/pkg/provider/operators.go
+++ b/pkg/provider/operators.go
@@ -81,14 +81,7 @@ func (op *Operator) SetPreflightResults(env *TestEnvironment) error {
 	}
 	ctx := artifacts.ContextWithWriter(context.Background(), artifactsWriter)
 	opts := []plibOperator.Option{}
-
-	// Check to make sure that the environment variable is set
-	if len(env.GetDockerConfigFile()) > 0 {
-		opts = append(opts, plibOperator.WithDockerConfigJSONFromFile(env.GetDockerConfigFile()))
-	} else {
-		logrus.Errorf("Operator func SetPreflightResults has failed due to missing PFLT_DOCKERCONFIG environment variable")
-		return nil
-	}
+	opts = append(opts, plibOperator.WithDockerConfigJSONFromFile(env.GetDockerConfigFile()))
 	if env.IsPreflightInsecureAllowed() {
 		logrus.Info("Insecure connections are being allowed to preflight")
 		opts = append(opts, plibOperator.WithInsecureConnection())

--- a/run-tnf-container.sh
+++ b/run-tnf-container.sh
@@ -14,10 +14,9 @@
 #   KUBECONFIG=/usr/tnf/kubeconfig/config:/usr/tnf/kubeconfig/config.2
 
 export REQUIRED_NUM_OF_ARGS=5
-export REQUIRED_VARS=('LOCAL_KUBECONFIG' 'LOCAL_TNF_CONFIG' 'OUTPUT_LOC' 'LOCAL_DOCKERCFG')
+export REQUIRED_VARS=('LOCAL_KUBECONFIG' 'LOCAL_TNF_CONFIG' 'OUTPUT_LOC')
 export REQUIRED_VARS_ERROR_MESSAGES=(
 	'KUBECONFIG is invalid or not given. Use the -k option to provide path to one or more kubeconfig files.'
-	'DOCKERCFG is invalid or not given. Use the -c option to provide path to one or more dockercfg files.'
 	'TNFCONFIG is required. Use the -t option to specify the directory containing the TNF configuration files.'
 	'OUTPUT_LOC is required. Use the -o option to specify the output location for the test results.'
 )


### PR DESCRIPTION
- Moved the check for the Docker Config file into the suite.go.
- Removed the `LOCAL_DOCKERCFG` as a required parameter to the script.
- Removed `required:"true"` from the envconfig variable for the docker config.