### PR TITLE
Run unit tests on RHCOS map update

### DIFF
--- a/.github/workflows/update-rhcos-mapping.yml
+++ b/.github/workflows/update-rhcos-mapping.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Execute `make update-rhcos-versions`
         run: make update-rhcos-versions
 
+        # This prevents any failures due to the updated rhcos_versions_map file from
+        # making it into the PR phase.
+      - name: Run unit tests
+        run: make test
+
       - name: Create PR
         uses: peter-evans/create-pull-request@v4
         env:


### PR DESCRIPTION
Follow up to discussion in #982 

If `make test` fails, the PR with the RHCOS map update won't be created.