### PR TITLE
Combine container and local self-hosted tests

### DIFF
--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -1,8 +1,6 @@
 name: Self Hosted Incoming Changes
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:
@@ -90,42 +88,6 @@ jobs:
             cnf-certification-test/claimjson.js
             cnf-certification-test/results.html
             cnf-certification-test/tnf-execution.log
-
-  smoke-tests-container:
-    name: Run Container Smoke Tests
-    runs-on: self-hosted
-    env:
-      SHELL: /bin/bash
-      KUBECONFIG: '/home/tnf/.kube/config'
-      PFLT_DOCKERCONFIG: '/home/tnf/.docker/config'
-
-    steps:
-      # Create a Kind cluster for testing.
-      - name: Check out `cnf-certification-test-partner`
-        uses: actions/checkout@v3
-        with:
-          repository: test-network-function/cnf-certification-test-partner
-          path: cnf-certification-test-partner
-
-      - name: Bootstrap the Kind and OC/Kubectl binaries for the `local-test-infra`
-        run: make bootstrap-cluster-fedora-local
-        working-directory: cnf-certification-test-partner
-
-      - name: Create `local-test-infra` OpenShift resources
-        run: make rebuild-cluster
-        working-directory: cnf-certification-test-partner
-
-      - name: Install partner resources
-        run: make install
-        working-directory: cnf-certification-test-partner
-            
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.sha }}
-
-      - name: Run initial setup
-        uses: ./.github/actions/setup
 
       - name: Build the `cnf-certification-test` image
         run: |


### PR DESCRIPTION
Since we only have one `self-hosted` runner instance, combining the local binary and container tests makes sense to shorten times.

Also, I have removed the need to run this when commits are pushed to the `main` branch after merging.  Not necessary and overloads the runner.