### PR TITLE
Add unit tests for scaling package

### DIFF
--- a/cnf-certification-test/lifecycle/scaling/deployment_scaling_test.go
+++ b/cnf-certification-test/lifecycle/scaling/deployment_scaling_test.go
@@ -18,15 +18,20 @@ package scaling
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/lifecycle/podsets"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
+	"github.com/test-network-function/cnf-certification-test/pkg/provider"
 	v1app "k8s.io/api/apps/v1"
+	v1autoscaling "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestScaleDeploymentFunc(t *testing.T) {
@@ -80,5 +85,230 @@ func TestScaleDeploymentFunc(t *testing.T) {
 		dp, err := c.K8sClient.AppsV1().Deployments("namespace1").Get(context.TODO(), tc.deploymentName, metav1.GetOptions{})
 		assert.Nil(t, err)
 		assert.Equal(t, int32(tc.replicaCount), *dp.Spec.Replicas)
+	}
+}
+
+func TestScaleHpaDeploymentFunc(t *testing.T) {
+	generateDeployment := func(name string, replicas *int32) *v1app.Deployment {
+		return &v1app.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "namespace1",
+			},
+			Spec: v1app.DeploymentSpec{
+				Replicas: replicas,
+			},
+		}
+	}
+
+	testCases := []struct {
+		deploymentName       string
+		replicaCount         int
+		hpaMinReplicas       int32
+		hpaMaxReplicas       int32
+		expectedReplicaCount int
+	}{
+		{ // Test Case 1 - Start with 3 replicas, HPA min 1, HPA max 3, expect 3 replicas
+			deploymentName:       "dp1",
+			replicaCount:         3,
+			hpaMinReplicas:       1,
+			hpaMaxReplicas:       3,
+			expectedReplicaCount: 3,
+		},
+		{ // Test Case 2 - Start with 1 replica, HPA min 1, HPA max 3, expect 3 replicas
+			deploymentName:       "dp2",
+			replicaCount:         1,
+			hpaMinReplicas:       1,
+			hpaMaxReplicas:       3,
+			expectedReplicaCount: 3,
+		},
+	}
+
+	// Always return that the Deployment is Ready
+	origFunc := podsets.WaitForDeploymentSetReady
+	defer func() {
+		podsets.WaitForDeploymentSetReady = origFunc
+	}()
+	podsets.WaitForDeploymentSetReady = func(ns, name string, timeout time.Duration) bool {
+		return true
+	}
+
+	// Create int32 pointer
+	int32Ptr := func(i int32) *int32 { return &i }
+
+	for _, tc := range testCases {
+		intVar := new(int32)
+		*intVar = int32(tc.replicaCount)
+		tempDP := generateDeployment(tc.deploymentName, intVar)
+
+		hpatest := &v1autoscaling.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "hpaName",
+				Namespace: "namespace1",
+			},
+			Spec: v1autoscaling.HorizontalPodAutoscalerSpec{
+				MinReplicas: int32Ptr(tc.hpaMinReplicas),
+				MaxReplicas: tc.hpaMaxReplicas,
+			},
+		}
+
+		var runtimeObjects []runtime.Object
+		runtimeObjects = append(runtimeObjects, tempDP, hpatest)
+		c := k8sfake.NewSimpleClientset(runtimeObjects...)
+		c.Fake.AddReactor("get", "horizontalpodautoscalers", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			return true, hpatest, nil
+		})
+
+		c.Fake.AddReactor("update", "horizontalpodautoscalers", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			return true, hpatest, nil
+		})
+
+		// Override the clientsholder with the fake client.
+		// The scaleHpaDeployment function uses the clientsholder to get the client.
+		clientsholder.SetTestK8sClientsHolder(c)
+
+		// Put the generated deployment into a provider.Deployment
+		dp := &provider.Deployment{
+			Deployment: tempDP,
+		}
+
+		// Run the function
+		TestScaleHpaDeployment(dp, hpatest, 10*time.Second)
+
+		// Get the deployment from the fake API
+		hpa, err := c.AutoscalingV1().HorizontalPodAutoscalers("namespace1").Get(context.TODO(), "hpaName", metav1.GetOptions{})
+		assert.Nil(t, err)
+		assert.Equal(t, int32(tc.expectedReplicaCount), hpa.Spec.MaxReplicas)
+	}
+}
+
+func TestScaleHpaDeploymentHelper(t *testing.T) {
+	testCases := []struct {
+		getResult      error
+		updateResult   error
+		expectedOutput bool
+	}{
+		{ // Test Case 1 - No errors issuing the get or update
+			getResult:      nil,
+			updateResult:   nil,
+			expectedOutput: true,
+		},
+		{ // Test Case 2 - Error updating the deployment
+			getResult:      nil,
+			updateResult:   errors.New("this is an error"),
+			expectedOutput: false,
+		},
+		{ // Test Case 3 - Error getting the deployment
+			getResult:      errors.New("this is an error"),
+			updateResult:   nil,
+			expectedOutput: false,
+		},
+	}
+
+	// Clear the test clientsholder object when complete
+	defer clientsholder.ClearTestClientsHolder()
+
+	// Create int32 pointer
+	int32Ptr := func(i int32) *int32 { return &i }
+
+	for _, tc := range testCases {
+		// Create a spoofed deployment to pass to the clientsholder.
+		// This is only needed because the podsets.WaitForDeploymentSetReady function
+		// utilizes the clientsholder straight from the function to retrieve the latest information.
+		hpatest := &v1autoscaling.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "hpaName",
+			},
+			Spec: v1autoscaling.HorizontalPodAutoscalerSpec{
+				MinReplicas: int32Ptr(1),
+				MaxReplicas: 3,
+			},
+		}
+
+		// Spoof the clientsholder with runtime objects
+		var runtimeObjs []runtime.Object
+		runtimeObjs = append(runtimeObjs, hpatest)
+		clientsholder.GetTestClientsHolder(runtimeObjs)
+
+		// Spoof the get and update functions
+		client := k8sfake.Clientset{}
+		client.Fake.AddReactor("get", "horizontalpodautoscalers", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			return true, runtimeObjs[0], tc.getResult
+		})
+
+		client.Fake.AddReactor("update", "horizontalpodautoscalers", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			return true, runtimeObjs[0], tc.updateResult
+		})
+
+		result := scaleHpaDeploymentHelper(client.AutoscalingV1().HorizontalPodAutoscalers("ns1"), "hpaName", "dp1", "ns1", 1, 3, 10*time.Second)
+		assert.Equal(t, tc.expectedOutput, result)
+	}
+}
+
+func TestScaleDeploymentHelper(t *testing.T) {
+	testCases := []struct {
+		getResult      error
+		updateResult   error
+		expectedOutput bool
+	}{
+		{ // Test Case 1 - No errors issuing the get or update
+			getResult:      nil,
+			updateResult:   nil,
+			expectedOutput: true,
+		},
+		{ // Test Case 2 - Error updating the deployment
+			getResult:      nil,
+			updateResult:   errors.New("this is an error"),
+			expectedOutput: false,
+		},
+		{ // Test Case 3 - Error getting the deployment
+			getResult:      errors.New("this is an error"),
+			updateResult:   nil,
+			expectedOutput: false,
+		},
+	}
+
+	// Clear the test clientsholder object when complete
+	defer clientsholder.ClearTestClientsHolder()
+
+	for _, tc := range testCases {
+		// Create a spoofed deployment to pass to the clientsholder.
+		// This is only needed because the podsets.WaitForDeploymentSetReady function
+		// utilizes the clientsholder straight from the function to retrieve the latest information.
+		dep := &v1app.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dp1",
+				Namespace: "ns1",
+			},
+			Status: v1app.DeploymentStatus{
+				Conditions: []v1app.DeploymentCondition{
+					{
+						Type: v1app.DeploymentAvailable,
+					},
+				},
+				Replicas:          1,
+				ReadyReplicas:     1,
+				UpdatedReplicas:   1,
+				AvailableReplicas: 1,
+			},
+		}
+
+		// Spoof the clientsholder with runtime objects
+		var runtimeObjs []runtime.Object
+		runtimeObjs = append(runtimeObjs, dep)
+		clientsholder.GetTestClientsHolder(runtimeObjs)
+
+		// Spoof the get and update functions
+		client := k8sfake.Clientset{}
+		client.Fake.AddReactor("get", "deployments", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			return true, runtimeObjs[0], tc.getResult
+		})
+
+		client.Fake.AddReactor("update", "deployments", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			return true, runtimeObjs[0], tc.updateResult
+		})
+
+		result := scaleDeploymentHelper(client.AppsV1(), dep, 1, 10*time.Second, true)
+		assert.Equal(t, tc.expectedOutput, result)
 	}
 }

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -135,6 +135,11 @@ func GetTestClientsHolder(k8sMockObjects []runtime.Object) *ClientsHolder {
 	return &clientsHolder
 }
 
+func SetTestK8sClientsHolder(k8sClient kubernetes.Interface) {
+	clientsHolder.K8sClient = k8sClient
+	clientsHolder.ready = true
+}
+
 func ClearTestClientsHolder() {
 	clientsHolder.K8sClient = nil
 	clientsHolder.ready = false


### PR DESCRIPTION
Added tests for:
- ScaleDeploymentHelper
- ScaleHpaDeploymentHelper

Adds a helper function `SetTestK8sClientsHolder` that lets us override the `k8sclient` with a spoofed fake client.