### PR TITLE
Add AddTestResultLog result to network connectivity test

### DIFF
--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -235,7 +235,8 @@ func testNetworkConnectivity(env *provider.TestEnvironment, aIPVersion netcommon
 	}
 	if n := len(badNets); n > 0 {
 		logrus.Debugf("Failed nets: %+v", badNets)
-		ginkgo.Fail(fmt.Sprintf("%d nets failed the %s network %s ping test.", n, aType, aIPVersion))
+		tnf.ClaimFilePrintf("%d nets failed the %s network %s ping test.", n, aType, aIPVersion)
+		testhelper.AddTestResultLog("Non-compliant", badNets, tnf.ClaimFilePrintf, ginkgo.Fail)
 	}
 }
 


### PR DESCRIPTION
The output from a recent DCI job provides output about which ping tests fail, but the summary doesn't show up.  This will give a better experience for people looking at the results.

![image](https://user-images.githubusercontent.com/4563082/225112547-aac1f9c3-47a3-4f6f-a972-d60c473e24e3.png)

![image](https://user-images.githubusercontent.com/4563082/225112623-e0ae9a62-6ea9-4648-a78f-c370fcf0f888.png)
