### PR TITLE
Disable 4.0.x build in tnf-image.yaml

### DIFF
--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -133,97 +133,97 @@ jobs:
       - name: Push the newly built image to Quay.io
         run: docker push --all-tags ${REGISTRY}/${TNF_IMAGE_NAME}
 
-  test-and-push-tnf-image-40x:
-    name: 'Test and push the 4.0.x `cnf-certification-test` image'
-    runs-on: ubuntu-22.04
-    env:
-      SHELL: /bin/bash
-      KUBECONFIG: '/home/runner/.kube/config'
-      CURRENT_VERSION_GENERIC_BRANCH: 4.0.x
-      TNF_VERSION: ""
-      PARTNER_VERSION: ""
-    steps:
+  # test-and-push-tnf-image-40x:
+  #   name: 'Test and push the 4.0.x `cnf-certification-test` image'
+  #   runs-on: ubuntu-22.04
+  #   env:
+  #     SHELL: /bin/bash
+  #     KUBECONFIG: '/home/runner/.kube/config'
+  #     CURRENT_VERSION_GENERIC_BRANCH: 4.0.x
+  #     TNF_VERSION: ""
+  #     PARTNER_VERSION: ""
+  #   steps:
 
-      - name: Checkout generic working branch of the current version
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ env.CURRENT_VERSION_GENERIC_BRANCH }}
-          fetch-depth: '0'
+  #     - name: Checkout generic working branch of the current version
+  #       uses: actions/checkout@v3
+  #       with:
+  #         ref: ${{ env.CURRENT_VERSION_GENERIC_BRANCH }}
+  #         fetch-depth: '0'
 
-      - name: Get the latest TNF version from GIT
-        run: |
-          GIT_RELEASE=$(git tag --points-at HEAD | head -n 1)
-          GIT_PREVIOUS_RELEASE=$(git tag --no-contains HEAD --sort=v:refname | grep 4.0 | tail -n 1)
-          GIT_LATEST_RELEASE=$GIT_RELEASE
-          if [ -z "$GIT_RELEASE" ]; then
-            GIT_LATEST_RELEASE=$GIT_PREVIOUS_RELEASE
-          fi
-          echo "version_number=$GIT_LATEST_RELEASE"
-        id: set_tnf_version
+  #     - name: Get the latest TNF version from GIT
+  #       run: |
+  #         GIT_RELEASE=$(git tag --points-at HEAD | head -n 1)
+  #         GIT_PREVIOUS_RELEASE=$(git tag --no-contains HEAD --sort=v:refname | grep 4.0 | tail -n 1)
+  #         GIT_LATEST_RELEASE=$GIT_RELEASE
+  #         if [ -z "$GIT_RELEASE" ]; then
+  #           GIT_LATEST_RELEASE=$GIT_PREVIOUS_RELEASE
+  #         fi
+  #         echo "version_number=$GIT_LATEST_RELEASE"
+  #       id: set_tnf_version
 
-      - name: Print the latest TNF version from GIT
-        run: |
-          echo Version tag: ${{ steps.set_tnf_version.outputs.version_number }}
-      - name: Get contents of the version.json file
-        run: echo "name=$(cat version.json | tr -d '[:space:]')" >> GITHUB_OUTPUT
-        id: get_version_json_file
+  #     - name: Print the latest TNF version from GIT
+  #       run: |
+  #         echo Version tag: ${{ steps.set_tnf_version.outputs.version_number }}
+  #     - name: Get contents of the version.json file
+  #       run: echo "name=$(cat version.json | tr -d '[:space:]')" >> GITHUB_OUTPUT
+  #       id: get_version_json_file
 
-      - name: Get the partner version number from file
-        run: |
-          echo Partner version tag: $VERSION_FROM_FILE_PARTNER
-          echo "partner_version_number=$VERSION_FROM_FILE_PARTNER" >> GITHUB_PARTNER
-        id: set_partner_version
-        env:
-          VERSION_FROM_FILE_PARTNER: ${{ fromJSON(steps.get_version_json_file.outputs.json).partner_tag }}
+  #     - name: Get the partner version number from file
+  #       run: |
+  #         echo Partner version tag: $VERSION_FROM_FILE_PARTNER
+  #         echo "partner_version_number=$VERSION_FROM_FILE_PARTNER" >> GITHUB_PARTNER
+  #       id: set_partner_version
+  #       env:
+  #         VERSION_FROM_FILE_PARTNER: ${{ fromJSON(steps.get_version_json_file.outputs.json).partner_tag }}
 
-      - name: Update env variables
-        run: |
-          echo "TNF_VERSION=${{ steps.set_tnf_version.outputs.version_number }}" >> $GITHUB_ENV
-          echo "PARTNER_VERSION=${{ steps.set_partner_version.outputs.partner_version_number }}" >> $GITHUB_ENV
+  #     - name: Update env variables
+  #       run: |
+  #         echo "TNF_VERSION=${{ steps.set_tnf_version.outputs.version_number }}" >> $GITHUB_ENV
+  #         echo "PARTNER_VERSION=${{ steps.set_partner_version.outputs.partner_version_number }}" >> $GITHUB_ENV
 
-      - name: Ensure $TNF_VERSION and $IMAGE_TAG are set
-        run: '[[ -n "$TNF_VERSION" ]] && [[ -n "$IMAGE_TAG" ]] && [[ -n "$PARTNER_VERSION" ]]'
+  #     - name: Ensure $TNF_VERSION and $IMAGE_TAG are set
+  #       run: '[[ -n "$TNF_VERSION" ]] && [[ -n "$IMAGE_TAG" ]] && [[ -n "$PARTNER_VERSION" ]]'
 
-      - name: Check whether the version tag exists on remote
-        run: git ls-remote --exit-code $TNF_SRC_URL refs/tags/$TNF_VERSION
+  #     - name: Check whether the version tag exists on remote
+  #       run: git ls-remote --exit-code $TNF_SRC_URL refs/tags/$TNF_VERSION
 
-      - name: (if tag is missing) Display debug message
-        if: ${{ failure() }}
-        run: echo "Tag '$TNF_VERSION' does not exist on remote $TNF_SRC_URL"
+  #     - name: (if tag is missing) Display debug message
+  #       if: ${{ failure() }}
+  #       run: echo "Tag '$TNF_VERSION' does not exist on remote $TNF_SRC_URL"
 
-      - name: Check whether the version tag exists on remote
-        run: git ls-remote --exit-code ${{ env.PARTNER_SRC_URL }} refs/tags/$PARTNER_VERSION
+  #     - name: Check whether the version tag exists on remote
+  #       run: git ls-remote --exit-code ${{ env.PARTNER_SRC_URL }} refs/tags/$PARTNER_VERSION
 
-      - name: (if partner_tag is missing) Display debug message
-        if: ${{ failure() }}
-        run: echo "Tag '$PARTNER_VERSION' does not exist on remote $PARTNER_SRC_URL"
+  #     - name: (if partner_tag is missing) Display debug message
+  #       if: ${{ failure() }}
+  #       run: echo "Tag '$PARTNER_VERSION' does not exist on remote $PARTNER_SRC_URL"
 
-      - name: Checkout the version tag
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ env.TNF_VERSION }}
+  #     - name: Checkout the version tag
+  #       uses: actions/checkout@v3
+  #       with:
+  #         ref: ${{ env.TNF_VERSION }}
 
-      - name: Build the `cnf-certification-test` image
-        run: |
-          VERSIONS=($(sudo curl -sH 'Accept: application/json' "https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-${RELEASE_LEVEL}&arch=amd64" | jq -r '.nodes[].version' | sort -t "." -k1,1n -k2,2n -k3,3n))
-          OPENSHIFT_VERSION=${VERSIONS[${#VERSIONS[@]} - 1]}
-          docker build --no-cache \
-            -t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
-            -t ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
-            -t ${REGISTRY}/${TNF_IMAGE_NAME}:${TNF_VERSION} \
-            --build-arg TNF_VERSION=${TNF_VERSION} \
-            --build-arg TNF_SRC_URL=${TNF_SRC_URL} \
-            --build-arg OPENSHIFT_VERSION=${OPENSHIFT_VERSION} .
+  #     - name: Build the `cnf-certification-test` image
+  #       run: |
+  #         VERSIONS=($(sudo curl -sH 'Accept: application/json' "https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-${RELEASE_LEVEL}&arch=amd64" | jq -r '.nodes[].version' | sort -t "." -k1,1n -k2,2n -k3,3n))
+  #         OPENSHIFT_VERSION=${VERSIONS[${#VERSIONS[@]} - 1]}
+  #         docker build --no-cache \
+  #           -t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
+  #           -t ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
+  #           -t ${REGISTRY}/${TNF_IMAGE_NAME}:${TNF_VERSION} \
+  #           --build-arg TNF_VERSION=${TNF_VERSION} \
+  #           --build-arg TNF_SRC_URL=${TNF_SRC_URL} \
+  #           --build-arg OPENSHIFT_VERSION=${OPENSHIFT_VERSION} .
 
-      # Push the new TNF image to Quay.io.
-      - name: Authenticate against Quay.io
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          # Use a Robot Account to authenticate against Quay.io
-          # https://docs.quay.io/glossary/robot-accounts.html
-          username: ${{ secrets.QUAY_ROBOT_USERNAME }}
-          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+  #     # Push the new TNF image to Quay.io.
+  #     - name: Authenticate against Quay.io
+  #       uses: docker/login-action@v2
+  #       with:
+  #         registry: ${{ env.REGISTRY }}
+  #         # Use a Robot Account to authenticate against Quay.io
+  #         # https://docs.quay.io/glossary/robot-accounts.html
+  #         username: ${{ secrets.QUAY_ROBOT_USERNAME }}
+  #         password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Push the newly built image to Quay.io
-        run: docker push ${REGISTRY}/${TNF_IMAGE_NAME}:${TNF_VERSION}
+  #     - name: Push the newly built image to Quay.io
+  #       run: docker push ${REGISTRY}/${TNF_IMAGE_NAME}:${TNF_VERSION}


### PR DESCRIPTION
Comment out the 4.0.x build temporarily (maybe permanently 😄) because it is [failing](https://github.com/test-network-function/cnf-certification-test/actions/runs/4295224753/jobs/7485340046) the build process.  We don't plan on building any more 4.0.x builds in the future so I don't see a problem with turning it off temporarily.