### PR TITLE
Add some more logging; safeguard against empty InstallPlans

### DIFF
--- a/cnf-certification-test/preflight/suite.go
+++ b/cnf-certification-test/preflight/suite.go
@@ -80,6 +80,8 @@ func testPreflightOperators(env *provider.TestEnvironment) {
 		}
 	}
 
+	logrus.Infof("Completed running preflight operator tests for %d operators", len(env.Operators))
+
 	// Handle Operator-based preflight tests
 	// Note: We only care about the `testEntry` variable below because we need its 'Description' and 'Suggestion' variables.
 	for testName, testEntry := range getUniqueTestEntriesFromOperatorResults(env.Operators) {
@@ -100,6 +102,8 @@ func testPreflightContainers(env *provider.TestEnvironment) {
 			logrus.Fatalf("failed running preflight on image: %s error: %v", cut.Image, err)
 		}
 	}
+
+	logrus.Infof("Completed running preflight container tests for %d containers", len(env.Containers))
 
 	// Handle Container-based preflight tests
 	// Note: We only care about the `testEntry` variable below because we need its 'Description' and 'Suggestion' variables.

--- a/pkg/provider/containers.go
+++ b/pkg/provider/containers.go
@@ -84,15 +84,12 @@ func (c *Container) SetPreflightResults(preflightImageCache map[string]plibRunti
 		return nil
 	}
 
-	var results plibRuntime.Results
 	opts := []plibContainer.Option{}
 	opts = append(opts, plibContainer.WithDockerConfigJSONFromFile(env.GetDockerConfigFile()))
 	if env.IsPreflightInsecureAllowed() {
 		logrus.Info("Insecure connections are being allowed to preflight")
 		opts = append(opts, plibContainer.WithInsecureConnection())
 	}
-
-	check := plibContainer.NewCheck(c.Image, opts...)
 
 	// Create artifacts handler
 	artifactsWriter, err := artifacts.NewMapWriter()
@@ -108,8 +105,8 @@ func (c *Container) SetPreflightResults(preflightImageCache map[string]plibRunti
 	logger := stdr.New(checklogger)
 	ctx = logr.NewContext(ctx, logger)
 
-	var runtimeErr error
-	results, runtimeErr = check.Run(ctx)
+	check := plibContainer.NewCheck(c.Image, opts...)
+	results, runtimeErr := check.Run(ctx)
 	logrus.StandardLogger().Out = os.Stderr
 	if runtimeErr != nil {
 		logrus.Error(runtimeErr)


### PR DESCRIPTION
There has been some recent DCI runs where it seems like an empty slice of InstallPlans is throwing an error.  We should probably have a safeguard against this sort of scenario.