### PR TITLE
Add a link to Dockerfile for dependabot monitoring

### DIFF
--- a/.github/actions/documentation/Dockerfile
+++ b/.github/actions/documentation/Dockerfile
@@ -1,12 +1,1 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.7
-
-RUN dnf install -y python39-3.9.16 && dnf clean all
-
-# Pin versions in pip.
-# hadolint ignore=DL3013
-RUN pip3 install --no-cache-dir mkdocs mkdocs-material markdown-include
-
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]
+../../../Dockerfile-documentation

--- a/Dockerfile-documentation
+++ b/Dockerfile-documentation
@@ -1,0 +1,1 @@
+.github/actions/documentation/Dockerfile

--- a/Dockerfile-documentation
+++ b/Dockerfile-documentation
@@ -1,1 +1,12 @@
-.github/actions/documentation/Dockerfile
+FROM registry.access.redhat.com/ubi8/ubi:8.7
+
+RUN dnf install -y python39-3.9.16 && dnf clean all
+
+# Pin versions in pip.
+# hadolint ignore=DL3013
+RUN pip3 install --no-cache-dir mkdocs mkdocs-material markdown-include
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
The link allows `Dependabot` to monitor the `Dockefile` inside a dot directory. There is an unfortunate downside. The PR created by `Dependabot` will replace the link with the actual file with a new version. We should not merge this PR (produced by `Dependabot`), but bump versions in the `Dockefile` manually.

UPDATE: The better solution is to move the `Dockerfile` to root with another name `Dockerfile-documentation` and create `Dockerfile` link to it.