### PR TITLE
Only build during smoke tests, do not run unit tests

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -209,8 +209,8 @@ jobs:
       - name: Install ginkgo
         run: make install-tools
 
-      - name: Execute `make build`
-        run: make build
+      - name: Build CNF test suite binary
+        run: make build-cnf-tests
 
       # Create a Kind cluster for testing.
       - name: Check out `cnf-certification-test-partner`

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Install ginkgo
         run: make install-tools
 
-      - name: Execute `make build`
-        run: make build
+      - name: Build CNF test suite binary
+        run: make build-cnf-tests
 
       # Create a Kind cluster for testing.
       - name: Check out `cnf-certification-test-partner`


### PR DESCRIPTION
Speed up the CI by not running the unit tests as part of `make build`.  Those are already ran in other `jobs` in the CI already and do not need to be repeated.

`make build` currently runs the unit tests first, then builds.