### PR TITLE
Handle beta OCP versions

### DIFF
--- a/pkg/compatibility/compatibility_test.go
+++ b/pkg/compatibility/compatibility_test.go
@@ -179,6 +179,11 @@ func TestIsRHCOSCompatible(t *testing.T) {
 			testMachineVersion: "",
 			expectedOutput:     false,
 		},
+		{ // Test Case #6 - OCP 4.13.0-rc.2 accepts RHCOS version 4.13.0-rc.2, pass
+			testOCPVersion:     "4.13.0-rc.2",
+			testMachineVersion: "4.13.0-rc.2",
+			expectedOutput:     true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Resolves #980 

Adds a variable called `ocpBetaVersions` which is just a slice of "major.minor" versions.

Adds a short-circuit func called `BetaRHCOSVersionsFoundToMatch` which will short circuit the `IsRHCOSCompatible` function if we have some beta versions running.