### PR TITLE
Updated CATALOG.md file

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -423,17 +423,6 @@ Suggested Remediation|Add a liveness probe to deployed containers
 Best Practice Reference|https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf Section 5.2.16, 12.1 and 12.5
 Exception Process|There is no documented exception process for this.
 Tags|common,telco,lifecycle
-#### lifecycle-no-pvs-on-localstorage
-
-Property|Description
----|---
-Unique ID|lifecycle-no-pvs-on-localstorage
-Description|Checks that pods do not place persistent volumes on local storage.
-Result Type|informative
-Suggested Remediation|If the kind of pods is StatefulSet, so we need to make sure that servicename is not local-storage.
-Best Practice Reference|https://TODO Section 4.6.24
-Exception Process|There is no documented exception process for this.
-Tags|extended,lifecycle
 #### lifecycle-persistent-volume-reclaim-policy
 
 Property|Description

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -255,17 +255,6 @@ The label value is not important, only its presence.`,
 		false,
 		TagExtended)
 
-	TestStorageRequiredPods = AddCatalogEntry(
-		"no-pvs-on-localstorage",
-		common.LifecycleTestKey,
-		`Checks that pods do not place persistent volumes on local storage.`,
-		StorageRequiredPods,
-		InformativeResult,
-		NoDocumentedProcess,
-		bestPracticeDocV1dot4URL+" Section 4.6.24",
-		false,
-		TagExtended)
-
 	TestStartupIdentifier = AddCatalogEntry(
 		"container-startup",
 		common.LifecycleTestKey,


### PR DESCRIPTION
build-depends: https://github.com/dci-labs/dallas-pipelines/pull/672
build-depends: 27665

Updated CATALOG.md file because we have duplicate entry for TestStorageRequiredPods.