### PR TITLE
Safeguard against preflight tests running if not specified

### DIFF
--- a/cnf-certification-test/preflight/suite.go
+++ b/cnf-certification-test/preflight/suite.go
@@ -47,7 +47,7 @@ var _ = ginkgo.Describe(common.PreflightTestKey, func() {
 	// Safeguard against running the preflight tests if we are specifically targeting a certain label eg. in QE.
 	ginkgoConfig, _ := ginkgo.GinkgoConfiguration()
 	if !labelsAllowTestRun(ginkgoConfig.LabelFilter, []string{common.PreflightTestKey, identifiers.TagCommon}) {
-		logrus.Debug("LabelFilter is set but 'preflight' or 'common' tests are not targeted.  Issuing skip.")
+		logrus.Warn("LabelFilter is set but 'preflight' or 'common' tests are not targeted. Skipping the preflight tests.")
 		return
 	}
 

--- a/cnf-certification-test/preflight/suite.go
+++ b/cnf-certification-test/preflight/suite.go
@@ -47,7 +47,8 @@ var _ = ginkgo.Describe(common.PreflightTestKey, func() {
 	// Safeguard against running the preflight tests if we are specifically targeting a certain label eg. in QE.
 	ginkgoConfig, _ := ginkgo.GinkgoConfiguration()
 	if !labelsAllowTestRun(ginkgoConfig.LabelFilter, []string{common.PreflightTestKey, identifiers.TagCommon}) {
-		ginkgo.Skip("LabelFilter is set but 'preflight' or 'common' tests are not targeted.  Issuing skip.")
+		logrus.Debug("LabelFilter is set but 'preflight' or 'common' tests are not targeted.  Issuing skip.")
+		return
 	}
 
 	testPreflightContainers(&env)
@@ -60,13 +61,12 @@ var _ = ginkgo.Describe(common.PreflightTestKey, func() {
 })
 
 func labelsAllowTestRun(labelFilter string, allowedLabels []string) bool {
-	foundAllowedLabel := false
 	for _, label := range allowedLabels {
 		if strings.Contains(labelFilter, label) {
-			foundAllowedLabel = true
+			return true
 		}
 	}
-	return foundAllowedLabel
+	return false
 }
 
 func testPreflightOperators(env *provider.TestEnvironment) {

--- a/cnf-certification-test/preflight/suite_test.go
+++ b/cnf-certification-test/preflight/suite_test.go
@@ -18,6 +18,10 @@ package preflight
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/common"
+	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/identifiers"
 )
 
 func TestGetUniqueTestEntriesFromContainerResults(t *testing.T) {
@@ -26,4 +30,37 @@ func TestGetUniqueTestEntriesFromContainerResults(t *testing.T) {
 
 func TestGetUniqueTestEntriesFromOperatorResults(t *testing.T) {
 	// Note: preflight lib does not expose their underlying plibRuntime.Result struct vars so I can not write unit tests for this
+}
+
+func TestLabelsAllowTestRun(t *testing.T) {
+	testCases := []struct {
+		testLabelFilter   string
+		testAllowedLabels []string
+		expectedOutput    bool
+	}{
+		{ // Test Case #1 - Label filter is empty, nothing to test, test cases not allowed
+			testLabelFilter:   "",
+			testAllowedLabels: []string{common.PreflightTestKey, identifiers.TagCommon},
+			expectedOutput:    false,
+		},
+		{ // Test Case #2 - Label filter matches other suite's test, test cases not allowed
+			testLabelFilter:   "platform-alteration-isredhat-release",
+			testAllowedLabels: []string{common.PreflightTestKey, identifiers.TagCommon},
+			expectedOutput:    false,
+		},
+		{ // Test Case #3 - Label filter is a preflight test, test is allowed
+			testLabelFilter:   "preflight-IsRedhatRelease",
+			testAllowedLabels: []string{common.PreflightTestKey, identifiers.TagCommon},
+			expectedOutput:    true,
+		},
+		{ // Test Case #3 - Label filter is a preflight test, test not allowed because missing allowed label
+			testLabelFilter:   "preflight-IsRedhatRelease",
+			testAllowedLabels: []string{identifiers.TagCommon},
+			expectedOutput:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedOutput, labelsAllowTestRun(tc.testLabelFilter, tc.testAllowedLabels))
+	}
 }


### PR DESCRIPTION
Since the `preflight` tests are marked as `TagCommon` and are living under the `preflight` test suite, any labeling that occurs that includes those two strings allows the preflight tests to run prior to the `It` blocks being created.

If there is a label set such as `platform-alteration-isredhat-release` (like in QE), we gracefully return our way out of the function so as to not run the preflight tests if we don't need them.