### PR TITLE
Add default NA case for docker config discovery

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -59,6 +59,9 @@ jobs:
       - name: Install golangci-lint
         run: make install-lint
 
+      - name: Install shfmt
+        run: make install-shfmt
+
       - name: make lint
         run: make lint
 

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,8 @@ install-tools:
 # Install linters
 install-lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GO_PATH}/bin ${GOLANGCI_VERSION}
+	
+install-shfmt:
 	go install mvdan.cc/sh/v3/cmd/shfmt@latest
 
 vet:

--- a/run-tnf-container.sh
+++ b/run-tnf-container.sh
@@ -151,6 +151,9 @@ perform_dockercfg_autodiscovery() {
 	elif [[ -f "$HOME/.docker/config.json" ]]; then
 		export LOCAL_DOCKERCFG=$HOME/.docker/config.json
 		dockercfg_autodiscovery_source="\$HOME/.docker/config.json ($HOME/.docker/config.json)"
+	else
+		# Default Case: Set the variable to NA (Not Applicable)
+		export LOCAL_DOCKERCFG=NA
 	fi
 }
 
@@ -163,6 +166,11 @@ display_kubeconfig_autodiscovery_summary() {
 display_dockercfg_autodiscovery_summary() {
 	if [[ -n "$dockercfg_autodiscovery_source" ]]; then
 		echo "DockerCfg Autodiscovery: configuration loaded from $dockercfg_autodiscovery_source"
+	fi
+
+	# Let the user know that the LOCAL_DOCKERCFG is set to NA
+	if [[ $LOCAL_DOCKERCFG == 'NA' ]]; then
+		echo "LOCAL_DOCKERCFG being set to 'NA' because PFLT_DOCKERCONFIG is not set and HOME/.docker/config.json does not exist."
 	fi
 }
 

--- a/script/run-container.sh
+++ b/script/run-container.sh
@@ -97,7 +97,7 @@ done
 
 # Explode loaded DOCKERCFG
 # shellcheck disable=SC2162 # Read without -r will mangle backslashes.
-if [[ $LOCAL_DOCKERCFG != 'NA' ]]; then
+if [[ $LOCAL_DOCKERCFG != NA ]]; then
 	IFS=: read -a local_dockercfg_paths <<<"$LOCAL_DOCKERCFG"
 
 	declare -a container_tnf_dockercfg_paths
@@ -129,7 +129,7 @@ container_tnf_kubeconfig_volumes_cmd_args=$(printf -- "-v %s " "${container_tnf_
 
 # Construct new $DOCKERCFG env variable containing all paths to dockercfgs mounted to the container.
 # This environment variable is passed to the TNF container
-if [[ $LOCAL_DOCKERCFG != 'NA' ]]; then
+if [[ $LOCAL_DOCKERCFG != NA ]]; then
 	CONTAINER_TNF_DOCKERCFG=$(join_paths "${container_tnf_dockercfg_paths[@]}")
 	container_tnf_dockercfg_volumes_cmd_args=$(printf -- "-v %s " "${container_tnf_dockercfg_volume_bindings[@]}")
 fi

--- a/script/run-container.sh
+++ b/script/run-container.sh
@@ -60,8 +60,11 @@ display_config_summary() {
 	printf "Mounting %d kubeconfig volume(s):\n" "${#container_tnf_kubeconfig_volume_bindings[@]}"
 	printf -- "-v %s\n" "${container_tnf_kubeconfig_volume_bindings[@]}"
 
-	printf "Mounting %d dockercfg volume(s):\n" "${#container_tnf_dockercfg_volume_bindings[@]}"
-	printf -- "-v %s\n" "${container_tnf_dockercfg_volume_bindings[@]}"
+	# Only display this -v line if the variable is set.
+	if [ -n "${container_tnf_dockercfg_volume_bindings}" ]; then
+		printf "Mounting %d dockercfg volume(s):\n" "${#container_tnf_dockercfg_volume_bindings[@]}"
+		printf -- "-v %s\n" "${container_tnf_dockercfg_volume_bindings[@]}"
+	fi
 
 	# Checks whether a prefix of the selected image path matches the address of the official TNF repository
 	if [[ "$TNF_IMAGE" != $TNF_OFFICIAL_ORG* ]]; then
@@ -94,19 +97,21 @@ done
 
 # Explode loaded DOCKERCFG
 # shellcheck disable=SC2162 # Read without -r will mangle backslashes.
-IFS=: read -a local_dockercfg_paths <<<"$LOCAL_DOCKERCFG"
+if [[ $LOCAL_DOCKERCFG != 'NA' ]]; then
+	IFS=: read -a local_dockercfg_paths <<<"$LOCAL_DOCKERCFG"
 
-declare -a container_tnf_dockercfg_paths
-declare -a container_tnf_dockercfg_volume_bindings
+	declare -a container_tnf_dockercfg_paths
+	declare -a container_tnf_dockercfg_volume_bindings
 
-# Assign a file in the TNF container for each provided local dockercfg
-for local_path_index in "${!local_dockercfg_paths[@]}"; do
-	local_path=${local_dockercfg_paths[$local_path_index]}
-	container_path=$(get_container_tnf_dockercfg_path_from_index "$local_path_index")
+	# Assign a file in the TNF container for each provided local dockercfg
+	for local_path_index in "${!local_dockercfg_paths[@]}"; do
+		local_path=${local_dockercfg_paths[$local_path_index]}
+		container_path=$(get_container_tnf_dockercfg_path_from_index "$local_path_index")
 
-	container_tnf_dockercfg_paths+=("$container_path")
-	container_tnf_dockercfg_volume_bindings+=("$local_path:$container_path:Z")
-done
+		container_tnf_dockercfg_paths+=("$container_path")
+		container_tnf_dockercfg_volume_bindings+=("$local_path:$container_path:Z")
+	done
+fi
 
 TNF_IMAGE="${TNF_IMAGE:-$TNF_OFFICIAL_IMAGE}"
 CONTAINER_NETWORK_MODE="${CONTAINER_NETWORK_MODE:-$CONTAINER_DEFAULT_NETWORK_MODE}"
@@ -124,8 +129,10 @@ container_tnf_kubeconfig_volumes_cmd_args=$(printf -- "-v %s " "${container_tnf_
 
 # Construct new $DOCKERCFG env variable containing all paths to dockercfgs mounted to the container.
 # This environment variable is passed to the TNF container
-CONTAINER_TNF_DOCKERCFG=$(join_paths "${container_tnf_dockercfg_paths[@]}")
-container_tnf_dockercfg_volumes_cmd_args=$(printf -- "-v %s " "${container_tnf_dockercfg_volume_bindings[@]}")
+if [[ $LOCAL_DOCKERCFG != 'NA' ]]; then
+	CONTAINER_TNF_DOCKERCFG=$(join_paths "${container_tnf_dockercfg_paths[@]}")
+	container_tnf_dockercfg_volumes_cmd_args=$(printf -- "-v %s " "${container_tnf_dockercfg_volume_bindings[@]}")
+fi
 
 # Safeguard against an empty variable
 if [ -z "$CONTAINER_TNF_DOCKERCFG" ]; then


### PR DESCRIPTION
The discovery of the LOCAL_DOCKERCFG variable needs a default option (NA).  If the `PFLT_DOCKERCONFIG` variable does not get set, and the `$HOME/.docker/config.json` does not exist, then the variables get set to `NA`.

Prior to this, we were seeing:

```
Mounting 1 kubeconfig volume(s):
-v /opt/ocp/r207-compact/kubeconfig:/usr/tnf/kubeconfig/config:Z
Mounting 1 dockercfg volume(s):
-v 
```

And the `-v` docker run flag was not populated causing an error: `Error: invalid reference format`.