### PR TITLE
Switch checkmake (macos) to brew

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -26,7 +26,6 @@ env:
   TERM: xterm-color
   CM_BIN: /usr/local/bin/checkmake
   CM_URL_LINUX: https://github.com/mrtazz/checkmake/releases/download/0.2.2/checkmake-0.2.2.linux.amd64 # yamllint disable-line
-  CM_URL_MACOS: https://github.com/mrtazz/checkmake/releases/download/0.2.2/checkmake-0.2.2.darwin.amd64 # yamllint disable-line
 
 jobs:
   lint:
@@ -62,7 +61,7 @@ jobs:
         if: runner.os == 'Linux'
 
       - name: Install checkmake MacOS
-        run: curl --location --output $CM_BIN --silent $CM_URL_MACOS
+        run: brew install checkmake
         if: runner.os == 'macOS'
 
       - run: chmod +x $CM_BIN


### PR DESCRIPTION
We use the brew install for `hadolint` as well.  Figured we would let this perform the install for us.

https://formulae.brew.sh/formula/checkmake