### PR TITLE
Admit that a control plane node can use CentOS Stream starting in OCP 4.13 (II)

### DIFF
--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -500,7 +500,7 @@ func testNodeOperatingSystemStatus(env *provider.TestEnvironment) {
 		// Control plane nodes must be RHCOS (also CentOS Stream starting in OCP 4.13)
 		// Per the release notes from OCP documentation:
 		// "You must use RHCOS machines for the control plane, and you can use either RHCOS or RHEL for compute machines."
-		if node.IsMasterNode() && (!node.IsRHCOS() || !node.IsCSCOS()) {
+		if node.IsMasterNode() && !node.IsRHCOS() && !node.IsCSCOS() {
 			tnf.ClaimFilePrintf("Master Node %s has been found to be running an incompatible operating system: %s", node.Data.Name, node.Data.Status.NodeInfo.OSImage)
 			failedControlPlaneNodes = append(failedControlPlaneNodes, node.Data.Name)
 			continue

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -497,10 +497,10 @@ func testNodeOperatingSystemStatus(env *provider.TestEnvironment) {
 		// Get the OSImage which should tell us what version of operating system the node is running.
 		logrus.Debug(fmt.Sprintf("Node %s is running operating system: %s", node.Data.Name, node.Data.Status.NodeInfo.OSImage))
 
-		// Control plane nodes must be RHCOS.
+		// Control plane nodes must be RHCOS (also CentOS Stream starting in OCP 4.13)
 		// Per the release notes from OCP documentation:
 		// "You must use RHCOS machines for the control plane, and you can use either RHCOS or RHEL for compute machines."
-		if node.IsMasterNode() && !node.IsRHCOS() {
+		if node.IsMasterNode() && (!node.IsRHCOS() || !node.IsCSCOS()) {
 			tnf.ClaimFilePrintf("Master Node %s has been found to be running an incompatible operating system: %s", node.Data.Name, node.Data.Status.NodeInfo.OSImage)
 			failedControlPlaneNodes = append(failedControlPlaneNodes, node.Data.Name)
 			continue


### PR DESCRIPTION
This minor check was missed in https://github.com/test-network-function/cnf-certification-test/pull/928, OCP 4.13 job was failing in fact: https://www.distributed-ci.io/jobs/f0f8d733-30d5-4994-9fb9-6006c28e210e/tests

https://github.com/test-network-function/cnf-certification-test/pull/932 was created to fix that but condition was wrong. This should fix everything.