### PR TITLE
Make the namespace for the debug daemonset configurable.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,3 +105,9 @@ skipScalingTestStatefulSetNames:
   - name: "statefulset1"
     namespace: "tnf"
 ```
+## debugDaemonSetNamespace
+This is an optional field with the name of the namespace where a privileged DaemonSet will be deployed. The namespace will be created in case it does not exist. In case this field is not set, the default namespace for this DaemonSet is "cnf-suite".
+```
+debugDaemonSetNamespace: cnf-cert
+```
+This DaemonSet, called "tnf-debug" is deployed and used internally by the CNF Certification tool to issue some shell commands that are needed in certain test cases. Some of these test cases might fail or be skipped in case it wasn't deployed correctly.

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -114,30 +114,26 @@ func buildLabelKeyValue(label configuration.Label) (key, value string) {
 // DoAutoDiscover finds objects under test
 //
 //nolint:funlen
-func DoAutoDiscover() DiscoveredTestData {
-	data.Env = *configuration.GetTestParameters()
+func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData {
+	oc := clientsholder.GetClientsHolder()
 
 	var err error
-	data.TestData, err = configuration.LoadConfiguration(data.Env.ConfigurationPath)
-	if err != nil {
-		logrus.Fatalf("Cannot load configuration, error: %v", err)
-	}
-	oc := clientsholder.GetClientsHolder()
 	data.StorageClasses, err = getAllStorageClasses()
 	if err != nil {
 		logrus.Fatalf("Failed to retrieve storageClasses - err: %v", err)
 	}
+
 	data.AllNamespaces, _ = getAllNamespaces(oc.K8sClient.CoreV1())
 	data.AllSubscriptions = findSubscriptions(oc.OlmClient, []string{""})
 	data.AllCsvs = getAllOperators(oc.OlmClient)
 	data.AllInstallPlans = getAllInstallPlans(oc.OlmClient)
 	data.AllCatalogSources = getAllCatalogSources(oc.OlmClient)
-	data.Namespaces = namespacesListToStringList(data.TestData.TargetNameSpaces)
-	data.Pods, data.AllPods = findPodsByLabel(oc.K8sClient.CoreV1(), data.TestData.TargetPodLabels, data.Namespaces)
+	data.Namespaces = namespacesListToStringList(config.TargetNameSpaces)
+	data.Pods, data.AllPods = findPodsByLabel(oc.K8sClient.CoreV1(), config.TargetPodLabels, data.Namespaces)
 	data.AbnormalEvents = findAbnormalEvents(oc.K8sClient.CoreV1(), data.Namespaces)
 	debugLabel := configuration.Label{Prefix: debugLabelPrefix, Name: debugLabelName, Value: debugLabelValue}
 	debugLabels := []configuration.Label{debugLabel}
-	debugNS := []string{defaultNamespace}
+	debugNS := []string{config.DebugDaemonSetNamespace}
 	data.DebugPods, _ = findPodsByLabel(oc.K8sClient.CoreV1(), debugLabels, debugNS)
 	data.ResourceQuotaItems, err = getResourceQuotas(oc.K8sClient.CoreV1())
 	if err != nil {
@@ -151,9 +147,9 @@ func DoAutoDiscover() DiscoveredTestData {
 	if err != nil {
 		logrus.Fatalln("Cannot get network policies")
 	}
-	data.Crds = FindTestCrdNames(data.TestData.CrdFilters)
-	data.ScaleCrUndetTest = GetScaleCrUnderTest(data.Namespaces, data.Crds, data.TestData.CrdFilters)
-	data.Csvs = findOperatorsByLabel(oc.OlmClient, []configuration.Label{{Name: tnfCsvTargetLabelName, Prefix: tnfLabelPrefix, Value: tnfCsvTargetLabelValue}}, data.TestData.TargetNameSpaces)
+	data.Crds = FindTestCrdNames(config.CrdFilters)
+	data.ScaleCrUndetTest = GetScaleCrUnderTest(data.Namespaces, data.Crds, config.CrdFilters)
+	data.Csvs = findOperatorsByLabel(oc.OlmClient, []configuration.Label{{Name: tnfCsvTargetLabelName, Prefix: tnfLabelPrefix, Value: tnfCsvTargetLabelValue}}, config.TargetNameSpaces)
 	data.Subscriptions = findSubscriptions(oc.OlmClient, data.Namespaces)
 	data.HelmChartReleases = getHelmList(oc.RestConfig, data.Namespaces)
 
@@ -168,15 +164,15 @@ func DoAutoDiscover() DiscoveredTestData {
 		logrus.Fatalf("Cannot get the K8s version, error: %v", err)
 	}
 	data.IstioServiceMeshFound = isIstioServiceMeshInstalled(data.AllNamespaces)
-	data.ValidProtocolNames = data.TestData.ValidProtocolNames
-	data.ServicesIgnoreList = data.TestData.ServicesIgnoreList
+	data.ValidProtocolNames = config.ValidProtocolNames
+	data.ServicesIgnoreList = config.ServicesIgnoreList
 
 	// Find the status of the OCP version (pre-ga, end-of-life, maintenance, or generally available)
 	data.OCPStatus = compatibility.DetermineOCPStatus(openshiftVersion, time.Now())
 
 	data.K8sVersion = k8sVersion.GitVersion
-	data.Deployments = findDeploymentByLabel(oc.K8sClient.AppsV1(), data.TestData.TargetPodLabels, data.Namespaces)
-	data.StatefulSet = findStatefulSetByLabel(oc.K8sClient.AppsV1(), data.TestData.TargetPodLabels, data.Namespaces)
+	data.Deployments = findDeploymentByLabel(oc.K8sClient.AppsV1(), config.TargetPodLabels, data.Namespaces)
+	data.StatefulSet = findStatefulSetByLabel(oc.K8sClient.AppsV1(), config.TargetPodLabels, data.Namespaces)
 	data.Hpas = findHpaControllers(oc.K8sClient, data.Namespaces)
 	data.Nodes, err = oc.K8sClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {

--- a/pkg/autodiscover/constants.go
+++ b/pkg/autodiscover/constants.go
@@ -16,7 +16,6 @@
 package autodiscover
 
 const (
-	defaultNamespace = "default"
 	debugLabelPrefix = "test-network-function.com"
 	debugLabelName   = "app"
 	debugLabelValue  = "tnf-debug"

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -16,6 +16,10 @@
 
 package configuration
 
+const (
+	defaultDebugDaemonSetNamespace = "cnf-suite"
+)
+
 // CertifiedContainerRequestInfo contains all certified images request info
 type CertifiedContainerRequestInfo struct {
 	// Name is the name of the `operator bundle package name` or `image-version` that you want to check if exists in the RedHat catalog
@@ -127,6 +131,7 @@ type TestConfiguration struct {
 	CheckDiscoveredContainerCertificationStatus bool     `yaml:"checkDiscoveredContainerCertificationStatus" json:"checkDiscoveredContainerCertificationStatus"`
 	ValidProtocolNames                          []string `yaml:"validProtocolNames" json:"validProtocolNames"`
 	ServicesIgnoreList                          []string `yaml:"servicesignorelist" json:"servicesignorelist"`
+	DebugDaemonSetNamespace                     string   `yaml:"debugDaemonSetNamespace" json:"debugDaemonSetNamespace"`
 }
 
 type TestParameters struct {

--- a/pkg/configuration/utils.go
+++ b/pkg/configuration/utils.go
@@ -46,7 +46,7 @@ func LoadConfiguration(filePath string) (TestConfiguration, error) {
 		log.Debug("config file already loaded, return previous element")
 		return configuration, nil
 	}
-	confLoaded = true
+
 	log.Info("Loading config from file: ", filePath)
 	contents, err := os.ReadFile(filePath)
 	if err != nil {
@@ -57,6 +57,16 @@ func LoadConfiguration(filePath string) (TestConfiguration, error) {
 	if err != nil {
 		return configuration, err
 	}
+
+	// Set default namespace for the debug daemonset pods, in case it was not set.
+	if configuration.DebugDaemonSetNamespace == "" {
+		log.Warnf("No namespace configured for the debug DaemonSet. Defaulting to namespace %s", defaultDebugDaemonSetNamespace)
+		configuration.DebugDaemonSetNamespace = defaultDebugDaemonSetNamespace
+	} else {
+		log.Infof("Namespace for debug DaemonSet: %s", configuration.DebugDaemonSetNamespace)
+	}
+
+	confLoaded = true
 	return configuration, nil
 }
 


### PR DESCRIPTION
The namespace for the debug daemonset is now configurable via yaml file. In case the field is not set, the namespace "cnf-suite" will be used.

Example:
debugDaemonSetNamespace: cnf-cert

+ Minor refactors.