### PR TITLE
Consolidate CI Kind Cluster YAML

### DIFF
--- a/.github/build-kind-cluster/action.yml
+++ b/.github/build-kind-cluster/action.yml
@@ -1,0 +1,20 @@
+name: build-kind-cluster
+description: A shared action that builds and deploys our Kind cluster
+
+runs:
+  steps:
+    - name: Check out `cnf-certification-test-partner`
+      uses: actions/checkout@v3
+      with:
+        repository: test-network-function/cnf-certification-test-partner
+        path: cnf-certification-test-partner
+
+    - name: Start the Kind cluster for `local-test-infra`
+      uses: ./cnf-certification-test-partner/.github/actions/start-k8s-cluster
+      with:
+        working_directory: cnf-certification-test-partner
+
+    - name: Create `local-test-infra` OpenShift resources
+      uses: ./cnf-certification-test-partner/.github/actions/create-local-test-infra-resources
+      with:
+        working_directory: cnf-certification-test-partner

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -51,8 +51,6 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.sha }}
 
       # TODO: golangci-lint team recommends using a GitHub Action to perform golangci-lint responsibilities.  However
       # there does not appear to be a way to honor our existing .golangci.yml.  For now, mimic developer behavior.
@@ -119,8 +117,6 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.sha }}
 
       - name: Run Tests
         run: make test
@@ -166,10 +162,12 @@ jobs:
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"
 
-      - name: Check out code into the Go module directory
+      - name: Check out code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.sha }}
+
+      # Create a Kind cluster for testing.
+      - name: Create Kind Cluster for testing
+        uses: ./.github/actions/build-kind-cluster
 
       # Update the CNF containers, helm charts and operators DB
 
@@ -184,23 +182,6 @@ jobs:
 
       - name: Execute `make build`
         run: make build
-
-      # Create a Kind cluster for testing.
-      - name: Check out `cnf-certification-test-partner`
-        uses: actions/checkout@v3
-        with:
-          repository: test-network-function/cnf-certification-test-partner
-          path: cnf-certification-test-partner
-
-      - name: Start the Kind cluster for `local-test-infra`
-        uses: ./cnf-certification-test-partner/.github/actions/start-k8s-cluster
-        with:
-          working_directory: cnf-certification-test-partner
-
-      - name: Create `local-test-infra` OpenShift resources
-        uses: ./cnf-certification-test-partner/.github/actions/create-local-test-infra-resources
-        with:
-          working_directory: cnf-certification-test-partner
 
       # Perform smoke tests.
       - name: 'Test: Run test suites'
@@ -233,29 +214,13 @@ jobs:
           touch ${PFLT_DOCKERCONFIG}
           echo '{ "auths": {} }' >> ${PFLT_DOCKERCONFIG}
 
-      # Create a Kind cluster for testing.
-      - name: Check out `cnf-certification-test-partner`
-        uses: actions/checkout@v3
-        with:
-          repository: test-network-function/cnf-certification-test-partner
-          path: cnf-certification-test-partner
-
-      - name: Start the Kind cluster for `local-test-infra`
-        uses: ./cnf-certification-test-partner/.github/actions/start-k8s-cluster
-        with:
-          working_directory: cnf-certification-test-partner
-
-      - name: Create `local-test-infra` OpenShift resources
-        uses: ./cnf-certification-test-partner/.github/actions/create-local-test-infra-resources
-        with:
-          working_directory: cnf-certification-test-partner
-            
-
       # Perform smoke tests using a TNF container.
-      - name: Check out code into the Go module directory
+      - name: Check out code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.sha }}
+
+      # Create a Kind cluster for testing.
+      - name: Create Kind Cluster for testing
+        uses: ./.github/actions/build-kind-cluster
 
       - name: Build the `cnf-certification-test` image
         run: |


### PR DESCRIPTION
#916 is also consolidating some of the same copy/pasted sections.

This change creates an action called `build-kind-cluster` and since it is called twice, we can consolidate it.