### PR TITLE
Bump Ubuntu runners to 22.04

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -28,7 +28,7 @@ env:
 jobs:
   lint:
     name: Run Linter and Vet
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.kube/config'
@@ -66,7 +66,7 @@ jobs:
         run: make vet
   shellcheck:
     name: Shellcheck
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Run ShellCheck
@@ -79,7 +79,7 @@ jobs:
           scandir: script
           severity: style
   yamllint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: yaml-lint
@@ -99,7 +99,7 @@ jobs:
 
   unit-tests:
     name: Run Unit Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.kube/config'
@@ -148,7 +148,7 @@ jobs:
 
   smoke-tests:
     name: Run Smoke Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.kube/config'

--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -37,7 +37,7 @@ env:
 jobs:
   test-and-push-tnf-image-main:
     name: 'Test and push the `cnf-certification-test` image'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.kube/config'
@@ -135,7 +135,7 @@ jobs:
 
   test-and-push-tnf-image-40x:
     name: 'Test and push the 4.0.x `cnf-certification-test` image'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.kube/config'

--- a/.github/workflows/update-rhcos-mapping.yml
+++ b/.github/workflows/update-rhcos-mapping.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-certification:
     name: Update offline mapping of RHCOS to OCP version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       SHELL: /bin/bash        
 


### PR DESCRIPTION
The Ubuntu 22.04 runner was in beta the last time we tried it in #218.

This is out of beta now and I'm curious to see if the errors we had before happened.