### PR TITLE
Install Go before make test

### DIFF
--- a/.github/workflows/update-rhcos-mapping.yml
+++ b/.github/workflows/update-rhcos-mapping.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Execute `make update-rhcos-versions`
         run: make update-rhcos-versions
 
+      - name: Set up Go 1.20
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.20.3
+
         # This prevents any failures due to the updated rhcos_versions_map file from
         # making it into the PR phase.
       - name: Run unit tests


### PR DESCRIPTION
Follow up to: https://github.com/test-network-function/cnf-certification-test/pull/984

We need `Go` before we can run `make test`.