### PR TITLE
Add new self-hosted PR tester YAML

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,21 @@
+name: initial-setup-resources
+description: A shared action that removes a lot of copied tasks from steps in our CI
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Write temporary docker file
+      run: |
+        mkdir -p $GITHUB_WORKSPACE/.docker
+        touch ${PFLT_DOCKERCONFIG}
+        echo '{ "auths": {} }' >> ${PFLT_DOCKERCONFIG}
+      shell: bash
+
+    - name: Set up Go 1.20
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.20.2
+
+    - name: Disable default go problem matcher
+      run: echo "::remove-matcher owner=go::"
+      shell: bash

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -1,4 +1,4 @@
-name: Test Incoming Changes
+name: Self Hosted Incoming Changes
 
 on:
   push:
@@ -28,11 +28,11 @@ env:
 jobs:
   lint:
     name: Run Linter and Vet
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     env:
       SHELL: /bin/bash
-      KUBECONFIG: '/home/runner/.kube/config'
-      PFLT_DOCKERCONFIG: '/home/runner/.docker/config'
+      KUBECONFIG: '/home/tnf/.kube/config'
+      PFLT_DOCKERCONFIG: '/home/tnf/.docker/config'
 
     steps:
       - name: Check out code into the Go module directory
@@ -56,16 +56,14 @@ jobs:
 
       - name: make vet
         run: make vet
-  shell-linters:
-    name: Shellcheck and shfmt
-    runs-on: ubuntu-22.04
+  shellcheck:
+    name: Shellcheck
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3
       - uses: ludeeus/action-shellcheck@master
-      - uses: mfinelli/setup-shfmt@v2
-      - run: shfmt -d *.sh script
   yamllint:
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3
       - name: yaml-lint
@@ -85,11 +83,11 @@ jobs:
 
   unit-tests:
     name: Run Unit Tests
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     env:
       SHELL: /bin/bash
-      KUBECONFIG: '/home/runner/.kube/config'
-      PFLT_DOCKERCONFIG: '/home/runner/.docker/config'
+      KUBECONFIG: '/home/tnf/.kube/config'
+      PFLT_DOCKERCONFIG: '/home/tnf/.docker/config'
 
     steps:
       - name: Check out code into the Go module directory
@@ -123,11 +121,11 @@ jobs:
 
   smoke-tests-local:
     name: Run Local Smoke Tests
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     env:
       SHELL: /bin/bash
-      KUBECONFIG: '/home/runner/.kube/config'
-      PFLT_DOCKERCONFIG: '/home/runner/.docker/config'
+      KUBECONFIG: '/home/tnf/.kube/config'
+      PFLT_DOCKERCONFIG: '/home/tnf/.docker/config'
 
     steps:
       - name: Check out code into the Go module directory
@@ -139,7 +137,6 @@ jobs:
         uses: ./.github/actions/setup
 
       # Update the CNF containers, helm charts and operators DB
-
       - name: Update the CNF DB
         run: |
           docker pull ${REGISTRY}/${OCT_IMAGE_NAME}:${OCT_IMAGE_TAG}
@@ -159,15 +156,17 @@ jobs:
           repository: test-network-function/cnf-certification-test-partner
           path: cnf-certification-test-partner
 
-      - name: Start the Kind cluster for `local-test-infra`
-        uses: ./cnf-certification-test-partner/.github/actions/start-k8s-cluster
-        with:
-          working_directory: cnf-certification-test-partner
+      - name: Bootstrap the Kind and OC/Kubectl binaries for the `local-test-infra`
+        run: make bootstrap-cluster-fedora-local
+        working-directory: cnf-certification-test-partner
 
       - name: Create `local-test-infra` OpenShift resources
-        uses: ./cnf-certification-test-partner/.github/actions/create-local-test-infra-resources
-        with:
-          working_directory: cnf-certification-test-partner
+        run: make rebuild-cluster
+        working-directory: cnf-certification-test-partner
+
+      - name: Install partner resources
+        run: make install
+        working-directory: cnf-certification-test-partner
 
       # Perform smoke tests.
       - name: 'Test: Run test suites'
@@ -187,21 +186,13 @@ jobs:
 
   smoke-tests-container:
     name: Run Container Smoke Tests
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     env:
       SHELL: /bin/bash
-      KUBECONFIG: '/home/runner/.kube/config'
-      PFLT_DOCKERCONFIG: '/home/runner/.docker/config'
+      KUBECONFIG: '/home/tnf/.kube/config'
+      PFLT_DOCKERCONFIG: '/home/tnf/.docker/config'
 
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.sha }}
-
-      - name: Run initial setup
-        uses: ./.github/actions/setup
-
       # Create a Kind cluster for testing.
       - name: Check out `cnf-certification-test-partner`
         uses: actions/checkout@v3
@@ -209,22 +200,25 @@ jobs:
           repository: test-network-function/cnf-certification-test-partner
           path: cnf-certification-test-partner
 
-      - name: Start the Kind cluster for `local-test-infra`
-        uses: ./cnf-certification-test-partner/.github/actions/start-k8s-cluster
-        with:
-          working_directory: cnf-certification-test-partner
+      - name: Bootstrap the Kind and OC/Kubectl binaries for the `local-test-infra`
+        run: make bootstrap-cluster-fedora-local
+        working-directory: cnf-certification-test-partner
 
       - name: Create `local-test-infra` OpenShift resources
-        uses: ./cnf-certification-test-partner/.github/actions/create-local-test-infra-resources
-        with:
-          working_directory: cnf-certification-test-partner
-            
+        run: make rebuild-cluster
+        working-directory: cnf-certification-test-partner
 
-      # Perform smoke tests using a TNF container.
+      - name: Install partner resources
+        run: make install
+        working-directory: cnf-certification-test-partner
+            
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
         with:
           ref: ${{ github.sha }}
+
+      - name: Run initial setup
+        uses: ./.github/actions/setup
 
       - name: Build the `cnf-certification-test` image
         run: |

--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -48,17 +48,15 @@ jobs:
       PARTNER_VERSION: ""
     steps:
 
-      - name: Write temporary docker file
-        run: |
-          mkdir -p /home/runner/.docker
-          touch ${PFLT_DOCKERCONFIG}
-          echo '{ "auths": {} }' >> ${PFLT_DOCKERCONFIG}
 
       - name: Checkout generic working branch of the current version
         uses: actions/checkout@v3
         with:
           ref: ${{ env.CURRENT_VERSION_GENERIC_BRANCH }}
           fetch-depth: '0'
+
+      - name: Run initial setup
+        uses: ./.github/actions/setup
 
       - name: Get the latest TNF version from GIT
         run: |


### PR DESCRIPTION
Adds a new YAML for the new self-hosted runner.  Currently this is still running the same tests we use in the github hosted runners but I hope to expand on the strategy in the future and maybe use the self-hosted runner to run our QE tests.