### PR TITLE
hugepages tc: avoid panic if debug pod doesn't exist for node under test

### DIFF
--- a/cnf-certification-test/lifecycle/podrecreation/podrecreation.go
+++ b/cnf-certification-test/lifecycle/podrecreation/podrecreation.go
@@ -48,7 +48,7 @@ const (
 func CordonHelper(name, operation string) error {
 	clients := clientsholder.GetClientsHolder()
 
-	logrus.Infof("Performing %q operation on node %s", operation, name)
+	logrus.Infof("Performing %s operation on node %s", operation, name)
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// Fetch node object
 		node, err := clients.K8sClient.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})

--- a/cnf-certification-test/lifecycle/podrecreation/podrecreation.go
+++ b/cnf-certification-test/lifecycle/podrecreation/podrecreation.go
@@ -48,6 +48,7 @@ const (
 func CordonHelper(name, operation string) error {
 	clients := clientsholder.GetClientsHolder()
 
+	logrus.Infof("Performing %q operation on node %s", operation, name)
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// Fetch node object
 		node, err := clients.K8sClient.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -383,7 +383,14 @@ func testHugepages(env *provider.TestEnvironment) {
 			continue
 		}
 
-		hpTester, err := hugepages.NewTester(&node, env.DebugPods[node.Data.Name], clientsholder.GetClientsHolder())
+		debugPod, exist := env.DebugPods[node.Data.Name]
+		if !exist {
+			tnf.ClaimFilePrintf("Node %s: tnf debug pod not found.", node.Data.Name)
+			badNodes = append(badNodes, node.Data.Name)
+			continue
+		}
+
+		hpTester, err := hugepages.NewTester(&node, debugPod, clientsholder.GetClientsHolder())
 		if err != nil {
 			tnf.ClaimFilePrintf("Unable to get node hugepages tester for node %s, err: %v", node.Data.Name, err)
 			badNodes = append(badNodes, node.Data.Name)


### PR DESCRIPTION
Make sure the debug pod is available for the node under test.

+ Added info trace for cordon/uncordon operations.