### PR TITLE
Add MacOS to CI matrix

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -28,19 +28,14 @@ env:
 jobs:
   lint:
     name: Run Linter and Vet
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-latest]
     env:
       SHELL: /bin/bash
-      KUBECONFIG: '/home/runner/.kube/config'
-      PFLT_DOCKERCONFIG: '/home/runner/.docker/config'
 
     steps:
-      - name: Write temporary docker file
-        run: |
-          mkdir -p /home/runner/.docker
-          touch ${PFLT_DOCKERCONFIG}
-          echo '{ "auths": {} }' >> ${PFLT_DOCKERCONFIG}
-
       - name: Set up Go 1.20
         uses: actions/setup-go@v4
         with:
@@ -66,6 +61,12 @@ jobs:
             --output /usr/local/bin/hadolint \
             https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
           chmod +x /usr/local/bin/hadolint
+        if: runner.os == 'Linux'
+
+      - name: Install hadolint
+        run: |
+          brew install hadolint
+        if: runner.os == 'macOS'
 
       - name: Install shfmt
         run: make install-shfmt
@@ -105,19 +106,14 @@ jobs:
                 level: warning
   unit-tests:
     name: Run Unit Tests
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-latest]
     env:
       SHELL: /bin/bash
-      KUBECONFIG: '/home/runner/.kube/config'
-      PFLT_DOCKERCONFIG: '/home/runner/.docker/config'
 
     steps:
-      - name: Write temporary docker file
-        run: |
-          mkdir -p /home/runner/.docker
-          touch ${PFLT_DOCKERCONFIG}
-          echo '{ "auths": {} }' >> ${PFLT_DOCKERCONFIG}
-
       - name: Set up Go 1.20
         uses: actions/setup-go@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ install-tools:
 
 # Install linters
 install-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GO_PATH}/bin ${GOLANGCI_VERSION}
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_VERSION}
 
 install-shfmt:
 	go install mvdan.cc/sh/v3/cmd/shfmt@latest


### PR DESCRIPTION
Notable changes:
- Changed `make install-lint` to use `go install` instead of curling the binary.
- Added additional `Install hadolint` step in pre-main.yaml that uses brew for macOS installs.
- Adds `macos-latest` to matrix for running tests.

Since we are running these scripts locally as well as in CI, they might as well pass both places.