### PR TITLE
Bug fix: config struct was not copied into global env.

### DIFF
--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -54,7 +54,6 @@ const (
 
 type DiscoveredTestData struct {
 	Env                    configuration.TestParameters
-	TestData               configuration.TestConfiguration
 	Pods                   []corev1.Pod
 	AllPods                []corev1.Pod
 	DebugPods              []corev1.Pod

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -213,7 +213,7 @@ func buildTestEnvironment() { //nolint:funlen
 	data := autodiscover.DoAutoDiscover(&config)
 	// OpenshiftVersion needs to be set asap, as other helper functions will use it here.
 	env.OpenshiftVersion = data.OpenshiftVersion
-	env.Config = data.TestData
+	env.Config = config
 	env.Crds = data.Crds
 	env.AllInstallPlans = data.AllInstallPlans
 	env.AllCatalogSources = data.AllCatalogSources
@@ -255,7 +255,7 @@ func buildTestEnvironment() { //nolint:funlen
 	env.NetworkPolicies = data.NetworkPolicies
 	for _, nsHelmChartReleases := range data.HelmChartReleases {
 		for _, helmChartRelease := range nsHelmChartReleases {
-			if !isSkipHelmChart(helmChartRelease.Name, data.TestData.SkipHelmChartList) {
+			if !isSkipHelmChart(helmChartRelease.Name, config.SkipHelmChartList) {
 				env.HelmChartReleases = append(env.HelmChartReleases, helmChartRelease)
 			}
 		}


### PR DESCRIPTION
My PR #967 (sha e7c7753), broke (at least) the test case affiliated-certification-container-is-certified because the config struct was not copied into the env.Config field.

Any other test case that needed to check the config in run-time, e.g. to consult whitelists, were also affected.