### PR TITLE
Fix error traces in scale objects autodiscover.

### DIFF
--- a/cnf-certification-test/lifecycle/podsets/podsets.go
+++ b/cnf-certification-test/lifecycle/podsets/podsets.go
@@ -59,7 +59,7 @@ var WaitForScalingToComplete = func(ns, name string, timeout time.Duration, grou
 	for time.Since(start) < timeout {
 		crScale, err := provider.GetUpdatedCrObject(clients.ScalingClient, ns, name, groupResourceSchema)
 		if err != nil {
-			logrus.Errorf("error while getting the scaling fields %e", err)
+			logrus.Errorf("error while getting the scaling fields %v", err)
 		} else if !crScale.IsScaleObjectReady() {
 			logrus.Errorf("%s is not ready yet", crScale.ToString())
 		} else {

--- a/pkg/autodiscover/autodiscover_scaleObject.go
+++ b/pkg/autodiscover/autodiscover_scaleObject.go
@@ -63,7 +63,7 @@ func appendCrItems(crs *unstructured.UnstructuredList, aCrd *apiextv1.CustomReso
 
 		crScale, err := clients.ScalingClient.Scales(namespace).Get(context.TODO(), groupResourceSchema, name, metav1.GetOptions{})
 		if err != nil {
-			logrus.Fatalf("error while getting the scaling fields %e", err)
+			logrus.Fatalf("error while getting the scaling fields %v", err)
 		}
 		scalableItems = append(scalableItems, Scaleobject{Scale: crScale, GroupResourceSchema: groupResourceSchema})
 	}


### PR DESCRIPTION
Switched from %e (scientific notation) to default format %v.