### PR TITLE
platform-alteration-base-image test case workaround.

### DIFF
--- a/cnf-certification-test/platform/cnffsdiff/fsdiff_test.go
+++ b/cnf-certification-test/platform/cnffsdiff/fsdiff_test.go
@@ -18,6 +18,8 @@ package cnffsdiff_test
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,7 +34,12 @@ type ClientHoldersMock struct {
 	err    error
 }
 
-func (o ClientHoldersMock) ExecCommandContainer(_ clientsholder.Context, _ string) (stdout, stderr string, err error) {
+func (o ClientHoldersMock) ExecCommandContainer(_ clientsholder.Context, cmd string) (stdout, stderr string, err error) {
+	// Filter out mkdir/rmdir and mount/umount commands.
+	if !strings.Contains(cmd, "podman diff") {
+		return "", "", nil
+	}
+
 	stdout, stderr, err = o.stdout, o.stderr, o.err
 	return stdout, stderr, err
 }
@@ -98,8 +105,165 @@ func TestRunTest(t *testing.T) {
 			err:    tc.clientErr,
 		}
 
-		fsdiff := NewFsDiffTester(chm)
-		fsdiff.RunTest(clientsholder.Context{}, "fakeUID")
+		fsdiff := NewFsDiffTester(chm, clientsholder.Context{})
+		fsdiff.RunTest("fakeUID")
 		assert.Equal(t, tc.expectedResult, fsdiff.GetResults())
+	}
+}
+
+type ClientHoldersMountCustomPodmanMock struct {
+	createFolderStdout string
+	createFolderStderr string
+	createFolderErr    error
+
+	mountFolderStdout string
+	mountFolderStderr string
+	mountFolderErr    error
+
+	// Since there are two calls to ExecCommandContainer inside fsdiff.RunTest(), we'll use a toggle bool
+	// to control which call to ExecCommandContainer should work.
+	MountPhaseReached bool
+}
+
+func (o *ClientHoldersMountCustomPodmanMock) ExecCommandContainer(_ clientsholder.Context, _ string) (stdout, stderr string, err error) {
+	if o.MountPhaseReached {
+		if o.mountFolderStdout != "" || o.mountFolderStderr != "" || o.mountFolderErr != nil {
+			return o.mountFolderStdout, o.mountFolderStderr, o.mountFolderErr
+		}
+	} else {
+		if o.createFolderStdout != "" || o.createFolderStderr != "" || o.createFolderErr != nil {
+			return o.createFolderStdout, o.createFolderStderr, o.createFolderErr
+		}
+		o.MountPhaseReached = true
+	}
+
+	return "", "", nil
+}
+
+func TestRunTestMountFolderErrors(t *testing.T) {
+	testCases := []struct {
+		mockedClientshHolder *ClientHoldersMountCustomPodmanMock
+		expectedError        string
+	}{
+		// Errors creating the mount point folder.
+		{
+			mockedClientshHolder: &ClientHoldersMountCustomPodmanMock{
+				createFolderErr: fmt.Errorf("custom error"),
+			},
+			expectedError: "failed to create folder /host/tmp/tnf-podman: custom error",
+		},
+		{
+			mockedClientshHolder: &ClientHoldersMountCustomPodmanMock{
+				createFolderStdout: "custom stdout",
+				createFolderStderr: "custom stderr",
+				createFolderErr:    nil,
+			},
+			expectedError: "unexpected output when creating folder /host/tmp/tnf-podman. Stdout: custom stdout - StdErr: custom stderr",
+		},
+
+		// Errors mounting the podman folder.
+		{
+			mockedClientshHolder: &ClientHoldersMountCustomPodmanMock{
+				mountFolderErr: fmt.Errorf("custom error"),
+			},
+			expectedError: "failed to mount /root/podman into /host/tmp/tnf-podman: custom error",
+		},
+		{
+			mockedClientshHolder: &ClientHoldersMountCustomPodmanMock{
+				mountFolderStdout: "custom stdout",
+				mountFolderStderr: "custom stderr",
+				mountFolderErr:    nil,
+			},
+			expectedError: "unexpected output when mounting /root/podman into /host/tmp/tnf-podman. Stdout: custom stdout - StdErr: custom stderr",
+		},
+	}
+
+	for _, tc := range testCases {
+		fsdiff := NewFsDiffTester(tc.mockedClientshHolder, clientsholder.Context{})
+		fsdiff.RunTest("fakeUID")
+		assert.Equal(t, testhelper.ERROR, fsdiff.GetResults())
+		assert.Equal(t, fsdiff.Error.Error(), tc.expectedError)
+	}
+}
+
+type ClientHoldersUnmountCustomPodmanMock struct {
+	unmountFolderStdout string
+	unmountFolderStderr string
+	unmountFolderErr    error
+
+	deleteFolderStdout string
+	deleteFolderStderr string
+	deleteFolderErr    error
+
+	// Since there are two calls to ExecCommandContainer inside fsdiff.RunTest(), we'll use a toggle bool
+	// to control which call to ExecCommandContainer should work.
+	DeletePhaseReached bool
+}
+
+func (o *ClientHoldersUnmountCustomPodmanMock) ExecCommandContainer(_ clientsholder.Context, cmd string) (stdout, stderr string, err error) {
+	// To reach the unmount/delete folder at the end, we need to make the mount operation and the podman diff to return no errors.
+	if strings.Contains(cmd, "mount --bind") || strings.Contains(cmd, "mkdir") {
+		return "", "", nil
+	}
+
+	if strings.Contains(cmd, "podman diff") {
+		return "{}", "", nil
+	}
+
+	if o.DeletePhaseReached {
+		if o.deleteFolderStdout != "" || o.deleteFolderStderr != "" || o.deleteFolderErr != nil {
+			return o.deleteFolderStdout, o.deleteFolderStderr, o.deleteFolderErr
+		}
+	} else {
+		if o.unmountFolderStdout != "" || o.unmountFolderStderr != "" || o.unmountFolderErr != nil {
+			return o.unmountFolderStdout, o.unmountFolderStderr, o.unmountFolderErr
+		}
+		o.DeletePhaseReached = true
+	}
+
+	return "", "", nil
+}
+
+func TestRunTestUnmountFolderErrors(t *testing.T) {
+	testCases := []struct {
+		mockedClientshHolder *ClientHoldersUnmountCustomPodmanMock
+		expectedError        string
+	}{
+		// Errors unmounting the podman folder.
+		{
+			mockedClientshHolder: &ClientHoldersUnmountCustomPodmanMock{
+				unmountFolderErr: fmt.Errorf("custom error"),
+			},
+			expectedError: "failed to unmount /host/tmp/tnf-podman: custom error",
+		},
+		{
+			mockedClientshHolder: &ClientHoldersUnmountCustomPodmanMock{
+				unmountFolderStdout: "custom stdout",
+				unmountFolderStderr: "custom stderr",
+			},
+			expectedError: "unexpected output when unmounting /host/tmp/tnf-podman. Stdout: custom stdout - StdErr: custom stderr",
+		},
+
+		// Errors deleting the mount point folder.
+		{
+			mockedClientshHolder: &ClientHoldersUnmountCustomPodmanMock{
+				deleteFolderErr: fmt.Errorf("custom error"),
+			},
+			expectedError: "failed to delete folder /host/tmp/tnf-podman: custom error",
+		},
+		{
+			mockedClientshHolder: &ClientHoldersUnmountCustomPodmanMock{
+				deleteFolderStdout: "custom stdout",
+				deleteFolderStderr: "custom stderr",
+			},
+			expectedError: "unexpected output when deleting folder /host/tmp/tnf-podman. Stdout: custom stdout - StdErr: custom stderr",
+		},
+	}
+
+	for _, tc := range testCases {
+		fsdiff := NewFsDiffTester(tc.mockedClientshHolder, clientsholder.Context{})
+		fsdiff.RunTest("fakeUID")
+		assert.Equal(t, testhelper.ERROR, fsdiff.GetResults())
+		assert.Equal(t, fsdiff.Error.Error(), tc.expectedError)
 	}
 }

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -204,8 +204,9 @@ func testContainersFsDiff(env *provider.TestEnvironment) {
 		if debugPod == nil {
 			ginkgo.Fail(fmt.Sprintf("Debug pod not found on Node: %s", cut.NodeName))
 		}
-		fsDiffTester := cnffsdiff.NewFsDiffTester(clientsholder.GetClientsHolder())
-		fsDiffTester.RunTest(clientsholder.NewContext(debugPod.Namespace, debugPod.Name, debugPod.Spec.Containers[0].Name), cut.UID)
+		ctxt := clientsholder.NewContext(debugPod.Namespace, debugPod.Name, debugPod.Spec.Containers[0].Name)
+		fsDiffTester := cnffsdiff.NewFsDiffTester(clientsholder.GetClientsHolder(), ctxt)
+		fsDiffTester.RunTest(cut.UID)
 		switch fsDiffTester.GetResults() {
 		case testhelper.SUCCESS:
 			continue


### PR DESCRIPTION
The previous implementation of this test cases fails in OCP 4.12.7+ due to podman installed on those OCP worker nodes (v4.2.0) using an older version of the containers/storage lib than the one cri-o uses on those nodes. As a result, "podman diff" won't work because it tries to read a file "containers.json" that has been renamed to
"volatile-containers.json" in latest OCP builds.

This workaround is based on a (compatible) precompiled podman binary existing in a /root/podman folder of the debug pods. Currently, v4.4.0 is the version that can be built with UBI 8 that can read the new "volatile-containers.json" inside worker nodes and fix the "podman diff" function.

In order to avoid copying the binary into the node, I prefer mounting the containing folder into node's /tmp/tnf-podman so the program can be run with /tmp/tnf-podman/podman.

The new implementation of the test case does the following:
1. Creates the temp folder /host/tmp/tnf-podman
2. Mounts debug pod's /root/podman into /host/tmp/tnf-podman
3. Calls /chroot /host /tmp/tnf-podman diff <container-id>
4. Unmounts /host/tmp/tnf-podman
5. Removes /host/tmp/tnf-podman