### PR TITLE
Update git version for docker image build to 2.39.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,14 @@ RUN \
 	&& dnf update --assumeyes --disableplugin=subscription-manager \
 	&& dnf install --assumeyes --disableplugin=subscription-manager \
 		gcc-8.5.0 \
-		git-2.39.1 \
+		git-2.39.3 \
 		jq-1.6 \
 		cmake-3.20.2 \
 		wget-1.19.5 \
 	&& dnf clean all --assumeyes --disableplugin=subscription-manager \
 	&& rm -rf /var/cache/yum
 
-# Install Go binary and set the PATH 
+# Install Go binary and set the PATH
 ENV \
 	GO_DL_URL=https://golang.org/dl \
 	GO_BIN_TAR=go1.20.4.linux-amd64.tar.gz \


### PR DESCRIPTION
The image building started failing after the recently updated git version (#1091) was updated again this weekend... See job:
https://github.com/test-network-function/cnf-certification-test/actions/runs/5043287587/jobs/9044891444