### PR TITLE
Improve the SCC package

### DIFF
--- a/cnf-certification-test/accesscontrol/securitycontextcontainer/securitycontextcontainer_test.go
+++ b/cnf-certification-test/accesscontrol/securitycontextcontainer/securitycontextcontainer_test.go
@@ -14,12 +14,12 @@ func TestCheckPod(t *testing.T) {
 	runAs2 := int64(1000)
 	testCases := []struct {
 		testSlice     *provider.Pod
-		expectedSlice []PodListcategory
+		expectedSlice []PodListCategory
 	}{
 		{
 			// Category 1 - pass
 			testSlice: createPod(runAs, false, true, []corev1.Capability{"KILL", "MKNOD", "SETUID", "SETGID"}, []corev1.Capability{}),
-			expectedSlice: []PodListcategory{{
+			expectedSlice: []PodListCategory{{
 				Containername: "test",
 				Podname:       "test",
 				NameSpace:     "tnf",
@@ -29,7 +29,7 @@ func TestCheckPod(t *testing.T) {
 		{
 			// Category 1 no UIOD0 - pass
 			testSlice: createPod(runAs2, true, true, []corev1.Capability{"KILL", "MKNOD", "SETUID", "SETGID"}, []corev1.Capability{}),
-			expectedSlice: []PodListcategory{{
+			expectedSlice: []PodListCategory{{
 				Containername: "test",
 				Podname:       "test",
 				NameSpace:     "tnf",
@@ -39,7 +39,7 @@ func TestCheckPod(t *testing.T) {
 		{
 			// Category 2 - pass
 			testSlice: createPod(runAs, false, true, []corev1.Capability{"KILL", "MKNOD", "SETUID", "SETGID"}, []corev1.Capability{"NET_ADMIN", "NET_RAW"}),
-			expectedSlice: []PodListcategory{{
+			expectedSlice: []PodListCategory{{
 				Containername: "test",
 				Podname:       "test",
 				NameSpace:     "tnf",
@@ -49,7 +49,7 @@ func TestCheckPod(t *testing.T) {
 		{
 			// category 3 - pass
 			testSlice: createPod(runAs, false, true, []corev1.Capability{"KILL", "MKNOD", "SETUID", "SETGID"}, []corev1.Capability{"IPC_LOCK", "NET_ADMIN", "NET_RAW"}),
-			expectedSlice: []PodListcategory{{
+			expectedSlice: []PodListCategory{{
 				Containername: "test",
 				Podname:       "test",
 				NameSpace:     "tnf",
@@ -59,7 +59,7 @@ func TestCheckPod(t *testing.T) {
 		{
 			// Fail due to required drop capabilities missing
 			testSlice: createPod(runAs2, false, true, []corev1.Capability{"SYS_TIME", "MKNOD", "SETUID", "SETGID"}, []corev1.Capability{}),
-			expectedSlice: []PodListcategory{{
+			expectedSlice: []PodListCategory{{
 				Containername: "test",
 				Podname:       "test",
 				NameSpace:     "tnf",
@@ -69,7 +69,7 @@ func TestCheckPod(t *testing.T) {
 		{
 			// Category 1 - passing with extra drop capabilities
 			testSlice: createPod(runAs2, false, true, []corev1.Capability{"SYS_TIME", "KILL", "MKNOD", "SETUID", "SETGID"}, []corev1.Capability{}),
-			expectedSlice: []PodListcategory{{
+			expectedSlice: []PodListCategory{{
 				Containername: "test",
 				Podname:       "test",
 				NameSpace:     "tnf",
@@ -79,7 +79,7 @@ func TestCheckPod(t *testing.T) {
 		{
 			// Category 1 - passing with ALL drop capabilities
 			testSlice: createPod(runAs2, false, true, []corev1.Capability{"ALL"}, []corev1.Capability{}),
-			expectedSlice: []PodListcategory{{
+			expectedSlice: []PodListCategory{{
 				Containername: "test",
 				Podname:       "test",
 				NameSpace:     "tnf",
@@ -89,7 +89,7 @@ func TestCheckPod(t *testing.T) {
 		{
 			// Category 1 - pass with no privilege escalation
 			testSlice: createPod(runAs, false, false, []corev1.Capability{"KILL", "MKNOD", "SETUID", "SETGID"}, []corev1.Capability{}),
-			expectedSlice: []PodListcategory{{
+			expectedSlice: []PodListCategory{{
 				Containername: "test",
 				Podname:       "test",
 				NameSpace:     "tnf",
@@ -97,9 +97,8 @@ func TestCheckPod(t *testing.T) {
 			}},
 		},
 		{
-
 			testSlice: createPod2Containers(runAs2, false, true, []corev1.Capability{"ALL"}, []corev1.Capability{}),
-			expectedSlice: []PodListcategory{{
+			expectedSlice: []PodListCategory{{
 				Containername: "test",
 				Podname:       "test",
 				NameSpace:     "tnf",

--- a/pkg/stringhelper/stringhelper.go
+++ b/pkg/stringhelper/stringhelper.go
@@ -36,21 +36,14 @@ func StringInSlice[T ~string](s []T, str T, contains bool) bool {
 	return false
 }
 
-// SubSlice checks if a slice exists within a slice
-func SubSlice[T ~string](s, sub []T) bool {
-	for i := range s {
-		if len(s)-i < len(sub) {
+// SubSlice checks if a slice's elements all exist within a slice
+func SubSlice(s, sub []string) bool {
+	for _, v := range sub {
+		if !StringInSlice(s, v, false) {
 			return false
 		}
-		for j := range sub {
-			if s[i+j] != sub[j] {
-				break
-			} else if j == len(sub)-1 {
-				return true
-			}
-		}
 	}
-	return false
+	return true
 }
 
 func RemoveEmptyStrings(s []string) []string {

--- a/pkg/stringhelper/stringhelper.go
+++ b/pkg/stringhelper/stringhelper.go
@@ -36,6 +36,23 @@ func StringInSlice[T ~string](s []T, str T, contains bool) bool {
 	return false
 }
 
+// SubSlice checks if a slice exists within a slice
+func SubSlice[T ~string](s, sub []T) bool {
+	for i := range s {
+		if len(s)-i < len(sub) {
+			return false
+		}
+		for j := range sub {
+			if s[i+j] != sub[j] {
+				break
+			} else if j == len(sub)-1 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func RemoveEmptyStrings(s []string) []string {
 	var r []string
 	for _, str := range s {

--- a/pkg/stringhelper/stringhelper_test.go
+++ b/pkg/stringhelper/stringhelper_test.go
@@ -151,3 +151,36 @@ func TestRemoveEmptyStrings(t *testing.T) {
 		assert.Equal(t, tc.expectedSlice, RemoveEmptyStrings(tc.testSlice))
 	}
 }
+
+func TestSubSlice(t *testing.T) {
+	testCases := []struct {
+		testSliceA     []string
+		testSliceB     []string
+		expectedOutput bool
+	}{
+		{ // Test #1 - SliceB exists in SliceA
+			testSliceA:     []string{"one", "two", "three"},
+			testSliceB:     []string{"one", "two"},
+			expectedOutput: true,
+		},
+		{ // Test #2 - SliceB does not exist in SliceA
+			testSliceA:     []string{"one", "two", "three"},
+			testSliceB:     []string{"four", "five"},
+			expectedOutput: false,
+		},
+		{ // Test #3 - Same slices, return true
+			testSliceA:     []string{"one", "two", "three"},
+			testSliceB:     []string{"one", "two", "three"},
+			expectedOutput: true,
+		},
+		{ // Test Case # - Empty SliceA
+			testSliceA:     []string{},
+			testSliceB:     []string{"one", "two", "three"},
+			expectedOutput: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedOutput, SubSlice(tc.testSliceA, tc.testSliceB))
+	}
+}

--- a/pkg/stringhelper/stringhelper_test.go
+++ b/pkg/stringhelper/stringhelper_test.go
@@ -173,10 +173,15 @@ func TestSubSlice(t *testing.T) {
 			testSliceB:     []string{"one", "two", "three"},
 			expectedOutput: true,
 		},
-		{ // Test Case # - Empty SliceA
+		{ // Test Case #4 - Empty SliceA
 			testSliceA:     []string{},
 			testSliceB:     []string{"one", "two", "three"},
 			expectedOutput: false,
+		},
+		{ // Test #5 - SliceB's elements exist out of order in SliceA
+			testSliceA:     []string{"one", "two", "three"},
+			testSliceB:     []string{"two", "one"},
+			expectedOutput: true,
 		},
 	}
 


### PR DESCRIPTION
Notable changes:
- Removed `subslice` and `contains` function and created a `stringhelper.SubSlice` helper function with corresponding unit tests.
- Re-ordered the subslice check to take the `drop` slice first followed by the `required` slice.  Because you want to check your SCCs against the required SCCs.
- Adjust camel case of `PodListcategory` to `PodListCategory`.
- Added a comment about the `NOK` value on the RunAsNonRoot in category 1.