### PR TITLE
Update GolangCI-lint to v1.51.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ COMMON_GO_ARGS=-race
 GIT_COMMIT=$(shell script/create-version-files.sh)
 GIT_RELEASE=$(shell script/get-git-release.sh)
 GIT_PREVIOUS_RELEASE=$(shell script/get-git-previous-release.sh)
-GOLANGCI_VERSION=v1.51.0
+GOLANGCI_VERSION=v1.51.1
 LINKER_TNF_RELEASE_FLAGS=-X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitCommit=${GIT_COMMIT}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitRelease=${GIT_RELEASE}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitPreviousRelease=${GIT_PREVIOUS_RELEASE}

--- a/docs/test-standalone.md
+++ b/docs/test-standalone.md
@@ -27,7 +27,7 @@ make install-tools
 Dependency|Minimum Version
 ---|---
 [GoLang](https://golang.org/dl/)|1.19
-[golangci-lint](https://golangci-lint.run/usage/install/)|1.51.0
+[golangci-lint](https://golangci-lint.run/usage/install/)|1.51.1
 [jq](https://stedolan.github.io/jq/)|1.6
 [OpenShift Client](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/)|4.11
 


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.51.1