### PR TITLE
Add support to CentOS Stream node OS

### DIFF
--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -530,6 +530,15 @@ func testNodeOperatingSystemStatus(env *provider.TestEnvironment) {
 					failedWorkerNodes = append(failedWorkerNodes, node.Data.Name)
 					continue
 				}
+			} else if node.IsCSCOS() {
+				// Get the short version from the node
+				shortVersion, err := node.GetCSCOSVersion()
+				if err != nil {
+					tnf.ClaimFilePrintf("Node %s failed to gather CentOS Stream CoreOS version. Error: %v", node.Data.Name, err)
+					failedWorkerNodes = append(failedWorkerNodes, node.Data.Name)
+					continue
+				}
+
 			} else if node.IsRHEL() {
 				// Get the short version from the node
 				shortVersion, err := node.GetRHELVersion()

--- a/pkg/provider/nodes.go
+++ b/pkg/provider/nodes.go
@@ -58,6 +58,10 @@ func (node *Node) IsRHCOS() bool {
 	return strings.Contains(strings.TrimSpace(node.Data.Status.NodeInfo.OSImage), rhcosName)
 }
 
+func (node *Node) IsCSCOS() bool {
+	return strings.Contains(strings.TrimSpace(node.Data.Status.NodeInfo.OSImage), cscosName)
+}
+
 func (node *Node) IsRHEL() bool {
 	return strings.Contains(strings.TrimSpace(node.Data.Status.NodeInfo.OSImage), rhelName)
 }
@@ -91,6 +95,19 @@ func (node *Node) GetRHCOSVersion() (string, error) {
 	}
 
 	return shortVersion, nil
+}
+
+func (node *Node) GetCSCOSVersion() (string, error) {
+	// Check if the node is running CoreOS or not
+	if !node.IsCSCOS() {
+		return "", fmt.Errorf("invalid OS type: %s", node.Data.Status.NodeInfo.OSImage)
+	}
+
+	// CentOS Stream CoreOS 413.92.202303061740-0 (Plow) --> 413.92.202303061740-0
+	splitStr := strings.Split(node.Data.Status.NodeInfo.OSImage, cscosName)
+	longVersionSplit := strings.Split(strings.TrimSpace(splitStr[1]), " ")
+
+	return longVersionSplit[0], nil
 }
 
 func (node *Node) GetRHELVersion() (string, error) {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// CentOS Stream CoreOS starts being used instead of rhcos from OCP 4.13 latest.
 const (
 	AffinityRequiredKey              = "AffinityRequired"
 	containerName                    = "container-00"
@@ -55,6 +56,7 @@ const (
 	skipConnectivityTestsLabel       = "test-network-function.com/skip_connectivity_tests"
 	skipMultusConnectivityTestsLabel = "test-network-function.com/skip_multus_connectivity_tests"
 	rhcosName                        = "Red Hat Enterprise Linux CoreOS"
+	cscosName                        = "CentOS Stream CoreOS"
 	rhelName                         = "Red Hat Enterprise Linux"
 	tnfPartnerRepoDef                = "quay.io/testnetworkfunction"
 	supportImageDef                  = "debug-partner:latest"

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -605,6 +605,52 @@ func TestGetRHCOSVersion(t *testing.T) {
 	}
 }
 
+func TestGetCSCOSVersion(t *testing.T) {
+	testCases := []struct {
+		testImageName  string
+		expectedOutput string
+		expectedErr    error
+	}{
+		{
+			testImageName:  "CentOS Stream CoreOS 413.92.202303061740-0 (Plow)",
+			expectedOutput: "413.92.202303061740-0",
+			expectedErr:    nil,
+		},
+		{
+			testImageName:  "Red Hat Enterprise Linux CoreOS 410.84.202205031645-0 (Ootpa)",
+			expectedOutput: "4.10.14",
+			expectedErr:    errors.New("invalid OS type: Red Hat Enterprise Linux CoreOS 410.84.202205031645-0 (Ootpa)"),
+		},
+		{
+			testImageName:  "Ubuntu 20.04",
+			expectedOutput: "",
+			expectedErr:    errors.New("invalid OS type: Ubuntu 20.04"),
+		},
+		{
+			testImageName:  "Ubuntu 21.10",
+			expectedOutput: "",
+			expectedErr:    errors.New("invalid OS type: Ubuntu 21.10"),
+		},
+	}
+
+	for _, tc := range testCases {
+		node := Node{
+			Data: &corev1.Node{
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
+						OSImage: tc.testImageName,
+					},
+				},
+			},
+		}
+
+		result, err := node.GetCSCOSVersion()
+		assert.Equal(t, tc.expectedErr, err)
+		assert.Equal(t, tc.expectedOutput, result)
+		rhcosRelativePath = origValue
+	}
+}
+
 func TestGetRHELVersion(t *testing.T) {
 	testCases := []struct {
 		testImageName  string


### PR DESCRIPTION
This is to address https://github.com/test-network-function/cnf-certification-test/issues/926

The idea is to consider that a node OS can be also CentOS Stream CoreOS, starting to be used in OCP 4.13/14 latest.

I have just simplified the inclusion of this new version to the minimum, but it's true we're missing here the following:

- A comparison between the CentOS Stream and OCP version, like the one we're doing for RHCOS with [this file](https://github.com/test-network-function/cnf-certification-test/blob/main/cnf-certification-test/platform/operatingsystem/files/rhcos_version_map).
- As a result, missing IsCSCOSCompatible function [here](https://github.com/test-network-function/cnf-certification-test/blob/main/pkg/compatibility/compatibility.go).

If you can guide me in these two points to have the full picture, I'd really appreciate that.