### PR TITLE
Safeguard against NA docker config

### DIFF
--- a/cnf-certification-test/preflight/suite.go
+++ b/cnf-certification-test/preflight/suite.go
@@ -39,7 +39,7 @@ var _ = ginkgo.Describe(common.PreflightTestKey, func() {
 	ginkgo.ReportAfterEach(results.RecordResult)
 
 	// Add safeguard against running the tests if the docker config doesn't exist.
-	if env.GetDockerConfigFile() == "" {
+	if env.GetDockerConfigFile() == "" || env.GetDockerConfigFile() == "NA" {
 		logrus.Debug("Skipping the preflight suite because the Docker Config file is not provided.")
 		return
 	}


### PR DESCRIPTION
#831 added this safeguard but the check for the empty string needs to also include the value "NA".  This check was added in #861.

Should be an easy fix and we can release 4.2.2 to pick it up.


For example, here are the ENV vars from a 4.2.1 run:
```
"Environment: {Home:/root Kubeconfig:/usr/tnf/kubeconfig/config ConfigurationPath:/usr/tnf/config/tnf_config.yml NonIntrusiveOnly:true LogLevel:trace OfflineDB:/usr/offline-db AllowPreflightInsecure:false PfltDockerconfig:NA}"
```