### PR TITLE
Skip some test cases that are incompatible with the Istio Service Mesh

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -485,7 +485,7 @@ func TestOneProcessPerContainer(env *provider.TestEnvironment) {
 	var badContainers []string
 
 	for _, cut := range env.Containers {
-		// the Istio sidecar container "istio-proxy" lauches two processes: "pilot-agent" and "envoy"
+		// the Istio sidecar container "istio-proxy" launches two processes: "pilot-agent" and "envoy"
 		if cut.IsIstioProxy() {
 			continue
 		}

--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -485,6 +485,10 @@ func TestOneProcessPerContainer(env *provider.TestEnvironment) {
 	var badContainers []string
 
 	for _, cut := range env.Containers {
+		// the Istio sidecar container "istio-proxy" lauches two processes: "pilot-agent" and "envoy"
+		if cut.IsIstioProxy() {
+			continue
+		}
 		debugPod := env.DebugPods[cut.NodeName]
 		if debugPod == nil {
 			ginkgo.Fail(fmt.Sprintf("Debug pod not found on Node: %s", cut.NodeName))

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -125,6 +125,9 @@ var _ = ginkgo.Describe(common.NetworkingTestKey, func() {
 		if env.DaemonsetFailedToSpawn {
 			ginkgo.Skip("Debug Daemonset failed to spawn skipping testIsNFTablesConfigPresent")
 		}
+		if env.IstioServiceMeshFound {
+			ginkgo.Skip("Skipping testIsNFTablesConfigPresent due to the presence of the Istio Service Mesh")
+		}
 		testIsNFTablesConfigPresent(&env)
 	})
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestIPTablesIdentifier)

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -136,6 +136,9 @@ var _ = ginkgo.Describe(common.NetworkingTestKey, func() {
 		if env.DaemonsetFailedToSpawn {
 			ginkgo.Skip("Debug Daemonset failed to spawn skipping testIsIPTablesConfigPresent")
 		}
+		if env.IstioServiceMeshFound {
+			ginkgo.Skip("Skipping testIsIPTablesConfigPresent due to the presence of the Istio Service Mesh")
+		}
 		testIsIPTablesConfigPresent(&env)
 	})
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestNetworkPolicyDenyAllIdentifier)


### PR DESCRIPTION
- For the "one process per container" test case the verification for the Istio containers is skipped, as they contain two processes. Although it still applies to the application containers.

- The "nftables" test case is skipped due to the networking rules that Istio injects in the application containers.