### PR TITLE
Added qe-coverage-report subcommand to tnf tool.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ lint:
 	shfmt -d *.sh script
 
 # Build and run unit tests
-test:
+test: coverage-qe
 	./script/create-missing-test-files.sh
 	go build ${COMMON_GO_ARGS} ./...
 	UNIT_TEST="true" go test -coverprofile=cover.out.tmp ./...
@@ -87,6 +87,9 @@ test:
 coverage-html: test
 	cat cover.out.tmp | grep -v "_moq.go" > cover.out
 	go tool cover -html cover.out
+
+coverage-qe: build-tnf-tool
+	./tnf generate qe-coverage-report
 
 # generate the test catalog in JSON
 build-catalog-json: build-tnf-tool
@@ -152,7 +155,7 @@ build-image-tnf:
 		-f Dockerfile .
 
 # Generates the classification.js file and creates a new result-embed.html
-classification-js:
+classification-js: build-tnf-tool
 	./tnf generate catalog javascript >script/classification.js
 	sed '/<script src=".\/classification.js"><\/script>/e echo "<script>"; cat script/classification.js; echo "<\/script>"' script/results.html >script/results-embed.html
 	sed -i -e 's@  <script src="./classification.js"></script>@@g' script/results-embed.html

--- a/cmd/tnf/generate/qe_coverage/qe_coverage.go
+++ b/cmd/tnf/generate/qe_coverage/qe_coverage.go
@@ -1,0 +1,97 @@
+package qecoverage
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/identifiers"
+	"github.com/test-network-function/test-network-function-claim/pkg/claim"
+)
+
+var (
+	// QeCoverageReportCmd is used to generate a QE coverage report.
+	QeCoverageReportCmd = &cobra.Command{
+		Use:   "qe-coverage-report",
+		Short: "Generates the current QE coverage report.",
+		RunE:  runGenerateQeCoverageReport,
+	}
+)
+
+type QeCoverage struct {
+	CoverageByTestSuite     map[string]TestSuiteQeCoverage
+	TotalCoveragePercentage float32
+	TestCasesTotal          int
+	TestCasesWithQe         int
+}
+
+type TestSuiteQeCoverage struct {
+	TestCases       int
+	TestCasesWithQe int
+	Coverage        float32
+}
+
+func GetQeCoverage(catalog map[claim.Identifier]claim.TestCaseDescription) QeCoverage {
+	totalTcs := 0
+	totalTcsWithQe := 0
+
+	qeCoverageByTestSuite := map[string]TestSuiteQeCoverage{}
+	for claimID := range catalog {
+		totalTcs++
+
+		tcDescription := catalog[claimID]
+		tsName := tcDescription.Identifier.Suite
+
+		tsQeCoverage, exists := qeCoverageByTestSuite[tsName]
+		if !exists {
+			tsQeCoverage = TestSuiteQeCoverage{}
+		}
+
+		tsQeCoverage.TestCases++
+		if tcDescription.Qe {
+			tsQeCoverage.TestCasesWithQe++
+			totalTcsWithQe++
+		}
+
+		// Update this test suite's coverage percentage
+		tsQeCoverage.Coverage = 100.0 * (float32(tsQeCoverage.TestCasesWithQe) / float32(tsQeCoverage.TestCases))
+
+		qeCoverageByTestSuite[tsName] = tsQeCoverage
+	}
+
+	totalCoverage := float32(0)
+	if totalTcs > 0 {
+		totalCoverage = 100.0 * (float32(totalTcsWithQe) / float32(totalTcs))
+	}
+
+	return QeCoverage{
+		CoverageByTestSuite:     qeCoverageByTestSuite,
+		TotalCoveragePercentage: totalCoverage,
+		TestCasesTotal:          totalTcs,
+		TestCasesWithQe:         totalTcsWithQe,
+	}
+}
+
+func runGenerateQeCoverageReport(_ *cobra.Command, _ []string) error {
+	qeCoverage := GetQeCoverage(identifiers.Catalog)
+
+	// Order test suite names so the report is in ascending test suite name order.
+	testSuites := []string{}
+	for suite := range qeCoverage.CoverageByTestSuite {
+		testSuites = append(testSuites, suite)
+	}
+	sort.Strings(testSuites)
+
+	// Total QE coverage
+	fmt.Printf("Total QE Coverage: %.f%%\n\n", qeCoverage.TotalCoveragePercentage)
+
+	// Per test suite QE coverage
+	fmt.Printf("%-30s\t%-10s\t%s\n", "Test Suite", "Test Cases", "QE Coverage")
+	for _, suite := range testSuites {
+		tsCoverage := qeCoverage.CoverageByTestSuite[suite]
+		fmt.Printf("%-30s\t%-10d\t%.0f%%\n", suite, tsCoverage.TestCases, tsCoverage.Coverage)
+	}
+
+	fmt.Println()
+	return nil
+}

--- a/cmd/tnf/generate/qe_coverage/qe_coverage_test.go
+++ b/cmd/tnf/generate/qe_coverage/qe_coverage_test.go
@@ -1,0 +1,169 @@
+package qecoverage
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/test-network-function-claim/pkg/claim"
+)
+
+type catalogEntry struct {
+	testSuiteName string
+	testCaseName  string
+	qe            bool
+}
+
+func createCatalog(entries []catalogEntry) map[claim.Identifier]claim.TestCaseDescription {
+	catalog := map[claim.Identifier]claim.TestCaseDescription{}
+
+	for _, entry := range entries {
+		tcDescription, aID := claim.BuildTestCaseDescription(entry.testCaseName, entry.testSuiteName, "", "", "", "", "", entry.qe, map[string]string{})
+		catalog[aID] = tcDescription
+	}
+
+	return catalog
+}
+
+func TestQeCoverage(t *testing.T) {
+	type testSuiteCoverage struct {
+		coverage  float32
+		tcs       int
+		tcsWithQe int
+	}
+
+	tcs := []struct {
+		catalogEntries         []catalogEntry
+		expectedTotalCoverage  float32
+		expectedTotalTcs       int
+		expectedTotalTcswithQe int
+		expectedCoverageByTS   map[string]testSuiteCoverage
+	}{
+		// Corner case: no test cases.
+		{
+			catalogEntries:         []catalogEntry{},
+			expectedTotalCoverage:  0.0,
+			expectedTotalTcs:       0,
+			expectedTotalTcswithQe: 0,
+			expectedCoverageByTS:   map[string]testSuiteCoverage{},
+		},
+
+		// 1 test suite with, 1 test case with QE flag set.
+		{
+			catalogEntries: []catalogEntry{
+				{
+					testSuiteName: "test-suite-1",
+					testCaseName:  "test-suite-1-tc-1",
+					qe:            true,
+				},
+			},
+			expectedTotalCoverage:  100.0,
+			expectedTotalTcs:       1,
+			expectedTotalTcswithQe: 1,
+			expectedCoverageByTS: map[string]testSuiteCoverage{
+				"test-suite-1": {
+					coverage:  100.0,
+					tcs:       1,
+					tcsWithQe: 1,
+				},
+			},
+		},
+		// 1 test suite with 2 test cases, but only 1 with QE flag set.
+		{
+			catalogEntries: []catalogEntry{
+				{
+					testSuiteName: "test-suite-1",
+					testCaseName:  "test-suite-1-tc-1",
+					qe:            false,
+				},
+				{
+					testSuiteName: "test-suite-1",
+					testCaseName:  "test-suite-1-tc-2",
+					qe:            true,
+				},
+			},
+			expectedTotalCoverage:  50.0,
+			expectedTotalTcs:       2,
+			expectedTotalTcswithQe: 1,
+			expectedCoverageByTS: map[string]testSuiteCoverage{
+				"test-suite-1": {
+					coverage:  50.0,
+					tcs:       1,
+					tcsWithQe: 1,
+				},
+			},
+		},
+		// 3 test suites: 2 of them with 1 test case not in QE. The third has
+		// 2 test cases, only 1 of them in QE.
+		{
+			catalogEntries: []catalogEntry{
+				{
+					testSuiteName: "test-suite-1",
+					testCaseName:  "test-suite-1-tc-1",
+					qe:            false,
+				},
+				{
+					testSuiteName: "test-suite-2",
+					testCaseName:  "test-suite-2-tc-1",
+					qe:            false,
+				},
+				{
+					testSuiteName: "test-suite-3",
+					testCaseName:  "test-suite-3-tc-1",
+					qe:            false,
+				},
+				{
+					testSuiteName: "test-suite-3",
+					testCaseName:  "test-suite-3-tc-2",
+					qe:            true,
+				},
+			},
+			expectedTotalCoverage:  25.0,
+			expectedTotalTcs:       4,
+			expectedTotalTcswithQe: 1,
+			expectedCoverageByTS: map[string]testSuiteCoverage{
+				"test-suite-1": {
+					coverage:  0.0,
+					tcs:       1,
+					tcsWithQe: 0,
+				},
+				"test-suite-2": {
+					coverage:  0.0,
+					tcs:       1,
+					tcsWithQe: 0,
+				},
+				"test-suite-3": {
+					coverage:  50.0,
+					tcs:       2,
+					tcsWithQe: 1,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		catalog := createCatalog(tc.catalogEntries)
+		qeCoverage := GetQeCoverage(catalog)
+		assert.Equal(t, tc.expectedTotalTcs, qeCoverage.TestCasesTotal)
+		assert.Equal(t, tc.expectedTotalTcswithQe, qeCoverage.TestCasesWithQe)
+		assert.Equal(t, tc.expectedTotalCoverage, qeCoverage.TotalCoveragePercentage)
+
+		// Sort expectd/actual test suites by name before comparing test suite coverages
+		expectedTestSuites := []string{}
+		for testSuite := range tc.expectedCoverageByTS {
+			expectedTestSuites = append(expectedTestSuites, testSuite)
+		}
+		sort.Strings(expectedTestSuites)
+
+		actualTestSuites := []string{}
+		for testSuite := range qeCoverage.CoverageByTestSuite {
+			actualTestSuites = append(actualTestSuites, testSuite)
+		}
+		sort.Strings(actualTestSuites)
+
+		assert.Equal(t, expectedTestSuites, actualTestSuites)
+		for _, expectedTestSuite := range expectedTestSuites {
+			assert.Equal(t, tc.expectedCoverageByTS[expectedTestSuite].coverage, qeCoverage.CoverageByTestSuite[expectedTestSuite].Coverage)
+		}
+	}
+}

--- a/cmd/tnf/main.go
+++ b/cmd/tnf/main.go
@@ -6,6 +6,7 @@ import (
 
 	claim "github.com/test-network-function/cnf-certification-test/cmd/tnf/addclaim"
 	"github.com/test-network-function/cnf-certification-test/cmd/tnf/generate/catalog"
+	qecoverage "github.com/test-network-function/cnf-certification-test/cmd/tnf/generate/qe_coverage"
 )
 
 var (
@@ -24,6 +25,7 @@ func main() {
 	rootCmd.AddCommand(claim.NewCommand())
 	rootCmd.AddCommand(generate)
 	generate.AddCommand(catalog.NewCommand())
+	generate.AddCommand(qecoverage.QeCoverageReportCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Parses the (bool) qe flag from each catalog test case identifier and computes the total and per test suite coverage percentages.