### PR TITLE
Adjust import naming convention

### DIFF
--- a/cnf-certification-test/lifecycle/scaling/scaling_helper.go
+++ b/cnf-certification-test/lifecycle/scaling/scaling_helper.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	scalingv1 "k8s.io/api/autoscaling/v1"
@@ -27,7 +27,7 @@ func IsManaged(podSetName string, managedPodSet []configuration.ManagedDeploymen
 	return false
 }
 
-func CheckOwnerReference(ownerReference []apiv1.OwnerReference, crdFilter []configuration.CrdFilter, crds []*v1.CustomResourceDefinition) bool {
+func CheckOwnerReference(ownerReference []apiv1.OwnerReference, crdFilter []configuration.CrdFilter, crds []*apiextv1.CustomResourceDefinition) bool {
 	for _, owner := range ownerReference {
 		for _, aCrd := range crds {
 			if aCrd.Spec.Names.Kind == owner.Kind {

--- a/pkg/autodiscover/autodiscover_networkpolicies.go
+++ b/pkg/autodiscover/autodiscover_networkpolicies.go
@@ -20,12 +20,12 @@ import (
 	"context"
 
 	networkingv1 "k8s.io/api/networking/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	networkingv1client "k8s.io/client-go/kubernetes/typed/networking/v1"
 )
 
 func getNetworkPolicies(oc networkingv1client.NetworkingV1Interface) ([]networkingv1.NetworkPolicy, error) {
-	nps, err := oc.NetworkPolicies("").List(context.TODO(), v1.ListOptions{})
+	nps, err := oc.NetworkPolicies("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/autodiscover/autodiscover_scaleObject_test.go
+++ b/pkg/autodiscover/autodiscover_scaleObject_test.go
@@ -1,0 +1,1 @@
+package autodiscover

--- a/pkg/provider/operators.go
+++ b/pkg/provider/operators.go
@@ -34,7 +34,7 @@ import (
 	plibOperator "github.com/redhat-openshift-ecosystem/openshift-preflight/operator"
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type Operator struct {
@@ -293,7 +293,7 @@ func getCatalogSourceImageIndexFromInstallPlan(installPlan *olmv1Alpha.InstallPl
 func getOperatorTargetNamespaces(namespace string) ([]string, error) {
 	client := clientsholder.GetClientsHolder()
 
-	list, err := client.OlmClient.OperatorsV1().OperatorGroups(namespace).List(context.TODO(), v1.ListOptions{})
+	list, err := client.OlmClient.OperatorsV1().OperatorGroups(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -27,7 +27,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/pkg/tnf"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -194,7 +194,7 @@ func (p *Pod) CreatedByDeploymentConfig() (bool, error) {
 	oc := clientsholder.GetClientsHolder()
 	for _, podOwner := range p.ObjectMeta.GetOwnerReferences() {
 		if podOwner.Kind == replicationController {
-			replicationControllers, err := oc.K8sClient.CoreV1().ReplicationControllers(p.Namespace).Get(context.TODO(), podOwner.Name, v1.GetOptions{})
+			replicationControllers, err := oc.K8sClient.CoreV1().ReplicationControllers(p.Namespace).Get(context.TODO(), podOwner.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -361,7 +361,7 @@ func (p *Pod) IsUsingSRIOV() (bool, error) {
 
 	for _, networkName := range cncfNetworkNames {
 		logrus.Tracef("%s: Reviewing network-attachment definition %q", p, networkName)
-		nad, err := oc.CNCFNetworkingClient.NetworkAttachmentDefinitions(p.Namespace).Get(context.TODO(), networkName, v1.GetOptions{})
+		nad, err := oc.CNCFNetworkingClient.NetworkAttachmentDefinitions(p.Namespace).Get(context.TODO(), networkName, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("failed to get NetworkAttachment %s: %v", networkName, err)
 		}


### PR DESCRIPTION
Related to: #814, #177, and #618 

Also adds the `pkg/autodiscover/autodiscover_scaleObject_test.go` automatically generated test file for the `scaleObject.go`.