### PR TITLE
Fix daily builds

### DIFF
--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -119,7 +119,7 @@ jobs:
         run: |
           make build-image-tnf
         env:
-          TNF_VERSION: ${{ github.event.release.tag_name }}
+          TNF_VERSION: ${{ env.TNF_VERSION }}
 
       # Push the new TNF image to Quay.io.
       - name: Authenticate against Quay.io


### PR DESCRIPTION
On the `daily` cron builds, the `github.event.release.tag_name` is not populated and we end up with an error.  Using the `env.TNF_VERSION` gets the correct latest release variable every time.