### PR TITLE
Remove pinned versions; add hadolint ignore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,16 @@ ENV \
 	TEMP_DIR=/tmp
 
 # Install dependencies
+# hadolint ignore=DL3041
 RUN \
 	mkdir ${TNF_DIR} \
 	&& dnf update --assumeyes --disableplugin=subscription-manager \
 	&& dnf install --assumeyes --disableplugin=subscription-manager \
-		gcc-8.5.0 \
-		git-2.39.3 \
-		jq-1.6 \
-		cmake-3.20.2 \
-		wget-1.19.5 \
+		gcc \
+		git \
+		jq \
+		cmake \
+		wget \
 	&& dnf clean all --assumeyes --disableplugin=subscription-manager \
 	&& rm -rf /var/cache/yum
 

--- a/Dockerfile-documentation
+++ b/Dockerfile-documentation
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi:8.8
 
-RUN dnf install -y python39-3.9.16 && dnf clean all
+# hadolint ignore=DL3041
+RUN dnf install -y python3 && dnf clean all
 
 # Pin versions in pip.
 # hadolint ignore=DL3013


### PR DESCRIPTION
Pinning the package versions does not work if the upstream repo removes the packages.  The base image _knows_ which recommended binaries to install so we do not need to lock them in.