### PR TITLE
Re-enable CodeQL with 'make install-tools' in the steps

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,13 +12,13 @@
 name: "CodeQL"
 
 on:
-  # push:
-  #   branches: [ main ]
-  # pull_request:
-  #   # The branches below must be a subset of the branches above
-  #   branches: [ main ]
-  # schedule:
-  #   - cron: '19 23 * * 0'
+  push:
+    branches: [ main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+  schedule:
+    - cron: '19 23 * * 0'
 
   # workflow_dispatch allows manual triggering of this workflow.
   workflow_dispatch:
@@ -46,6 +46,9 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.20.1
+
+      - name: Install ginkgo
+        run: make install-tools
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL


### PR DESCRIPTION
The last run:

https://github.com/test-network-function/cnf-certification-test/actions/runs/4351853705/jobs/7603935304

Failed with:

```
  /bin/sh: 1: ginkgo: not found
  make[1]: *** [Makefile:108: build-cnf-tests] Error 127
  make: *** [Makefile:60: build] Error 2
```