### PR TITLE
Fix for backward compatible label support

### DIFF
--- a/cnf-certification-test/tnf_config.yml
+++ b/cnf-certification-test/tnf_config.yml
@@ -6,9 +6,10 @@ targetNameSpaces:
 #    name: generic
 #    value: target
 podsUnderTestLabels:
-  test-network-function.com/generic: target
+  - "test-network-function.com/generic: target"
+# deprecated operator label ("test-network-function.com/operator:"") still configured by default, no need to add it here
 operatorsUnderTestLabels:
-  test-network-function.com/operator: 
+  - "test-network-function.com/operator1:new" 
 targetCrdFilters:
   - nameSuffix: "group1.test.com"
     scalable: false

--- a/pkg/autodiscover/autodiscover_operators.go
+++ b/pkg/autodiscover/autodiscover_operators.go
@@ -68,7 +68,11 @@ func findOperatorsByLabel(olmClient clientOlm.Interface, labels map[string]strin
 	for _, ns := range namespaces {
 		logrus.Debugf("Searching CSVs in namespace %s", ns)
 		for key, value := range labels {
-			label := key + "=" + value
+			label := key
+			// DEPRECATED special processing for deprecated operator label. Value not needed to match.
+			if key != deprecatedHardcodedOperatorLabelName {
+				label += "=" + value
+			}
 			logrus.Debugf("Searching CSVs with label %s", label)
 			csvList, err := olmClient.OperatorsV1alpha1().ClusterServiceVersions(ns.Name).List(context.TODO(), metav1.ListOptions{
 				LabelSelector: label,

--- a/pkg/autodiscover/autodiscover_operators.go
+++ b/pkg/autodiscover/autodiscover_operators.go
@@ -63,15 +63,15 @@ func isIstioServiceMeshInstalled(allNs []string) bool {
 	return true
 }
 
-func findOperatorsByLabel(olmClient clientOlm.Interface, labels map[string]string, namespaces []configuration.Namespace) []*olmv1Alpha.ClusterServiceVersion {
+func findOperatorsByLabel(olmClient clientOlm.Interface, labels []configuration.LabelObject, namespaces []configuration.Namespace) []*olmv1Alpha.ClusterServiceVersion {
 	csvs := []*olmv1Alpha.ClusterServiceVersion{}
 	for _, ns := range namespaces {
 		logrus.Debugf("Searching CSVs in namespace %s", ns)
-		for key, value := range labels {
-			label := key
+		for _, aLabelObject := range labels {
+			label := aLabelObject.LabelKey
 			// DEPRECATED special processing for deprecated operator label. Value not needed to match.
-			if key != deprecatedHardcodedOperatorLabelName {
-				label += "=" + value
+			if aLabelObject.LabelKey != deprecatedHardcodedOperatorLabelName {
+				label += "=" + aLabelObject.LabelValue
 			}
 			logrus.Debugf("Searching CSVs with label %s", label)
 			csvList, err := olmClient.OperatorsV1alpha1().ClusterServiceVersions(ns.Name).List(context.TODO(), metav1.ListOptions{

--- a/pkg/autodiscover/autodiscover_pods.go
+++ b/pkg/autodiscover/autodiscover_pods.go
@@ -20,17 +20,18 @@ import (
 	"context"
 
 	"github.com/sirupsen/logrus"
+	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-func findPodsByLabel(oc corev1client.CoreV1Interface, labels map[string]string, namespaces []string) (runningPods, allPods []corev1.Pod) {
+func findPodsByLabel(oc corev1client.CoreV1Interface, labels []configuration.LabelObject, namespaces []string) (runningPods, allPods []corev1.Pod) {
 	runningPods = []corev1.Pod{}
 	allPods = []corev1.Pod{}
 	for _, ns := range namespaces {
-		for key, value := range labels {
-			label := key + "=" + value
+		for _, aLabelObject := range labels {
+			label := aLabelObject.LabelKey + "=" + aLabelObject.LabelValue
 			logrus.Debugf("Searching Pods with label %s", label)
 			pods, err := oc.Pods(ns).List(context.TODO(), metav1.ListOptions{
 				LabelSelector: label,

--- a/pkg/autodiscover/autodiscover_pods_test.go
+++ b/pkg/autodiscover/autodiscover_pods_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
+	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 )
 
 func TestFindPodsByLabel(t *testing.T) {
@@ -83,7 +84,7 @@ func TestFindPodsByLabel(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		testLabel := map[string]string{"testLabel": tc.testPodLabel}
+		testLabel := []configuration.LabelObject{{LabelKey: "testLabel", LabelValue: tc.testPodLabel}}
 		testNamespaces := []string{
 			tc.testPodNamespace,
 		}

--- a/pkg/autodiscover/autodiscover_podset.go
+++ b/pkg/autodiscover/autodiscover_podset.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	"github.com/sirupsen/logrus"
+	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 	appsv1 "k8s.io/api/apps/v1"
 	scalingv1 "k8s.io/api/autoscaling/v1"
 
@@ -58,7 +59,7 @@ func FindCrObjectByNameByNamespace(scalesGetter scale.ScalesGetter, ns, name str
 //nolint:dupl
 func findDeploymentByLabel(
 	appClient appv1client.AppsV1Interface,
-	labels map[string]string,
+	labels []configuration.LabelObject,
 	namespaces []string,
 ) []appsv1.Deployment {
 	deployments := []appsv1.Deployment{}
@@ -73,9 +74,9 @@ func findDeploymentByLabel(
 		}
 
 		for i := 0; i < len(dps.Items); i++ {
-			for key, value := range labels {
-				logrus.Tracef("Searching pods in deployment %q found in ns %q using label %s=%s", dps.Items[i].Name, ns, key, value)
-				if dps.Items[i].Spec.Template.ObjectMeta.Labels[key] == value {
+			for _, aLabelObject := range labels {
+				logrus.Tracef("Searching pods in deployment %q found in ns %q using label %s=%s", dps.Items[i].Name, ns, aLabelObject.LabelKey, aLabelObject.LabelValue)
+				if dps.Items[i].Spec.Template.ObjectMeta.Labels[aLabelObject.LabelKey] == aLabelObject.LabelValue {
 					deployments = append(deployments, dps.Items[i])
 					logrus.Info("Deployment ", dps.Items[i].Name, " found in ns ", ns)
 				}
@@ -91,7 +92,7 @@ func findDeploymentByLabel(
 //nolint:dupl
 func findStatefulSetByLabel(
 	appClient appv1client.AppsV1Interface,
-	labels map[string]string,
+	labels []configuration.LabelObject,
 	namespaces []string,
 ) []appsv1.StatefulSet {
 	statefulsets := []appsv1.StatefulSet{}
@@ -106,9 +107,9 @@ func findStatefulSetByLabel(
 		}
 
 		for i := 0; i < len(ss.Items); i++ {
-			for key, value := range labels {
-				logrus.Tracef("Searching pods in statefulset %q found in ns %q using label %s=%s", ss.Items[i].Name, ns, key, value)
-				if ss.Items[i].Spec.Template.ObjectMeta.Labels[key] == value {
+			for _, aLabelObject := range labels {
+				logrus.Tracef("Searching pods in statefulset %q found in ns %q using label %s=%s", ss.Items[i].Name, ns, aLabelObject.LabelKey, aLabelObject.LabelValue)
+				if ss.Items[i].Spec.Template.ObjectMeta.Labels[aLabelObject.LabelKey] == aLabelObject.LabelValue {
 					statefulsets = append(statefulsets, ss.Items[i])
 					logrus.Info("StatefulSet ", ss.Items[i].Name, " found in ns ", ns)
 				}

--- a/pkg/autodiscover/autodiscover_podset_test.go
+++ b/pkg/autodiscover/autodiscover_podset_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
+	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 )
 
 func TestFindDeploymentByLabel(t *testing.T) {
@@ -90,7 +91,8 @@ func TestFindDeploymentByLabel(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		testLabel := map[string]string{"testLabel": tc.testDeploymentLabel}
+		testLabel := []configuration.LabelObject{{LabelKey: "testLabel", LabelValue: tc.testDeploymentLabel}}
+
 		testNamespaces := []string{
 			tc.testDeploymentNamespace,
 		}
@@ -165,7 +167,7 @@ func TestFindStatefulSetByLabel(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		testLabel := map[string]string{"testLabel": tc.testStatefulSetLabel}
+		testLabel := []configuration.LabelObject{{LabelKey: "testLabel", LabelValue: tc.testStatefulSetLabel}}
 		testNamespaces := []string{
 			tc.testStatefulSetNamespace,
 		}

--- a/pkg/configuration/config_test.go
+++ b/pkg/configuration/config_test.go
@@ -45,18 +45,26 @@ func TestLoadConfiguration(t *testing.T) {
 	assert.Contains(t, env.TargetPodLabels, podlabel1)
 	podlabel2 := configuration.Label{Prefix: label2Prefix, Name: label2Name, Value: label2Value}
 	assert.Contains(t, env.TargetPodLabels, podlabel2)
-	// podsUnderTestLabels
-	assert.Equal(t, 4, len(env.PodsUnderTestLabels))
-	assert.Equal(t, env.PodsUnderTestLabels["test"], "pod")
-	assert.Equal(t, env.PodsUnderTestLabels["cnf"], "pod")
-	assert.Equal(t, env.PodsUnderTestLabels["cnf/test"], "pod1")
-	assert.Equal(t, env.PodsUnderTestLabels["cnf/testEmpty"], "")
-	// operatorsUnderTestLabels
-	assert.Equal(t, 4, len(env.OperatorsUnderTestLabels))
-	assert.Equal(t, env.OperatorsUnderTestLabels["test"], "operator")
-	assert.Equal(t, env.OperatorsUnderTestLabels["cnf"], "operator")
-	assert.Equal(t, env.OperatorsUnderTestLabels["cnf/test"], "operator1")
-	assert.Equal(t, env.PodsUnderTestLabels["cnf/testEmpty"], "")
+	// PodsUnderTestLabelsObjects
+	assert.Equal(t, 4, len(env.PodsUnderTestLabelsObjects))
+	assert.Equal(t, env.PodsUnderTestLabelsObjects[0].LabelKey, "test", "pod")
+	assert.Equal(t, env.PodsUnderTestLabelsObjects[1].LabelKey, "cnf", "pod")
+	assert.Equal(t, env.PodsUnderTestLabelsObjects[2].LabelKey, "cnf/test", "pod1")
+	assert.Equal(t, env.PodsUnderTestLabelsObjects[3].LabelKey, "cnf/testEmpty", "")
+	assert.Equal(t, env.PodsUnderTestLabelsObjects[0].LabelValue, "pod")
+	assert.Equal(t, env.PodsUnderTestLabelsObjects[1].LabelValue, "pod")
+	assert.Equal(t, env.PodsUnderTestLabelsObjects[2].LabelValue, "pod1")
+	assert.Equal(t, env.PodsUnderTestLabelsObjects[3].LabelValue, "")
+	// OperatorsUnderTestLabelsObjects
+	assert.Equal(t, 4, len(env.OperatorsUnderTestLabelsObjects))
+	assert.Equal(t, env.OperatorsUnderTestLabelsObjects[0].LabelKey, "test")
+	assert.Equal(t, env.OperatorsUnderTestLabelsObjects[1].LabelKey, "cnf/test")
+	assert.Equal(t, env.OperatorsUnderTestLabelsObjects[2].LabelKey, "cnf")
+	assert.Equal(t, env.PodsUnderTestLabelsObjects[3].LabelKey, "cnf/testEmpty")
+	assert.Equal(t, env.OperatorsUnderTestLabelsObjects[0].LabelValue, "operator")
+	assert.Equal(t, env.OperatorsUnderTestLabelsObjects[1].LabelValue, "operator1")
+	assert.Equal(t, env.OperatorsUnderTestLabelsObjects[2].LabelValue, "operator")
+	assert.Equal(t, env.PodsUnderTestLabelsObjects[3].LabelValue, "")
 	// check if targetCrdFilters section is parsed properly
 	assert.Equal(t, crds, len(env.CrdFilters))
 	crd1 := configuration.CrdFilter{NameSuffix: crdSuffix1}

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -105,6 +105,11 @@ type ContainerImageIdentifier struct {
 	Digest string `yaml:"digest" json:"digest"`
 }
 
+type LabelObject struct {
+	LabelKey   string
+	LabelValue string
+}
+
 // TestConfiguration provides test related configuration
 type TestConfiguration struct {
 	// targetNameSpaces to be used in
@@ -112,9 +117,13 @@ type TestConfiguration struct {
 	// DEPRECATED - Custom Pod labels for discovering containers/pods under test
 	TargetPodLabels []Label `yaml:"targetPodLabels,omitempty" json:"targetPodLabels,omitempty"`
 	// labels identifying pods under test
-	PodsUnderTestLabels map[string]string `yaml:"podsUnderTestLabels,omitempty" json:"podsUnderTestLabels,omitempty"`
+	PodsUnderTestLabels []string `yaml:"podsUnderTestLabels,omitempty" json:"podsUnderTestLabels,omitempty"`
 	// labels identifying operators unde test
-	OperatorsUnderTestLabels map[string]string `yaml:"operatorsUnderTestLabels,omitempty" json:"operatorsUnderTestLabels,omitempty"`
+	OperatorsUnderTestLabels []string `yaml:"operatorsUnderTestLabels,omitempty" json:"operatorsUnderTestLabels,omitempty"`
+	// Parsed labels identifying pods under test
+	PodsUnderTestLabelsObjects []LabelObject `yaml:"-" json:"-"`
+	// Parsed labels identifying operators under test
+	OperatorsUnderTestLabelsObjects []LabelObject `yaml:"-" json:"-"`
 	// CertifiedContainerInfo is the list of container images to be checked for certification status.
 	CertifiedContainerInfo []ContainerImageIdentifier `yaml:"certifiedcontainerinfo,omitempty" json:"certifiedcontainerinfo,omitempty"`
 	// CertifiedOperatorInfo is list of operator bundle names that are queried for certification status.

--- a/pkg/configuration/testdata/tnf_test_config.yml
+++ b/pkg/configuration/testdata/tnf_test_config.yml
@@ -9,15 +9,15 @@ targetPodLabels:
     name: name2
     value: value2
 podsUnderTestLabels:
-  test: pod
-  cnf: pod
-  cnf/test: pod1
-  cnf/testEmpty:
+  - "test: pod"
+  - "cnf: pod"
+  - "cnf/test: pod1"
+  - "cnf/testEmpty:"
 operatorsUnderTestLabels:
-  test: operator
-  cnf/test: operator1
-  cnf: operator
-  cnf/testEmpty:
+  - "test: operator"
+  - "cnf/test: operator1"
+  - "cnf: operator"
+  - "cnf/testEmpty:"
 targetCrdFilters:
   - nameSuffix: "group1.test.com"
   - nameSuffix: "group2.test.com"

--- a/pkg/configuration/utils.go
+++ b/pkg/configuration/utils.go
@@ -18,6 +18,7 @@ package configuration
 
 import (
 	"os"
+	"regexp"
 
 	"github.com/kelseyhightower/envconfig"
 	log "github.com/sirupsen/logrus"
@@ -66,10 +67,33 @@ func LoadConfiguration(filePath string) (TestConfiguration, error) {
 		log.Infof("Namespace for debug DaemonSet: %s", configuration.DebugDaemonSetNamespace)
 	}
 
+	configuration.OperatorsUnderTestLabelsObjects = createLabels(configuration.OperatorsUnderTestLabels)
+	configuration.PodsUnderTestLabelsObjects = createLabels(configuration.PodsUnderTestLabels)
+
 	confLoaded = true
 	return configuration, nil
 }
 
 func GetTestParameters() *TestParameters {
 	return &parameters
+}
+
+const labelRegex = `(\S*)\s*:\s*(\S*)`
+const labelRegexMatches = 3
+
+func createLabels(labelStrings []string) (labelObjects []LabelObject) {
+	for _, label := range labelStrings {
+		r := regexp.MustCompile(labelRegex)
+
+		values := r.FindStringSubmatch(label)
+		if len(values) != labelRegexMatches {
+			log.Errorf("failed to parse label=%s, will not be used!, ", label)
+			continue
+		}
+		var aLabel LabelObject
+		aLabel.LabelKey = values[1]
+		aLabel.LabelValue = values[2]
+		labelObjects = append(labelObjects, aLabel)
+	}
+	return labelObjects
 }

--- a/pkg/configuration/utils_test.go
+++ b/pkg/configuration/utils_test.go
@@ -15,3 +15,41 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package configuration
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_createLabels(t *testing.T) {
+	type args struct {
+		labelStrings []string
+	}
+	tests := []struct {
+		name             string
+		args             args
+		wantLabelObjects []LabelObject
+	}{
+		{
+			name:             "ok",
+			args:             args{labelStrings: []string{"test-network-function.com/generic: target"}},
+			wantLabelObjects: []LabelObject{{LabelKey: "test-network-function.com/generic", LabelValue: "target"}},
+		},
+		{
+			name:             "ok1",
+			args:             args{labelStrings: []string{"test-network-function.com/generic   : 1"}},
+			wantLabelObjects: []LabelObject{{LabelKey: "test-network-function.com/generic", LabelValue: "1"}},
+		},
+		{
+			name: "nok",
+			args: args{labelStrings: []string{"test-network-function.com/generic= target"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotLabelObjects := createLabels(tt.args.labelStrings); !reflect.DeepEqual(gotLabelObjects, tt.wantLabelObjects) {
+				t.Errorf("createLabels() = %v, want %v", gotLabelObjects, tt.wantLabelObjects)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The deprecated label used for operator will be match with any value. The previous PR introducing new labelling procedure broke this wildcard mechanism. This PR adds it back.
fix regression with last PR introducing new labels:
- using a list of strings instead of Map to store labels
- use the correct label for statefulset and deployments under test