### PR TITLE
adding failure reason to icmp connectivity tests

### DIFF
--- a/cnf-certification-test/accesscontrol/pidshelper_test.go
+++ b/cnf-certification-test/accesscontrol/pidshelper_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
+	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
 )
 
 func TestGetNbOfProcessesInPidNamespace(t *testing.T) {
@@ -86,7 +87,7 @@ func TestGetNbOfProcessesInPidNamespace(t *testing.T) {
 			},
 		}
 
-		result, err := getNbOfProcessesInPidNamespace(clientsholder.NewContext("testNamespace", "testPod", "containerName"), tc.testPID, ch)
+		result, err := getNbOfProcessesInPidNamespace(clientsholder.NewContext("testNamespace", "testPod", testhelper.ContainerName), tc.testPID, ch)
 
 		// assertions
 		assert.Equal(t, tc.expectedResult, result)

--- a/cnf-certification-test/networking/icmp/icmp_test.go
+++ b/cnf-certification-test/networking/icmp/icmp_test.go
@@ -53,8 +53,13 @@ func Test_parsePingResult(t *testing.T) {
 		 --- 8.8.8.8 ping statistics ---
 		 5 packets transmitted, 5 received, 0% packet loss, time 4005ms
 		 rtt min/avg/max/mdev = 32.593/35.761/38.212/1.802 ms`, stderr: ""},
-			wantResults: PingResults{outcome: testhelper.SUCCESS, transmitted: 5, received: 5, errors: 0},
-			wantErr:     false,
+			wantResults: PingResults{
+				outcome:     testhelper.SUCCESS,
+				transmitted: 5,
+				received:    5,
+				errors:      0,
+			},
+			wantErr: false,
 		},
 		{
 			name: "pingErrorPacket",
@@ -83,15 +88,25 @@ func Test_parsePingResult(t *testing.T) {
 			--- 192.168.1.1 ping statistics ---
 			20 packets transmitted, 16 received, +4 errors, 20% packet loss, time 19118ms
 			rtt min/avg/max/mdev = 1.582/134.079/585.861/179.394 ms`, stderr: ""},
-			wantResults: PingResults{outcome: testhelper.ERROR, transmitted: 20, received: 16, errors: 4},
-			wantErr:     false,
+			wantResults: PingResults{
+				outcome:     testhelper.ERROR,
+				transmitted: 20,
+				received:    16,
+				errors:      4,
+			},
+			wantErr: false,
 		},
 		{
 			name: "pingIncorrectIp",
 			args: args{stdout: `connect: Invalid argument
 			command terminated with exit code 2`, stderr: ""},
-			wantResults: PingResults{outcome: testhelper.ERROR, transmitted: 0, received: 0, errors: 0},
-			wantErr:     true,
+			wantResults: PingResults{
+				outcome:     testhelper.ERROR,
+				transmitted: 0,
+				received:    0,
+				errors:      0,
+			},
+			wantErr: true,
 		},
 		{
 			name: "pingPassingPacketLoss",
@@ -118,8 +133,13 @@ func Test_parsePingResult(t *testing.T) {
 			--- 192.168.1.5 ping statistics ---
 			20 packets transmitted, 19 received, 5% packet loss, time 19297ms
 			rtt min/avg/max/mdev = 3.381/7.772/14.867/4.167 ms`, stderr: ""},
-			wantResults: PingResults{outcome: testhelper.SUCCESS, transmitted: 20, received: 19, errors: 0},
-			wantErr:     false,
+			wantResults: PingResults{
+				outcome:     testhelper.SUCCESS,
+				transmitted: 20,
+				received:    19,
+				errors:      0,
+			},
+			wantErr: false,
 		},
 		{
 			name: "pingFailingPacketLoss",
@@ -130,8 +150,13 @@ func Test_parsePingResult(t *testing.T) {
 			1 packets transmitted, 0 received, 100% packet loss, time 0ms
 			
 			command terminated with exit code 1`, stderr: ""},
-			wantResults: PingResults{outcome: testhelper.FAILURE, transmitted: 1, received: 0, errors: 0},
-			wantErr:     false,
+			wantResults: PingResults{
+				outcome:     testhelper.FAILURE,
+				transmitted: 1,
+				received:    0,
+				errors:      0,
+			},
+			wantErr: false,
 		},
 		{
 			name: "pingHostnameNoPacketLoss",
@@ -150,8 +175,13 @@ func Test_parsePingResult(t *testing.T) {
 			--- www.google.com ping statistics ---
 			10 packets transmitted, 10 received, 0% packet loss, time 9014ms
 			rtt min/avg/max/mdev = 21.650/27.619/37.003/3.885 ms`, stderr: ""},
-			wantResults: PingResults{outcome: testhelper.SUCCESS, transmitted: 10, received: 10, errors: 0},
-			wantErr:     false,
+			wantResults: PingResults{
+				outcome:     testhelper.SUCCESS,
+				transmitted: 10,
+				received:    10,
+				errors:      0,
+			},
+			wantErr: false,
 		},
 		{
 			name: "decodingError",
@@ -170,8 +200,13 @@ func Test_parsePingResult(t *testing.T) {
 			--- www.google.com ping statistics ---
 			10 pacets transmitted, 10 received, 0% packet loss, time 9014ms
 			rtt min/avg/max/mdev = 21.650/27.619/37.003/3.885 ms`, stderr: ""},
-			wantResults: PingResults{outcome: testhelper.FAILURE, transmitted: 0, received: 0, errors: 0},
-			wantErr:     true,
+			wantResults: PingResults{
+				outcome:     testhelper.FAILURE,
+				transmitted: 0,
+				received:    0,
+				errors:      0,
+			},
+			wantErr: true,
 		},
 	}
 
@@ -264,9 +299,19 @@ func TestProcessContainerIpsPerNet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ProcessContainerIpsPerNet(tt.args.containerID, tt.args.netKey, tt.args.ipAddresses, tt.args.netsUnderTest, tt.args.aIPVersion)
+			ProcessContainerIpsPerNet(
+				tt.args.containerID,
+				tt.args.netKey,
+				tt.args.ipAddresses,
+				tt.args.netsUnderTest,
+				tt.args.aIPVersion,
+			)
 			if !reflect.DeepEqual(tt.args.netsUnderTest, tt.args.wantNetsUnderTest) {
-				t.Errorf("ProcessContainerIpsPerNet() = %v, want %v", tt.args.netsUnderTest, tt.args.wantNetsUnderTest)
+				t.Errorf(
+					"ProcessContainerIpsPerNet() = %v, want %v",
+					tt.args.netsUnderTest,
+					tt.args.wantNetsUnderTest,
+				)
 			}
 		})
 	}
@@ -349,7 +394,9 @@ func TestBuildNetTestContext(t *testing.T) {
 				},
 			},
 
-			wantClaimsLogStr: []string{"Skipping pod: pod2 ns: ns1 because it is excluded from all connectivity tests\n"},
+			wantClaimsLogStr: []string{
+				"Skipping pod: pod2 ns: ns1 because it is excluded from all connectivity tests\n",
+			},
 		},
 		{
 			name: "ipv4ok multus",
@@ -464,7 +511,9 @@ func TestBuildNetTestContext(t *testing.T) {
 				},
 			},
 
-			wantClaimsLogStr: []string{"Skipping pod pod2 because it is excluded from Multus connectivity tests only\n"},
+			wantClaimsLogStr: []string{
+				"Skipping pod pod2 because it is excluded from Multus connectivity tests only\n",
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -472,18 +521,28 @@ func TestBuildNetTestContext(t *testing.T) {
 			for idx := range tt.args.pods {
 				tt.args.pods[idx].MultusIPs = make(map[string][]string)
 				var err error
-				tt.args.pods[idx].MultusIPs, err = provider.GetPodIPsPerNet(tt.args.pods[idx].GetAnnotations()[provider.CniNetworksStatusKey])
+				tt.args.pods[idx].MultusIPs, err = provider.GetPodIPsPerNet(
+					tt.args.pods[idx].GetAnnotations()[provider.CniNetworksStatusKey],
+				)
 				if err != nil {
 					fmt.Printf("Could not decode networks-status annotation")
 				}
 			}
 
-			gotNetsUnderTest, gotClaimsLog := BuildNetTestContext(tt.args.pods, tt.args.aIPVersion, tt.args.aType)
+			gotNetsUnderTest, gotClaimsLog := BuildNetTestContext(
+				tt.args.pods,
+				tt.args.aIPVersion,
+				tt.args.aType,
+			)
 
 			out, _ := json.MarshalIndent(gotNetsUnderTest, "", "")
 			fmt.Printf("%s", out)
 			if !reflect.DeepEqual(gotNetsUnderTest, tt.wantNetsUnderTest) {
-				t.Errorf("BuildNetTestContext() gotNetsUnderTest = %v, want %v", gotNetsUnderTest, tt.wantNetsUnderTest)
+				t.Errorf(
+					"BuildNetTestContext() gotNetsUnderTest = %v, want %v",
+					gotNetsUnderTest,
+					tt.wantNetsUnderTest,
+				)
 			}
 
 			testClaimsLog := loghelper.CuratedLogLines{}
@@ -492,7 +551,11 @@ func TestBuildNetTestContext(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(gotClaimsLog, testClaimsLog) {
-				t.Errorf("BuildNetTestContext() gotClaimsLog = %v, want %v", gotClaimsLog, testClaimsLog)
+				t.Errorf(
+					"BuildNetTestContext() gotClaimsLog = %v, want %v",
+					gotClaimsLog,
+					testClaimsLog,
+				)
 			}
 		})
 	}
@@ -662,7 +725,7 @@ func TestRunNetworkingTests(t *testing.T) {
 	tests := []struct {
 		name             string
 		args             args
-		wantBadNets      map[string][]string
+		wantReport       testhelper.FailureReasonOut
 		wantClaimsLogStr []string
 		testPingSuccess  bool
 	}{
@@ -699,15 +762,56 @@ func TestRunNetworkingTests(t *testing.T) {
 			},
 			}, count: 10, aIPVersion: netcommons.IPv4,
 			},
-			wantBadNets:      map[string][]string{},
-			wantClaimsLogStr: []string{"IPv4 ping test on network default from ( container: test1 pod: test-0 ns: tnf  srcip: 10.244.195.231 ) to ( container: test2 pod: test-1 ns: tnf dstip: 10.244.195.232 ) result: outcome: SUCCESS transmitted: 10 received: 10 errors: 0\n"}, //nolint:lll
-			testPingSuccess:  true,
+			wantReport: testhelper.FailureReasonOut{
+				CompliantObjectsOut: []*testhelper.ReportObject{
+					{
+						ObjectType: "ICMP result",
+						ObjectFieldsKeys: []string{
+							testhelper.ReasonForCompliance,
+							"Namespace",
+							testhelper.PodName,
+							testhelper.ContainerName,
+							testhelper.NetworkName,
+							testhelper.SourceIP,
+							testhelper.DestinationNamespace,
+							testhelper.DestinationPodName,
+							testhelper.DestinationContainerName,
+							testhelper.DestinationIP,
+						},
+						ObjectFieldsValues: []string{
+							"Pinging destination container/IP from source container (identified by Namespace/Pod Name/Container Name) Succeeded",
+							"tnf",
+							"test-0",
+							"test1",
+							"default",
+							"10.244.195.231",
+							"tnf",
+							"test-1",
+							"test2",
+							"10.244.195.232",
+						},
+					},
+					{
+						ObjectType:       "Network",
+						ObjectFieldsKeys: []string{testhelper.ReasonForCompliance, testhelper.NetworkName},
+						ObjectFieldsValues: []string{
+							"ICMP tests were successful for  all 1 IP source/destination in this network",
+							"default",
+						},
+					},
+				},
+				NonCompliantObjectsOut: []*testhelper.ReportObject{},
+			},
+			wantClaimsLogStr: []string{
+				"IPv4 ping test on network default from ( container: test1 pod: test-0 ns: tnf  srcip: 10.244.195.231 ) to ( container: test2 pod: test-1 ns: tnf dstip: 10.244.195.232 ) result: outcome: SUCCESS transmitted: 10 received: 10 errors: 0\n",
+			},
+			testPingSuccess: true,
 		},
 		{name: "noNetToTest",
 			args: args{netsUnderTest: map[string]netcommons.NetTestContext{},
 				count: 10, aIPVersion: netcommons.IPv4,
 			},
-			wantBadNets:     nil,
+			wantReport:      testhelper.FailureReasonOut{},
 			testPingSuccess: true,
 		},
 		{name: "only one container",
@@ -730,7 +834,7 @@ func TestRunNetworkingTests(t *testing.T) {
 			},
 			}, count: 10, aIPVersion: netcommons.IPv4,
 			},
-			wantBadNets:     map[string][]string{},
+			wantReport:      testhelper.FailureReasonOut{},
 			testPingSuccess: true,
 		},
 		{name: "ping fails",
@@ -779,9 +883,77 @@ func TestRunNetworkingTests(t *testing.T) {
 			},
 			}, count: 10, aIPVersion: netcommons.IPv4,
 			},
-			wantBadNets: map[string][]string{"default": {"10.244.195.232", "10.244.195.233"}},
-			wantClaimsLogStr: []string{"IPv4 ping test on network default from ( container: test1 pod: test-0 ns: tnf  srcip: 10.244.195.231 ) to ( container: test2 pod: test-1 ns: tnf dstip: 10.244.195.232 ) result: outcome: FAILURE transmitted: 10 received: 5 errors: 5\n", //nolint:lll
-				"IPv4 ping test on network default from ( container: test1 pod: test-0 ns: tnf  srcip: 10.244.195.231 ) to ( container: test3 pod: test-1 ns: tnf dstip: 10.244.195.233 ) result: outcome: FAILURE transmitted: 10 received: 5 errors: 5\n"}, //nolint:lll
+			wantReport: testhelper.FailureReasonOut{
+				CompliantObjectsOut: []*testhelper.ReportObject{},
+				NonCompliantObjectsOut: []*testhelper.ReportObject{
+					{
+						ObjectType: "ICMP result",
+						ObjectFieldsKeys: []string{
+							testhelper.ReasonForNonCompliance,
+							"Namespace",
+							testhelper.PodName,
+							testhelper.ContainerName,
+							testhelper.NetworkName,
+							testhelper.SourceIP,
+							testhelper.DestinationNamespace,
+							testhelper.DestinationPodName,
+							testhelper.DestinationContainerName,
+							testhelper.DestinationIP,
+						},
+						ObjectFieldsValues: []string{
+							"Pinging destination container/IP from source container (identified by Namespace/Pod Name/Container Name) Failed",
+							"tnf",
+							"test-0",
+							"test1",
+							"default",
+							"10.244.195.231",
+							"tnf",
+							"test-1",
+							"test2",
+							"10.244.195.232",
+						},
+					},
+					{
+						ObjectType: "ICMP result",
+						ObjectFieldsKeys: []string{
+							testhelper.ReasonForNonCompliance,
+							"Namespace",
+							testhelper.PodName,
+							testhelper.ContainerName,
+							testhelper.NetworkName,
+							testhelper.SourceIP,
+							testhelper.DestinationNamespace,
+							testhelper.DestinationPodName,
+							testhelper.DestinationContainerName,
+							testhelper.DestinationIP,
+						},
+						ObjectFieldsValues: []string{
+							"Pinging destination container/IP from source container (identified by Namespace/Pod Name/Container Name) Failed",
+							"tnf",
+							"test-0",
+							"test1",
+							"default",
+							"10.244.195.231",
+							"tnf",
+							"test-1",
+							"test3",
+							"10.244.195.233",
+						},
+					},
+					{
+						ObjectType:       "Network",
+						ObjectFieldsKeys: []string{testhelper.ReasonForNonCompliance, testhelper.NetworkName},
+						ObjectFieldsValues: []string{
+							"ICMP tests failed for 2 IP source/destination in this network",
+							"default",
+						},
+					},
+				},
+			},
+			wantClaimsLogStr: []string{
+				"IPv4 ping test on network default from ( container: test1 pod: test-0 ns: tnf  srcip: 10.244.195.231 ) to ( container: test2 pod: test-1 ns: tnf dstip: 10.244.195.232 ) result: outcome: FAILURE transmitted: 10 received: 5 errors: 5\n", //nolint:lll
+				"IPv4 ping test on network default from ( container: test1 pod: test-0 ns: tnf  srcip: 10.244.195.231 ) to ( container: test3 pod: test-1 ns: tnf dstip: 10.244.195.233 ) result: outcome: FAILURE transmitted: 10 received: 5 errors: 5\n",
+			},
 			testPingSuccess: false,
 		},
 	}
@@ -792,12 +964,24 @@ func TestRunNetworkingTests(t *testing.T) {
 			} else {
 				TestPing = TestPingFailure
 			}
-			gotBadNets, gotClaimsLog, _ := RunNetworkingTests(tt.args.netsUnderTest, tt.args.count, tt.args.aIPVersion)
-			if !reflect.DeepEqual(gotBadNets, tt.wantBadNets) {
-				t.Errorf("RunNetworkingTests() gotBadNets = %v, want %v", gotBadNets, tt.wantBadNets)
+			gotReport, gotClaimsLog, _ := RunNetworkingTests(
+				tt.args.netsUnderTest,
+				tt.args.count,
+				tt.args.aIPVersion,
+			)
+			if !gotReport.Equal(tt.wantReport) {
+				t.Errorf(
+					"RunNetworkingTests() gotReport = %s, want %s",
+					testhelper.FailureReasonOutTestString(gotReport),
+					testhelper.FailureReasonOutTestString(tt.wantReport),
+				)
 			}
 			if !reflect.DeepEqual(gotClaimsLog.GetLogLines(), tt.wantClaimsLogStr) {
-				t.Errorf("RunNetworkingTests() gotClaimsLog = %v, want %v", gotClaimsLog, tt.wantClaimsLogStr)
+				t.Errorf(
+					"RunNetworkingTests() gotReport = %+v, want %+v",
+					gotClaimsLog,
+					tt.wantClaimsLogStr,
+				)
 			}
 		})
 	}
@@ -808,5 +992,12 @@ var TestPingSuccess = func(sourceContainerID *provider.Container, targetContaine
 }
 
 var TestPingFailure = func(sourceContainerID *provider.Container, targetContainerIP netcommons.ContainerIP, count int) (results PingResults, err error) {
-	return PingResults{outcome: testhelper.FAILURE, transmitted: 10, received: 5, errors: 5}, fmt.Errorf("ping failed")
+	return PingResults{
+			outcome:     testhelper.FAILURE,
+			transmitted: 10,
+			received:    5,
+			errors:      5,
+		}, fmt.Errorf(
+			"ping failed",
+		)
 }

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -209,17 +209,13 @@ func testNetworkConnectivity(env *provider.TestEnvironment, aIPVersion netcommon
 	netsUnderTest, claimsLog := icmp.BuildNetTestContext(env.Pods, aIPVersion, aType)
 	// Saving  curated logs to claims file
 	tnf.ClaimFilePrintf("%s", claimsLog.GetLogLines())
-	badNets, claimsLog, skip := icmp.RunNetworkingTests(netsUnderTest, defaultNumPings, aIPVersion)
+	report, claimsLog, skip := icmp.RunNetworkingTests(netsUnderTest, defaultNumPings, aIPVersion)
 	// Saving curated logs to claims file
 	tnf.ClaimFilePrintf("%s", claimsLog.GetLogLines())
 	if skip {
 		ginkgo.Skip(fmt.Sprintf("There are no %s networks to test, skipping test", aIPVersion))
 	}
-	if n := len(badNets); n > 0 {
-		logrus.Debugf("Failed nets: %+v", badNets)
-		tnf.ClaimFilePrintf("%d nets failed the %s network %s ping test.", n, aType, aIPVersion)
-		testhelper.AddTestResultLog("Non-compliant", badNets, tnf.ClaimFilePrintf, ginkgo.Fail)
-	}
+	testhelper.AddTestResultReason(report.CompliantObjectsOut, report.NonCompliantObjectsOut, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 func testOCPReservedPortsUsage(env *provider.TestEnvironment) {

--- a/pkg/diagnostics/diagnostics_test.go
+++ b/pkg/diagnostics/diagnostics_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
+	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -80,7 +81,7 @@ func TestGetHWJsonOutput(t *testing.T) {
 				// context .
 				Containers: []corev1.Container{
 					{
-						Name: "podname",
+						Name: testhelper.PodName,
 					},
 				},
 			},
@@ -142,7 +143,7 @@ func TestGetHWTextOutput(t *testing.T) {
 				// context .
 				Containers: []corev1.Container{
 					{
-						Name: "podname",
+						Name: testhelper.PodName,
 					},
 				},
 			},

--- a/pkg/scheduling/scheduling_test.go
+++ b/pkg/scheduling/scheduling_test.go
@@ -18,6 +18,7 @@ package scheduling
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,7 +29,10 @@ import (
 )
 
 func TestProcessPidsCPUScheduling(t *testing.T) {
-	testPids := []*crclient.Process{{PidNs: 2, Pid: 101, Args: "tbd command line"}, {PidNs: 3, Pid: 102, Args: "tbd command line"}}
+	testPids := []*crclient.Process{
+		{PidNs: 2, Pid: 101, Args: "tbd command line"},
+		{PidNs: 3, Pid: 102, Args: "tbd command line"},
+	}
 	testContainer := &provider.Container{}
 	testContainer.Container = &corev1.Container{}
 
@@ -41,114 +45,202 @@ func TestProcessPidsCPUScheduling(t *testing.T) {
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_OTHER", 0, nil
 			},
-			check: SharedCPUScheduling,
-			compliant: []testhelper.ReportObject{
+			check:     SharedCPUScheduling + "1",
+			compliant: []testhelper.ReportObject{},
+
+			nonCompliant: []testhelper.ReportObject{
 				{
 					ObjectType: "ContainerProcess",
-					ObjectFields: map[string]string{
-						"ContainerName":       "",
-						"Namespace":           "",
-						"PodName":             "",
-						"ReasonForCompliance": "process satisfies: SHARED_CPU_SCHEDULING: scheduling priority == 0",
-						"SchedulingPolicy":    "SCHED_OTHER", "SchedulingPriority": "0", "ProcessCommandLine": "tbd command line",
+					ObjectFieldsKeys: []string{
+						testhelper.ReasonForNonCompliance,
+						"Namespace",
+						testhelper.PodName,
+						testhelper.ContainerName,
+						testhelper.ProcessCommandLine,
+						testhelper.SchedulingPolicy,
+						testhelper.SchedulingPriority,
+					},
+					ObjectFieldsValues: []string{
+						"process does not satisfy: ",
+						"",
+						"",
+						"",
+						"tbd command line",
+						"SCHED_OTHER",
+						"0",
 					},
 				},
 				{
 					ObjectType: "ContainerProcess",
-					ObjectFields: map[string]string{
-						"ContainerName":       "",
-						"Namespace":           "",
-						"PodName":             "",
-						"ReasonForCompliance": "process satisfies: SHARED_CPU_SCHEDULING: scheduling priority == 0",
-						"SchedulingPolicy":    "SCHED_OTHER", "SchedulingPriority": "0", "ProcessCommandLine": "tbd command line",
+					ObjectFieldsKeys: []string{
+						testhelper.ReasonForNonCompliance,
+						"Namespace",
+						testhelper.PodName,
+						testhelper.ContainerName,
+						testhelper.ProcessCommandLine,
+						testhelper.SchedulingPolicy,
+						testhelper.SchedulingPriority,
+					},
+					ObjectFieldsValues: []string{
+						"process does not satisfy: ",
+						"",
+						"",
+						"",
+						"tbd command line",
+						"SCHED_OTHER",
+						"0",
 					},
 				},
 			},
-
-			nonCompliant: []testhelper.ReportObject{},
 		},
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_RR", 90, nil
 			},
-			check: SharedCPUScheduling,
+			check:     SharedCPUScheduling + "2",
+			compliant: []testhelper.ReportObject{},
+
 			nonCompliant: []testhelper.ReportObject{
 				{
 					ObjectType: "ContainerProcess",
-					ObjectFields: map[string]string{
-						"ContainerName":          "",
-						"Namespace":              "",
-						"PodName":                "",
-						"ReasonForNonCompliance": "process does not satisfy: SHARED_CPU_SCHEDULING: scheduling priority == 0",
-						"SchedulingPolicy":       "SCHED_RR", "SchedulingPriority": "90", "ProcessCommandLine": "tbd command line",
+					ObjectFieldsKeys: []string{
+						testhelper.ReasonForNonCompliance,
+						"Namespace",
+						testhelper.PodName,
+						testhelper.ContainerName,
+						testhelper.ProcessCommandLine,
+						testhelper.SchedulingPolicy,
+						testhelper.SchedulingPriority,
+					},
+					ObjectFieldsValues: []string{
+						"process does not satisfy: ",
+						"",
+						"",
+						"",
+						"tbd command line",
+						"SCHED_RR",
+						"90",
 					},
 				},
 				{
 					ObjectType: "ContainerProcess",
-					ObjectFields: map[string]string{
-						"ContainerName":          "",
-						"Namespace":              "",
-						"PodName":                "",
-						"ReasonForNonCompliance": "process does not satisfy: SHARED_CPU_SCHEDULING: scheduling priority == 0",
-						"SchedulingPolicy":       "SCHED_RR", "SchedulingPriority": "90", "ProcessCommandLine": "tbd command line",
+					ObjectFieldsKeys: []string{
+						testhelper.ReasonForNonCompliance,
+						"Namespace",
+						testhelper.PodName,
+						testhelper.ContainerName,
+						testhelper.ProcessCommandLine,
+						testhelper.SchedulingPolicy,
+						testhelper.SchedulingPriority,
+					},
+					ObjectFieldsValues: []string{
+						"process does not satisfy: ",
+						"",
+						"",
+						"",
+						"tbd command line",
+						"SCHED_RR",
+						"90",
 					},
 				},
-			},
-
-			compliant: []testhelper.ReportObject{}},
+			}},
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_FIFO", 9, nil
 			},
-			check: ExclusiveCPUScheduling,
-			compliant: []testhelper.ReportObject{
-				{
-					ObjectType: "ContainerProcess",
-					ObjectFields: map[string]string{
-						"ContainerName":       "",
-						"Namespace":           "",
-						"PodName":             "",
-						"ReasonForCompliance": "process satisfies: EXCLUSIVE_CPU_SCHEDULING: scheduling priority < 10 and scheduling policy == SCHED_RR or SCHED_FIFO",
-						"SchedulingPolicy":    "SCHED_FIFO", "SchedulingPriority": "9", "ProcessCommandLine": "tbd command line",
-					},
-				},
-				{
-					ObjectType: "ContainerProcess",
-					ObjectFields: map[string]string{
-						"ContainerName":       "",
-						"Namespace":           "",
-						"PodName":             "",
-						"ReasonForCompliance": "process satisfies: EXCLUSIVE_CPU_SCHEDULING: scheduling priority < 10 and scheduling policy == SCHED_RR or SCHED_FIFO",
-						"SchedulingPolicy":    "SCHED_FIFO", "SchedulingPriority": "9", "ProcessCommandLine": "tbd command line",
-					},
-				},
-			},
+			check:     ExclusiveCPUScheduling + "1",
+			compliant: []testhelper.ReportObject{},
 
-			nonCompliant: []testhelper.ReportObject{}},
+			nonCompliant: []testhelper.ReportObject{
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFieldsKeys: []string{
+						testhelper.ReasonForNonCompliance,
+						"Namespace",
+						testhelper.PodName,
+						testhelper.ContainerName,
+						testhelper.ProcessCommandLine,
+						testhelper.SchedulingPolicy,
+						testhelper.SchedulingPriority,
+					},
+					ObjectFieldsValues: []string{
+						"process does not satisfy: ",
+						"",
+						"",
+						"",
+						"tbd command line",
+						"SCHED_FIFO",
+						"9",
+					},
+				},
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFieldsKeys: []string{
+						testhelper.ReasonForNonCompliance,
+						"Namespace",
+						testhelper.PodName,
+						testhelper.ContainerName,
+						testhelper.ProcessCommandLine,
+						testhelper.SchedulingPolicy,
+						testhelper.SchedulingPriority,
+					},
+					ObjectFieldsValues: []string{
+						"process does not satisfy: ",
+						"",
+						"",
+						"",
+						"tbd command line",
+						"SCHED_FIFO",
+						"9",
+					},
+				},
+			}},
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_FIFO", 11, nil
 			},
-			check: ExclusiveCPUScheduling,
+			check: ExclusiveCPUScheduling + "2",
 			nonCompliant: []testhelper.ReportObject{
 				{
 					ObjectType: "ContainerProcess",
-					ObjectFields: map[string]string{
-						"ContainerName":          "",
-						"Namespace":              "",
-						"PodName":                "",
-						"ReasonForNonCompliance": "process does not satisfy: EXCLUSIVE_CPU_SCHEDULING: scheduling priority < 10 and scheduling policy == SCHED_RR or SCHED_FIFO",
-						"SchedulingPolicy":       "SCHED_FIFO", "SchedulingPriority": "11", "ProcessCommandLine": "tbd command line",
+					ObjectFieldsKeys: []string{
+						testhelper.ReasonForNonCompliance,
+						"Namespace",
+						testhelper.PodName,
+						testhelper.ContainerName,
+						testhelper.ProcessCommandLine,
+						testhelper.SchedulingPolicy,
+						testhelper.SchedulingPriority,
+					},
+					ObjectFieldsValues: []string{
+						"process does not satisfy: ",
+						"",
+						"",
+						"",
+						"tbd command line",
+						"SCHED_FIFO",
+						"11",
 					},
 				},
 				{
 					ObjectType: "ContainerProcess",
-					ObjectFields: map[string]string{
-						"ContainerName":          "",
-						"Namespace":              "",
-						"PodName":                "",
-						"ReasonForNonCompliance": "process does not satisfy: EXCLUSIVE_CPU_SCHEDULING: scheduling priority < 10 and scheduling policy == SCHED_RR or SCHED_FIFO",
-						"SchedulingPolicy":       "SCHED_FIFO", "SchedulingPriority": "11", "ProcessCommandLine": "tbd command line",
+					ObjectFieldsKeys: []string{
+						testhelper.ReasonForNonCompliance,
+						"Namespace",
+						testhelper.PodName,
+						testhelper.ContainerName,
+						testhelper.ProcessCommandLine,
+						testhelper.SchedulingPolicy,
+						testhelper.SchedulingPriority,
+					},
+					ObjectFieldsValues: []string{
+						"process does not satisfy: ",
+						"",
+						"",
+						"",
+						"tbd command line",
+						"SCHED_FIFO",
+						"11",
 					},
 				},
 			},
@@ -158,84 +250,150 @@ func TestProcessPidsCPUScheduling(t *testing.T) {
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_FIFO", 50, nil
 			},
-			check: IsolatedCPUScheduling,
-			compliant: []testhelper.ReportObject{
-				{
-					ObjectType: "ContainerProcess",
-					ObjectFields: map[string]string{
-						"ContainerName":       "",
-						"Namespace":           "",
-						"PodName":             "",
-						"ReasonForCompliance": "process satisfies: ISOLATED_CPU_SCHEDULING: scheduling policy == SCHED_RR or SCHED_FIFO",
-						"SchedulingPolicy":    "SCHED_FIFO", "SchedulingPriority": "50", "ProcessCommandLine": "tbd command line",
-					},
-				},
-				{
-					ObjectType: "ContainerProcess",
-					ObjectFields: map[string]string{
-						"ContainerName":       "",
-						"Namespace":           "",
-						"PodName":             "",
-						"ReasonForCompliance": "process satisfies: ISOLATED_CPU_SCHEDULING: scheduling policy == SCHED_RR or SCHED_FIFO",
-						"SchedulingPolicy":    "SCHED_FIFO", "SchedulingPriority": "50", "ProcessCommandLine": "tbd command line",
-					},
-				},
-			},
+			check:     IsolatedCPUScheduling + "1",
+			compliant: []testhelper.ReportObject{},
 
-			nonCompliant: []testhelper.ReportObject{}},
+			nonCompliant: []testhelper.ReportObject{
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFieldsKeys: []string{
+						testhelper.ReasonForNonCompliance,
+						"Namespace",
+						testhelper.PodName,
+						testhelper.ContainerName,
+						testhelper.ProcessCommandLine,
+						testhelper.SchedulingPolicy,
+						testhelper.SchedulingPriority,
+					},
+					ObjectFieldsValues: []string{
+						"process does not satisfy: ",
+						"",
+						"",
+						"",
+						"tbd command line",
+						"SCHED_FIFO",
+						"50",
+					},
+				},
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFieldsKeys: []string{
+						testhelper.ReasonForNonCompliance,
+						"Namespace",
+						testhelper.PodName,
+						testhelper.ContainerName,
+						testhelper.ProcessCommandLine,
+						testhelper.SchedulingPolicy,
+						testhelper.SchedulingPriority,
+					},
+					ObjectFieldsValues: []string{
+						"process does not satisfy: ",
+						"",
+						"",
+						"",
+						"tbd command line",
+						"SCHED_FIFO",
+						"50",
+					},
+				},
+			}},
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_RR", 99, nil
 			},
-			check: IsolatedCPUScheduling,
-			compliant: []testhelper.ReportObject{
-				{
-					ObjectType: "ContainerProcess",
-					ObjectFields: map[string]string{
-						"ContainerName":       "",
-						"Namespace":           "",
-						"PodName":             "",
-						"ReasonForCompliance": "process satisfies: ISOLATED_CPU_SCHEDULING: scheduling policy == SCHED_RR or SCHED_FIFO",
-						"SchedulingPolicy":    "SCHED_RR", "SchedulingPriority": "99", "ProcessCommandLine": "tbd command line",
-					},
-				},
-				{
-					ObjectType: "ContainerProcess",
-					ObjectFields: map[string]string{
-						"ContainerName":       "",
-						"Namespace":           "",
-						"PodName":             "",
-						"ReasonForCompliance": "process satisfies: ISOLATED_CPU_SCHEDULING: scheduling policy == SCHED_RR or SCHED_FIFO",
-						"SchedulingPolicy":    "SCHED_RR", "SchedulingPriority": "99", "ProcessCommandLine": "tbd command line",
-					},
-				},
-			},
+			check:     IsolatedCPUScheduling + "2",
+			compliant: []testhelper.ReportObject{},
 
-			nonCompliant: []testhelper.ReportObject{}},
+			nonCompliant: []testhelper.ReportObject{
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFieldsKeys: []string{
+						testhelper.ReasonForNonCompliance,
+						"Namespace",
+						testhelper.PodName,
+						testhelper.ContainerName,
+						testhelper.ProcessCommandLine,
+						testhelper.SchedulingPolicy,
+						testhelper.SchedulingPriority,
+					},
+					ObjectFieldsValues: []string{
+						"process does not satisfy: ",
+						"",
+						"",
+						"",
+						"tbd command line",
+						"SCHED_RR",
+						"99",
+					},
+				},
+				{
+					ObjectType: "ContainerProcess",
+					ObjectFieldsKeys: []string{
+						testhelper.ReasonForNonCompliance,
+						"Namespace",
+						testhelper.PodName,
+						testhelper.ContainerName,
+						testhelper.ProcessCommandLine,
+						testhelper.SchedulingPolicy,
+						testhelper.SchedulingPriority,
+					},
+					ObjectFieldsValues: []string{
+						"process does not satisfy: ",
+						"",
+						"",
+						"",
+						"tbd command line",
+						"SCHED_RR",
+						"99",
+					},
+				},
+			}},
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				return "SCHED_OTHER", 0, nil
 			},
-			check: IsolatedCPUScheduling,
+			check: IsolatedCPUScheduling + "3",
 			nonCompliant: []testhelper.ReportObject{
 				{
 					ObjectType: "ContainerProcess",
-					ObjectFields: map[string]string{
-						"ContainerName":          "",
-						"Namespace":              "",
-						"PodName":                "",
-						"ReasonForNonCompliance": "process does not satisfy: ISOLATED_CPU_SCHEDULING: scheduling policy == SCHED_RR or SCHED_FIFO",
-						"SchedulingPolicy":       "SCHED_OTHER", "SchedulingPriority": "0", "ProcessCommandLine": "tbd command line",
+					ObjectFieldsKeys: []string{
+						testhelper.ReasonForNonCompliance,
+						"Namespace",
+						testhelper.PodName,
+						testhelper.ContainerName,
+						testhelper.ProcessCommandLine,
+						testhelper.SchedulingPolicy,
+						testhelper.SchedulingPriority,
+					},
+					ObjectFieldsValues: []string{
+						"process does not satisfy: ",
+						"",
+						"",
+						"",
+						"tbd command line",
+						"SCHED_OTHER",
+						"0",
 					},
 				},
 				{
 					ObjectType: "ContainerProcess",
-					ObjectFields: map[string]string{
-						"ContainerName":          "",
-						"Namespace":              "",
-						"PodName":                "",
-						"ReasonForNonCompliance": "process does not satisfy: ISOLATED_CPU_SCHEDULING: scheduling policy == SCHED_RR or SCHED_FIFO",
-						"SchedulingPolicy":       "SCHED_OTHER", "SchedulingPriority": "0", "ProcessCommandLine": "tbd command line",
+					ObjectFieldsKeys: []string{
+						testhelper.ReasonForNonCompliance,
+						"Namespace",
+						testhelper.PodName,
+						testhelper.ContainerName,
+						testhelper.ProcessCommandLine,
+						testhelper.SchedulingPolicy,
+						testhelper.SchedulingPriority,
+					},
+					ObjectFieldsValues: []string{
+						"process does not satisfy: ",
+						"",
+						"",
+						"",
+						"tbd command line",
+						"SCHED_OTHER",
+						"0",
 					},
 				},
 			},
@@ -246,12 +404,34 @@ func TestProcessPidsCPUScheduling(t *testing.T) {
 		GetProcessCPUSchedulingFn = tc.mockGetProcessCPUScheduling
 		compliant, nonCompliant := ProcessPidsCPUScheduling(testPids, testContainer, tc.check)
 
+		fmt.Printf(
+			"test=%s Actual compliant=%s,\n",
+			tc.check,
+			testhelper.ReportObjectTestString(compliant),
+		)
+		fmt.Printf(
+			"test=%s Actual non-compliant=%s,\nfail=%v",
+			tc.check,
+			testhelper.ReportObjectTestString(nonCompliant),
+			len(compliant) != len(tc.compliant),
+		)
+
 		assert.Equal(t, len(compliant), len(tc.compliant))
 		assert.Equal(t, len(nonCompliant), len(tc.nonCompliant))
 		for i := range compliant {
+			fmt.Printf(
+				"compliant test=%s fail=%v",
+				tc.check,
+				!reflect.DeepEqual(tc.compliant[i], *compliant[i]),
+			)
 			assert.Equal(t, tc.compliant[i], *compliant[i])
 		}
 		for i := range nonCompliant {
+			fmt.Printf(
+				"non compliant test=%s fail=%v",
+				tc.check,
+				!reflect.DeepEqual(tc.nonCompliant[i], *nonCompliant[i]),
+			)
 			assert.Equal(t, tc.nonCompliant[i], *nonCompliant[i])
 		}
 	}
@@ -327,7 +507,9 @@ func TestExistsSchedulingPolicyAndPriority(t *testing.T) {
 			outputString:     `chrt: failed to get pid 2396136's policy: No such process`,
 			expectedPolicy:   "",
 			expectedPriority: -1,
-			expectedError:    fmt.Errorf("invalid: chrt: failed to get pid 2396136's policy: No such process"),
+			expectedError: fmt.Errorf(
+				"invalid: chrt: failed to get pid 2396136's policy: No such process",
+			),
 		},
 	}
 

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -31,8 +31,9 @@ const (
 )
 
 type ReportObject struct {
-	ObjectType   string
-	ObjectFields map[string]string
+	ObjectType         string
+	ObjectFieldsKeys   []string
+	ObjectFieldsValues []string
 }
 
 type FailureReasonOut struct {
@@ -40,29 +41,86 @@ type FailureReasonOut struct {
 	NonCompliantObjectsOut []*ReportObject
 }
 
+func Equal(p, other []*ReportObject) bool {
+	if len(p) != len(other) {
+		return false
+	}
+	for i := 0; i < len(p); i++ {
+		if p[i] == nil && other[i] == nil {
+			continue
+		}
+		if p[i] == nil || other[i] == nil {
+			return false
+		}
+		if !reflect.DeepEqual(*p[i], *other[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func FailureReasonOutTestString(p FailureReasonOut) (out string) {
+	out = "testhelper.FailureReasonOut{"
+	out += fmt.Sprintf("CompliantObjectsOut: %s,", ReportObjectTestStringPointer(p.CompliantObjectsOut))
+	out += fmt.Sprintf("NonCompliantObjectsOut: %s,", ReportObjectTestStringPointer(p.NonCompliantObjectsOut))
+	out += "}"
+	return out
+}
+
+func ReportObjectTestStringPointer(p []*ReportObject) (out string) {
+	out = "[]*testhelper.ReportObject{"
+	for _, p := range p {
+		out += fmt.Sprintf("&%#v,", *p)
+	}
+	out += "}"
+	return out
+}
+
+func ReportObjectTestString(p []*ReportObject) (out string) {
+	out = "[]testhelper.ReportObject{"
+	for _, p := range p {
+		out += fmt.Sprintf("%#v,", *p)
+	}
+	out += "}"
+	return out
+}
+
+func (p FailureReasonOut) Equal(other FailureReasonOut) bool {
+	return Equal(p.CompliantObjectsOut, other.CompliantObjectsOut) &&
+		Equal(p.NonCompliantObjectsOut, other.NonCompliantObjectsOut)
+}
+
 // When adding new field types, please update the following:
 
 const (
 	Namespace                    = "Namespace"
-	PodName                      = "PodName"
-	ContainerName                = "ContainerName"
-	ProcessID                    = "ProcessID"
-	ProcessCommandLine           = "ProcessCommandLine"
-	SchedulingPolicy             = "SchedulingPolicy"
-	SchedulingPriority           = "SchedulingPriority"
-	ReasonForNonCompliance       = "ReasonForNonCompliance"
-	ReasonForCompliance          = "ReasonForCompliance"
+	PodName                      = "Pod Name"
+	ContainerName                = "Container Name"
+	ProcessID                    = "Process ID"
+	ProcessCommandLine           = "Process CommandLine"
+	SchedulingPolicy             = "Scheduling Policy"
+	SchedulingPriority           = "Scheduling Priority"
+	ReasonForNonCompliance       = "Reason For Non Compliance"
+	ReasonForCompliance          = "Reason For Compliance"
 	Category                     = "Category"
-	ProjectedVolumeName          = "ProjectedVolumeName"
-	ProjectedVolumeSAToken       = "ProjectedVolumeSAToken"
-	RoleBindingName              = "RoleBindingName"
-	RoleBindingNamespace         = "RoleBindingNamespace"
-	ServiceAccountName           = "ServiceAccountName"
-	ServiceMode                  = "ServiceType"
-	ServiceName                  = "ServiceName"
-	DeploymentName               = "DeploymentName"
-	StatefulSetName              = "StatefulSetName"
-	PodDisruptionBudgetReference = "PodDisruptionBudgetReference"
+	ProjectedVolumeName          = "Projected Volume Name"
+	ProjectedVolumeSAToken       = "Projected Volume SA Token"
+	RoleBindingName              = "Role Binding Name"
+	RoleBindingNamespace         = "Role Binding Namespace"
+	ServiceAccountName           = "Service Account Name"
+	ServiceMode                  = "Service Type"
+	ServiceName                  = "Service Name"
+	DeploymentName               = "Deployment Name"
+	StatefulSetName              = "StatefulSet Name"
+	PodDisruptionBudgetReference = "Pod Disruption Budget Reference"
+
+	// ICMP tests
+	NetworkName              = "Network Name"
+	DestinationNamespace     = "Destination Namespace"
+	DestinationPodName       = "Destination Pod Name"
+	DestinationContainerName = "Destination Container Name"
+	DestinationIP            = "Destination IP"
+	SourceIP                 = "Source IP"
 )
 
 // When adding new object types, please update the following:
@@ -78,45 +136,47 @@ const (
 	ServiceType          = "Service"
 	DeploymentType       = "Deployment"
 	StatefulSetType      = "StatefulSet"
+	ICMPResultType       = "ICMP result"
+	NetworkType          = "Network"
 )
 
 func (obj *ReportObject) SetContainerProcessValues(aPolicy, aPriority, aCommandLine string) *ReportObject {
+	obj.AddField(ProcessCommandLine, aCommandLine)
+	obj.AddField(SchedulingPolicy, aPolicy)
+	obj.AddField(SchedulingPriority, aPriority)
 	obj.ObjectType = ContainerProcessType
-	obj.ObjectFields[ProcessCommandLine] = aCommandLine
-	obj.ObjectFields[SchedulingPolicy] = aPolicy
-	obj.ObjectFields[SchedulingPriority] = aPriority
 	return obj
 }
 
 func NewContainerReportObject(aNamespace, aPodName, aContainerName, aReason string, isCompliant bool) (out *ReportObject) {
 	out = NewReportObject(aReason, ContainerType, isCompliant)
-	out.ObjectFields[Namespace] = aNamespace
-	out.ObjectFields[PodName] = aPodName
-	out.ObjectFields[ContainerName] = aContainerName
+	out.AddField(Namespace, aNamespace)
+	out.AddField(PodName, aPodName)
+	out.AddField(ContainerName, aContainerName)
 	return out
 }
 
 func NewPodReportObject(aNamespace, aPodName, aReason string, isCompliant bool) (out *ReportObject) {
 	out = NewReportObject(aReason, PodType, isCompliant)
-	out.ObjectFields[Namespace] = aNamespace
-	out.ObjectFields[PodName] = aPodName
+	out.AddField(Namespace, aNamespace)
+	out.AddField(PodName, aPodName)
 	return out
 }
 
 func NewReportObject(aReason, aType string, isCompliant bool) (out *ReportObject) {
 	out = &ReportObject{}
 	out.ObjectType = aType
-	out.ObjectFields = make(map[string]string)
 	if isCompliant {
-		out.ObjectFields[ReasonForCompliance] = aReason
+		out.AddField(ReasonForCompliance, aReason)
 	} else {
-		out.ObjectFields[ReasonForNonCompliance] = aReason
+		out.AddField(ReasonForNonCompliance, aReason)
 	}
 	return out
 }
 
-func (obj *ReportObject) AddField(aKey, aString string) (out *ReportObject) {
-	obj.ObjectFields[aKey] = aString
+func (obj *ReportObject) AddField(aKey, aValue string) (out *ReportObject) {
+	obj.ObjectFieldsKeys = append(obj.ObjectFieldsKeys, aKey)
+	obj.ObjectFieldsValues = append(obj.ObjectFieldsValues, aValue)
 	return obj
 }
 

--- a/script/results-embed.html
+++ b/script/results-embed.html
@@ -5,22 +5,24 @@
   <meta charset=utf-8>
   <title>CNF Certification Test Results</title>
   <meta charset="utf-8">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/css/bootstrap.min.css" rel="stylesheet"
-    integrity="sha384-KK94CHFLLe+nY2dmCWGMq91rCGa5gtU4mk92HdvYe+M/SXH301p5ILy+dN9+nJOZ" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://getbootstrap.com/docs/5.3/assets/css/docs.css" rel="stylesheet">
 
+
+  <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
+  <script src="https://cdn.jsdelivr.net/npm/dayjs@1.10.4/dayjs.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dayjs@1.10.4/plugin/duration.min.js"></script>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"
+    integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://unpkg.com/ansi_up@5.1.0/ansi_up.js" crossorigin="anonymous"></script>
   <style type="text/css">
     li.dropdown-menu {
       background-color: white;
     }
 
-    table {
-      border-collapse: collapse;
-    }
-
-    table td {
-      border: 1px solid #000;
-    }
 
     tg {
       background-color: #28a745;
@@ -36,6 +38,60 @@
 
     tgy {
       background-color: #ced4da;
+    }
+
+    body {
+      font-family: sans-serif;
+    }
+
+    ul {
+      list-style: none;
+      padding-left: 1.75em;
+    }
+
+    ul li {
+      border-bottom-left-radius: 0.75em;
+      border-top-left-radius: 0.75em;
+      margin: 2px 0;
+      position: relative;
+    }
+
+    ul li a {
+      background-color: #eee;
+      border-radius: 50%;
+      color: #000;
+      display: inline-block;
+      height: 1.5em;
+      left: -1.5em;
+      line-height: 1.5em;
+      position: absolute;
+      text-align: center;
+      text-decoration: none;
+      width: 1.5em;
+    }
+
+    ul li a.plus {
+      background-color: #77aeff;
+    }
+
+    ul li a.minus {
+      background-color: #eee;
+    }
+
+    ul li a:active {
+      top: 1px;
+    }
+
+    ul li span {
+      display: inline-block;
+      margin: 0.25em 0.5em;
+    }
+
+    .top-right {
+      font-size: small;
+      position: fixed;
+      right: 1em;
+      top: 1em;
     }
   </style>
 </head>
@@ -62,12 +118,15 @@
   <button class="w3-button w3-right w3-light-grey" id="download" type="submit" onclick=download()
     hidden="hidden">Download Results Feedback</button>
 
-    <button class="w3-button w3-right w3-light-grey" id="downloadjson" type="submit" onclick=downloadjson()
+  <button class="w3-button w3-right w3-light-grey" id="downloadjson" type="submit" onclick=downloadjson()
     hidden="hidden">Download Feedback as a JSON file</button>
-    <p hidden="hidden" id ="UploadFeedback">
-      Upload Feedback File: <input type="file" id="feedbackFile" size="40">
-      </p>
-
+  <p hidden="hidden" id="UploadFeedback">
+    Upload Feedback File: <input type="file" id="feedbackFile" size="40">
+  </p>
+  <div class="progress" role="progressbar" aria-label="Basic example" aria-valuenow="0" aria-valuemin="0"
+    aria-valuemax="100">
+    <div class="progress-bar" style="width: 0%"></div>
+  </div>
   <ul class="nav nav-tabs">
     <li class="nav-item">
       <button class="nav-link active" id="config-tab" data-bs-toggle="tab" data-bs-target="#config" type="button"
@@ -108,54 +167,47 @@
   </ul>
   <div class="tab-content" id="myTabContent">
     <div class="tab-pane fade show active" id="config" role="tabpanel" aria-labelledby="config-tab">
-      <table class="table table-hover table-bordered" id="config-table">
+      <div id="config-table">
+      </div>
+    </div>
+    <div class="table-responsive tab-pane fade" id="metadata" role="tabpanel" aria-labelledby="metadata-tab">
+      <table class="table" id="metadata-table">
       </table>
     </div>
-    <div class="tab-pane fade" id="metadata" role="tabpanel" aria-labelledby="metadata-tab">
-      <table class="table table-hover table-bordered" id="metadata-table">
-      </table>
-    </div>
-    <div class="tab-pane fade" id="nodes" role="tabpanel" aria-labelledby="nodes-tab">
-      <table class="table table-hover table-bordered" id="nodes-table">
+    <div class="table-responsive tab-pane fade" id="nodes" role="tabpanel" aria-labelledby="nodes-tab">
+      <table class="table" id="nodes-table">
       </table>
     </div>
 
-    <div class="tab-pane fade" id="results" role="tabpanel" aria-labelledby="result-tab">
-      <table class="table table-hover table-bordered" id="results-table" hidden="hidden">
+    <div class="tab-pane fade table-responsive" id="results" role="tabpanel" aria-labelledby="result-tab">
+      <table class="table" id="results-table" hidden="hidden">
       </table>
-      <table class="table table-hover table-bordered" id="mandatory-far-edge-table" hidden="hidden">
+      <table class="table" id="mandatory-far-edge-table" hidden="hidden">
       </table>
-      <table class="table table-hover table-bordered" id="optional-far-edge-table" hidden="hidden">
+      <table class="table" id="optional-far-edge-table" hidden="hidden">
       </table>
-      <table class="table table-hover table-bordered" id="mandatory-telco-table" hidden="hidden">
+      <table class="table" id="mandatory-telco-table" hidden="hidden">
       </table>
-      <table class="table table-hover table-bordered" id="optional-telco-table" hidden="hidden">
+      <table class="table" id="optional-telco-table" hidden="hidden">
       </table>
-      <table class="table table-hover table-bordered" id="mandatory-non-telco-table" hidden="hidden">
+      <table class="table" id="mandatory-non-telco-table" hidden="hidden">
       </table>
-      <table class="table table-hover table-bordered" id="optional-non-telco-table" hidden="hidden">
-        <table class="table table-hover table-bordered" id="mandatory-extended-table" hidden="hidden">
+      <table class="table" id="optional-non-telco-table" hidden="hidden">
+        <table class="table" id="mandatory-extended-table" hidden="hidden">
         </table>
-        <table class="table table-hover table-bordered" id="optional-extended-table" hidden="hidden">
+        <table class="table" id="optional-extended-table" hidden="hidden">
         </table>
     </div>
 
 
-    <div class="tab-pane fade" id="versions" role="tabpanel" aria-labelledby="versions-tab">
-      <table class="table table-hover table-bordered" id="versions-table">
+
+    <div class="table-responsive tab-pane fade" id="versions" role="tabpanel" aria-labelledby="versions-tab">
+      <table class="table" id="versions-table">
       </table>
     </div>
   </div>
   </div>
-  <script src="https://cdn.jsdelivr.net/npm/dayjs@1.10.4/dayjs.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/dayjs@1.10.4/plugin/duration.min.js"></script>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"
-    integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
-    crossorigin="anonymous"></script>
-  <script src="https://unpkg.com/ansi_up@5.1.0/ansi_up.js" crossorigin="anonymous"></script>
   <!-- We should extract the javascript code to a separate file, but if we include it here we can just use a single file HTMl, which is handy -->
   <!--    <script src="./utils.js"></script> -->
   <script>
@@ -272,7 +324,7 @@
       document.getElementById("download").removeAttribute("hidden");
       document.getElementById("downloadjson").removeAttribute("hidden");
       document.getElementById("UploadFeedback").removeAttribute("hidden");
-      
+
     }
 
 
@@ -337,7 +389,7 @@
       if (typeof input === 'string') {
         text = input
       } else if (Array.isArray(input)) {
-        text += '<table class="table table-light table-bordered">'
+        text += '<div class="table-responsive"><table class="table table-light table-bordered">'
         // Gather header from first item
         text += '<thead><tr>'
 
@@ -359,15 +411,15 @@
           }
           text += '</tr>'
         }
-        text += '</tbody></table>'
+        text += '</tbody></table></div>'
       } else if (typeof input === 'object' && input !== null) {
-        text += '<table class="table table-light table-bordered"><tbody>'
+        text += '<div class="table-responsive"><table class="table table-light table-bordered"><tbody>'
         // Go down the rabbit hole
         for (const key in input) {
           text += '<tr><td><b>' + key + '</b></td><td>'
           text += innerFill(input[key]) + '</td></tr>'
         }
-        text += '</tbody></table>'
+        text += '</tbody></table></div>'
       } else {
         // What else could it be?
         text = input
@@ -460,7 +512,7 @@
           }
         }
       }
-      text += '<th scope="col" class="th-sm">Test ID</th>'
+      text += '<th>Test ID</th>'
       tableNameMap = {
         "faredge": "Far-Edge",
         "telco": "Telco",
@@ -541,15 +593,16 @@
             text += key + '</button></h2>'
             // Now we should populate the item contents
             text += '<div id="' + itemid + '" class="accordion-collapse collapse" aria-labelledby="' + headingid + '">'
-            text += '<div class="accordion-body">'
+            text += '<div class="accordion-body" >'
             // Inside the accordion, 1 table with the following colummns
             text += '<h1>Results</h1>'
-            text += '<table id="myTable-' + key + '"class="table table-bordered table-fixed"><thead><tr>'
-            text += '<th scope="col" class="th-sm">Test ID</th>'
-            text += '<th scope="col" class="th-sm">Test Text</th>'
-            text += '<th scope="col" class="th-sm">Duration</th>'
-            text += '<th scope="col" class="th-sm">State</th>'
-            text += '<th scope="col" class="th-lg">Test output</th>'
+            text += '<div class="table-responsive">'
+            text += '<table id="myTable-' + key + '" class="table table-bordered"><thead><tr>'
+            text += '<th>Test ID</th>'
+            text += '<th class="th-lg">Test Text</th>'
+            text += '<th>Duration</th>'
+            text += '<th>State</th>'
+            text += '<th>Test output</th>'
             text += '</tr></thead><tbody>'
 
             // Note we are skipping some columns for now
@@ -560,10 +613,10 @@
             for (const item of input[key]) {
               const duration = dayjs.duration(item.duration / 1000000)
               formattedDuration = duration.format('D[d] H[h] m[m] s[s] SSS[ms]')
-              text += '<tr><td>' + item.testID.id + '</td>'
-              text += '<td>' + item.testText.replace(/\n/g, '<br>') + '</td>'
+              text += '<tr><td  style="white-space: nowrap;">' + item.testID.id + '</td>'
+              text += '<td class="th-lg">' + item.testText.replace(/\n/g, '<br>') + '</td>'
               text += '<td>' + formattedDuration + '</td>'
-              text += '<td>' + item.state + '</td>'
+              text += '<td style="white-space: nowrap;">' + item.state + '</td>'
               text += '<td>' + ansi_up.ansi_to_html(item.CapturedTestOutput).replace(/\n/g, '<br>') + '</td></tr>'
               jsonObjNonCompliant = NonCompliantReasonTextToJson(item.CapturedTestOutput)
               jsonObjCompliant = CompliantReasonTextToJson(item.CapturedTestOutput)
@@ -572,7 +625,7 @@
             id = id + 1
             if (eqData == "Optional" && tableName != "all") {
               text2 += text
-              text2 += '</tbody></table>'
+              text2 += '</tbody></table></div>'
               for (const item of input[key]) {
                 text2 += '<h1>Feedback</h1><label>Write your feedback for ' + item.testID.id + ' test case</label>'
                 text2 += '<textarea style="width: 100%; margin: 0 auto;" rows = "5" id="source-' + tableName + '-' + item.testID.id + '" type="text" ></textarea>'
@@ -584,7 +637,7 @@
               text2 += '</div></div></div>'
             } else {
               text3 += text
-              text3 += '</tbody></table>'
+              text3 += '</tbody></table></div>'
               for (const item of input[key]) {
                 text3 += '<h1>Feedback</h1><label>Write your feedback for ' + item.testID.id + ' test case</label>'
                 text3 += '<textarea style="width: 100%; margin: 0 auto;" rows = "5" id="source-' + tableName + '-' + item.testID.id + '" type="text"></textarea>'
@@ -606,12 +659,12 @@
       $(text2).appendTo($(element2))
     }
 
-    function fillFeedback(input){
-      for ( key in input) { 
+    function fillFeedback(input) {
+      for (key in input) {
         // copy previus daata
-          document.getElementById(key).textContent = document.getElementById(key).value;
-          document.getElementById(key).textContent = input[key]
-          document.getElementById(key).value=input[key]
+        document.getElementById(key).textContent = document.getElementById(key).value;
+        document.getElementById(key).textContent = input[key]
+        document.getElementById(key).value = input[key]
       }
     }
 
@@ -1189,8 +1242,20 @@ classification=  {
         let fileUploaded = new FileReader();
         fileUploaded.addEventListener("load", e => {
           json = JSON.parse(fileUploaded.result)
-          fillConfig(json.claim.configurations, '#config-table')
-          fillConfig(json.claim.nodes, '#nodes-table')
+          //fillConfig(json.claim.configurations, '#config-table')
+
+
+          // Create treeview from JSON data
+          var container = document.getElementById("config-table");
+          //var [configurationsArr, childName, childNamespace] = format_for_treeview("", json.claim.configurations, [])
+          //createTreeView(container, configurationsArr, 0);
+          var [data, dummy, dummy] = format_for_fast_treeview(0, json.claim.configurations, [])
+          addOrphans(data, "#config-table");
+          //expandAll(document.querySelector("#config-table"));
+          var [data, dummy, dummy] = format_for_fast_treeview(0, json.claim.nodes, [])
+          addOrphans(data, "#nodes-table");
+          //expandAll(document.querySelector("#nodes-table"));
+          //fillConfig(json.claim.nodes, '#nodes-table')
           fillMetadata(json.claim.metadata, '#metadata-table')
           fillVersions(json.claim.versions, '#versions-table')
           fillResults(json.claim.results, classification, '#results-table', '#optional-', "all")
@@ -1271,33 +1336,33 @@ classification=  {
       return doc.documentElement.outerHTML
     }
     function downloadjson() {
-      var dict = {}; 
-      const tablesName = ["all","telco","nontelco","extended","faredge"]; // to go over all the feedback and save it
+      var dict = {};
+      const tablesName = ["all", "telco", "nontelco", "extended", "faredge"]; // to go over all the feedback and save it
       for (const key in this.json.claim.results) {
         for (const key2 in this.classification) {
           if (key == key2) {
-            for (let i = 0; i <  tablesName.length; i++) {
-                var keydict='source-'+tablesName[i]+'-'+key
-                var data = document.getElementById(keydict)
-                if (data != null){
-                  dict[keydict]=data.value 
+            for (let i = 0; i < tablesName.length; i++) {
+              var keydict = 'source-' + tablesName[i] + '-' + key
+              var data = document.getElementById(keydict)
+              if (data != null) {
+                dict[keydict] = data.value
               }
             }
-     
+
+          }
         }
       }
-    }
-  
-    var pom = document.createElement('a');
-  pom.setAttribute('href', 'data:text/json;charset=utf-8,' + 
 
-encodeURIComponent(JSON.stringify(dict)));
-  pom.setAttribute('download', "feedback.json");
-  pom.style.display = 'none';
-  document.body.appendChild(pom);
-  pom.click();
-  document.body.removeChild(pom);
-  }
+      var pom = document.createElement('a');
+      pom.setAttribute('href', 'data:text/json;charset=utf-8,' +
+
+        encodeURIComponent(JSON.stringify(dict)));
+      pom.setAttribute('download', "feedback.json");
+      pom.style.display = 'none';
+      document.body.appendChild(pom);
+      pom.click();
+      document.body.removeChild(pom);
+    }
 
     function download() {
       var selectBox = document.getElementById("selectBox");
@@ -1395,7 +1460,9 @@ encodeURIComponent(JSON.stringify(dict)));
       var allTables = ""
       aTypeMap.forEach(function (value, key) {
         allTables += '<h2> Type: ' + key + '</h2>'
+        allTables += '<div class="table-responsive">'
         allTables += createReasonTableOneType(jsonData, key)
+        allTables += '</div>'
       })
       return allTables
     }
@@ -1421,7 +1488,7 @@ encodeURIComponent(JSON.stringify(dict)));
           // Create table header
           var thead = document.createElement('thead');
           var headerRow = document.createElement('tr');
-          Object.keys(item.ObjectFields).forEach(function (key) {
+          Object.values(item.ObjectFieldsKeys).forEach(function (key) {
             var th = document.createElement('th');
             th.textContent = key;
             headerRow.appendChild(th);
@@ -1431,7 +1498,7 @@ encodeURIComponent(JSON.stringify(dict)));
           firstItem = false
         }
         var row = document.createElement('tr');
-        Object.values(item.ObjectFields).forEach(function (value) {
+        Object.values(item.ObjectFieldsValues).forEach(function (value) {
           var cell = document.createElement('td');
           cell.textContent = value;
           row.appendChild(cell);
@@ -1442,6 +1509,248 @@ encodeURIComponent(JSON.stringify(dict)));
       return table.outerHTML
     }
 
+    function format_for_treeview(parentKey, data, arr) {
+      var objectName = ""
+      var objectNamespace = ""
+      for (var key in data) {
+        if (data[key] == null || key == "managedFields") {
+          continue
+        }
+        if (key.toLowerCase() == "name") {
+          objectName = data[key]
+        }
+        if (key.toLowerCase() == "namespace") {
+          objectNamespace = data[key]
+        }
+        if (Array.isArray(data[key]) || data[key].toString() === "[object Object]") {
+          // when data[key] is an array or object
+          var nodes = [];
+          var [completedNodes, childName, childNamespace] = format_for_treeview(key, data[key], nodes);
+          if (childName != "") {
+            objectName = childName
+            objectNamespace = childNamespace
+          }
+          var nameToPush = key
+          if (isStringInt(key) && objectName != "") {
+            nameToPush = "ns:" + objectNamespace + " name:" + objectName
+            objectName = ""
+            objectNamespace = ""
+          }
+
+          arr.push({
+            name: nameToPush,
+            children: completedNodes
+          });
+        } else {
+          // when data[key] is just strings or integer values
+          arr.push({
+            name: key + " : " + data[key]
+          });
+        }
+      }
+      return [arr, objectName, objectNamespace];
+    }
+
+    function isStringInt(str) {
+      return /^\d+$/.test(str);
+    }
+
+    //Fast tree
+    var uuidNode = 1 // zero is root
+    function format_for_fast_treeview(parentKey, data, arr) {
+      var objectName = ""
+      var objectNamespace = ""
+      for (var key in data) {
+        if (data[key] == null || key == "managedFields") {
+          continue
+        }
+        if (key.toLowerCase() == "name") {
+          objectName = data[key]
+        }
+        if (key.toLowerCase() == "namespace") {
+          objectNamespace = data[key]
+        }
+        var objectID = uuidNode++
+        if (Array.isArray(data[key]) || data[key].toString() === "[object Object]") {
+          // when data[key] is an array or object
+
+          var [arrRet, childName, childNamespace] = format_for_fast_treeview(objectID, data[key], arr);
+          if (childName != "") {
+            objectName = childName
+            objectNamespace = childNamespace
+          }
+          var nameToPush = key
+          if (isStringInt(key) && objectName != "") {
+            nameToPush = "ns:" + objectNamespace + " name:" + objectName
+            objectName = ""
+            objectNamespace = ""
+          }
+
+          arr.push({
+            id: objectID.toString(),
+            name: nameToPush,
+            parent: parentKey.toString()
+          });
+        } else {
+          // when data[key] is just strings or integer values
+          arr.push({
+            id: objectID.toString(),
+            name: key + " : " + data[key],
+            parent: parentKey.toString()
+          });
+        }
+      }
+      return [arr, objectName, objectNamespace];
+    }
+
+    function orphans(data) {
+      return data.filter(function (item) {
+        return item.parent === "0";
+      });
+    }
+
+    function hasChildren(data, parentId) {
+      return data.some(function (item) {
+        return item.parent === parentId;
+      });
+    }
+
+    function getChildren(data, parentId) {
+      return data.filter(function (item) {
+        return item.parent === parentId;
+      });
+    }
+
+    function generateListItem(data, item) {
+      const li = document.createElement('li');
+      li.id = 'item-' + item.id;
+      if (hasChildren(data, item.id)) {
+        const a = document.createElement('a');
+        a.href = '#';
+        a.textContent = '+';
+        a.classList.add('plus');
+        a.title = "hold shift to expand sub tree"
+        a.addEventListener('click', expand.bind(null, data), { once: true });
+        li.appendChild(a);
+      }
+      const span = document.createElement('span');
+      span.textContent = item.name;
+      li.appendChild(span);
+      return li;
+    }
+
+    function expand(data, event) {
+      event.preventDefault();
+      event.stopPropagation();
+      const et = event.target,
+        parent = et.parentElement,
+        id = parent.id.replace('item-', ''),
+        kids = getChildren(data, id),
+        items = kids.map(generateListItem.bind(null, data)),
+        ul = document.createElement('ul');
+      items.forEach(function (li) {
+        ul.appendChild(li);
+      });
+      parent.appendChild(ul);
+      et.classList.remove('plus');
+      et.classList.add('minus');
+      et.textContent = '-';
+      et.addEventListener('click', collapse.bind(null, data), { once: true });
+
+      if (event.shiftKey) {
+        max = countChildren(data, id, 0)
+        console.log(max)
+        initProgressBar()
+        expandAll({ value: ul }, max, { value: 2 })
+        return
+      }
+    }
+
+    function collapse(data, event) {
+      event.preventDefault();
+      event.stopPropagation();
+      const et = event.target,
+        parent = et.parentElement,
+        ul = parent.querySelector('ul');
+      parent.removeChild(ul);
+      et.classList.remove('minus');
+      et.classList.add('plus');
+      et.textContent = '+';
+      et.addEventListener('click', expand.bind(null, data), { once: true });
+    }
+
+    function addOrphans(data, rootObject) {
+      const root = document.querySelector(rootObject),
+        orphansArray = orphans(data);
+      if (orphansArray.length) {
+        const items = orphansArray.map(generateListItem.bind(null, data)),
+          ul = document.createElement('ul');
+        items.forEach(function (li) {
+          ul.appendChild(li);
+        });
+        root.appendChild(ul);
+      }
+    }
+
+    function expandAll(obj, max, count) {
+      if (isAnchorElement(obj.value)) {
+        const clickEvent = new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+          view: window
+        });
+        obj.value.dispatchEvent(clickEvent);
+      }
+      count.value++
+      percent = count.value * 100 / max
+      updateProgressBar(percent)
+      // Check if the object has children
+      if (obj.value.children.length > 0) {
+        // Iterate through the children and recursively process each child
+        setTimeout(function () {
+          for (let i = 0; i < obj.value.children.length; i++) {
+            const child = obj.value.children[i];
+            expandAll({ value: child }, max, count);
+          }
+        }, 0);
+      }
+    }
+
+    function isAnchorElement(obj) {
+      return obj instanceof HTMLAnchorElement;
+    }
+
+    function isListElement(obj) {
+      return obj instanceof HTMLUListElement;
+    }
+
+
+    function countChildren(data, id, count) {
+      kids = getChildren(data, id);
+      count++;
+      if (kids.length > 0) {
+        count += 2
+      }
+      kids.forEach(function (kid) {
+        count = countChildren(data, kid.id, count) + 1
+      });
+      return count;
+    }
+
+    function updateProgressBar(value) {
+      const progressBar = document.querySelector('.progress-bar');
+      const strippedStr = progressBar.style.width.replace(/%/g, '');
+      currentValue = parseInt(strippedStr)
+      if (value >= currentValue + 2) {
+        progressBar.style.width = value.toString() + '%';
+      }
+
+    }
+
+    function initProgressBar() {
+      const progressBar = document.querySelector('.progress-bar');
+      progressBar.style.width = "0%"
+    }
   </script>
 </body>
 

--- a/script/results.html
+++ b/script/results.html
@@ -5,22 +5,24 @@
   <meta charset=utf-8>
   <title>CNF Certification Test Results</title>
   <meta charset="utf-8">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/css/bootstrap.min.css" rel="stylesheet"
-    integrity="sha384-KK94CHFLLe+nY2dmCWGMq91rCGa5gtU4mk92HdvYe+M/SXH301p5ILy+dN9+nJOZ" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://getbootstrap.com/docs/5.3/assets/css/docs.css" rel="stylesheet">
 
+
+  <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
+  <script src="https://cdn.jsdelivr.net/npm/dayjs@1.10.4/dayjs.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dayjs@1.10.4/plugin/duration.min.js"></script>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"
+    integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://unpkg.com/ansi_up@5.1.0/ansi_up.js" crossorigin="anonymous"></script>
   <style type="text/css">
     li.dropdown-menu {
       background-color: white;
     }
 
-    table {
-      border-collapse: collapse;
-    }
-
-    table td {
-      border: 1px solid #000;
-    }
 
     tg {
       background-color: #28a745;
@@ -36,6 +38,60 @@
 
     tgy {
       background-color: #ced4da;
+    }
+
+    body {
+      font-family: sans-serif;
+    }
+
+    ul {
+      list-style: none;
+      padding-left: 1.75em;
+    }
+
+    ul li {
+      border-bottom-left-radius: 0.75em;
+      border-top-left-radius: 0.75em;
+      margin: 2px 0;
+      position: relative;
+    }
+
+    ul li a {
+      background-color: #eee;
+      border-radius: 50%;
+      color: #000;
+      display: inline-block;
+      height: 1.5em;
+      left: -1.5em;
+      line-height: 1.5em;
+      position: absolute;
+      text-align: center;
+      text-decoration: none;
+      width: 1.5em;
+    }
+
+    ul li a.plus {
+      background-color: #77aeff;
+    }
+
+    ul li a.minus {
+      background-color: #eee;
+    }
+
+    ul li a:active {
+      top: 1px;
+    }
+
+    ul li span {
+      display: inline-block;
+      margin: 0.25em 0.5em;
+    }
+
+    .top-right {
+      font-size: small;
+      position: fixed;
+      right: 1em;
+      top: 1em;
     }
   </style>
 </head>
@@ -62,12 +118,15 @@
   <button class="w3-button w3-right w3-light-grey" id="download" type="submit" onclick=download()
     hidden="hidden">Download Results Feedback</button>
 
-    <button class="w3-button w3-right w3-light-grey" id="downloadjson" type="submit" onclick=downloadjson()
+  <button class="w3-button w3-right w3-light-grey" id="downloadjson" type="submit" onclick=downloadjson()
     hidden="hidden">Download Feedback as a JSON file</button>
-    <p hidden="hidden" id ="UploadFeedback">
-      Upload Feedback File: <input type="file" id="feedbackFile" size="40">
-      </p>
-
+  <p hidden="hidden" id="UploadFeedback">
+    Upload Feedback File: <input type="file" id="feedbackFile" size="40">
+  </p>
+  <div class="progress" role="progressbar" aria-label="Basic example" aria-valuenow="0" aria-valuemin="0"
+    aria-valuemax="100">
+    <div class="progress-bar" style="width: 0%"></div>
+  </div>
   <ul class="nav nav-tabs">
     <li class="nav-item">
       <button class="nav-link active" id="config-tab" data-bs-toggle="tab" data-bs-target="#config" type="button"
@@ -108,54 +167,47 @@
   </ul>
   <div class="tab-content" id="myTabContent">
     <div class="tab-pane fade show active" id="config" role="tabpanel" aria-labelledby="config-tab">
-      <table class="table table-hover table-bordered" id="config-table">
+      <div id="config-table">
+      </div>
+    </div>
+    <div class="table-responsive tab-pane fade" id="metadata" role="tabpanel" aria-labelledby="metadata-tab">
+      <table class="table" id="metadata-table">
       </table>
     </div>
-    <div class="tab-pane fade" id="metadata" role="tabpanel" aria-labelledby="metadata-tab">
-      <table class="table table-hover table-bordered" id="metadata-table">
-      </table>
-    </div>
-    <div class="tab-pane fade" id="nodes" role="tabpanel" aria-labelledby="nodes-tab">
-      <table class="table table-hover table-bordered" id="nodes-table">
+    <div class="table-responsive tab-pane fade" id="nodes" role="tabpanel" aria-labelledby="nodes-tab">
+      <table class="table" id="nodes-table">
       </table>
     </div>
 
-    <div class="tab-pane fade" id="results" role="tabpanel" aria-labelledby="result-tab">
-      <table class="table table-hover table-bordered" id="results-table" hidden="hidden">
+    <div class="tab-pane fade table-responsive" id="results" role="tabpanel" aria-labelledby="result-tab">
+      <table class="table" id="results-table" hidden="hidden">
       </table>
-      <table class="table table-hover table-bordered" id="mandatory-far-edge-table" hidden="hidden">
+      <table class="table" id="mandatory-far-edge-table" hidden="hidden">
       </table>
-      <table class="table table-hover table-bordered" id="optional-far-edge-table" hidden="hidden">
+      <table class="table" id="optional-far-edge-table" hidden="hidden">
       </table>
-      <table class="table table-hover table-bordered" id="mandatory-telco-table" hidden="hidden">
+      <table class="table" id="mandatory-telco-table" hidden="hidden">
       </table>
-      <table class="table table-hover table-bordered" id="optional-telco-table" hidden="hidden">
+      <table class="table" id="optional-telco-table" hidden="hidden">
       </table>
-      <table class="table table-hover table-bordered" id="mandatory-non-telco-table" hidden="hidden">
+      <table class="table" id="mandatory-non-telco-table" hidden="hidden">
       </table>
-      <table class="table table-hover table-bordered" id="optional-non-telco-table" hidden="hidden">
-        <table class="table table-hover table-bordered" id="mandatory-extended-table" hidden="hidden">
+      <table class="table" id="optional-non-telco-table" hidden="hidden">
+        <table class="table" id="mandatory-extended-table" hidden="hidden">
         </table>
-        <table class="table table-hover table-bordered" id="optional-extended-table" hidden="hidden">
+        <table class="table" id="optional-extended-table" hidden="hidden">
         </table>
     </div>
 
 
-    <div class="tab-pane fade" id="versions" role="tabpanel" aria-labelledby="versions-tab">
-      <table class="table table-hover table-bordered" id="versions-table">
+
+    <div class="table-responsive tab-pane fade" id="versions" role="tabpanel" aria-labelledby="versions-tab">
+      <table class="table" id="versions-table">
       </table>
     </div>
   </div>
   </div>
-  <script src="https://cdn.jsdelivr.net/npm/dayjs@1.10.4/dayjs.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/dayjs@1.10.4/plugin/duration.min.js"></script>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"
-    integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
-    crossorigin="anonymous"></script>
-  <script src="https://unpkg.com/ansi_up@5.1.0/ansi_up.js" crossorigin="anonymous"></script>
   <!-- We should extract the javascript code to a separate file, but if we include it here we can just use a single file HTMl, which is handy -->
   <!--    <script src="./utils.js"></script> -->
   <script>
@@ -272,7 +324,7 @@
       document.getElementById("download").removeAttribute("hidden");
       document.getElementById("downloadjson").removeAttribute("hidden");
       document.getElementById("UploadFeedback").removeAttribute("hidden");
-      
+
     }
 
 
@@ -337,7 +389,7 @@
       if (typeof input === 'string') {
         text = input
       } else if (Array.isArray(input)) {
-        text += '<table class="table table-light table-bordered">'
+        text += '<div class="table-responsive"><table class="table table-light table-bordered">'
         // Gather header from first item
         text += '<thead><tr>'
 
@@ -359,15 +411,15 @@
           }
           text += '</tr>'
         }
-        text += '</tbody></table>'
+        text += '</tbody></table></div>'
       } else if (typeof input === 'object' && input !== null) {
-        text += '<table class="table table-light table-bordered"><tbody>'
+        text += '<div class="table-responsive"><table class="table table-light table-bordered"><tbody>'
         // Go down the rabbit hole
         for (const key in input) {
           text += '<tr><td><b>' + key + '</b></td><td>'
           text += innerFill(input[key]) + '</td></tr>'
         }
-        text += '</tbody></table>'
+        text += '</tbody></table></div>'
       } else {
         // What else could it be?
         text = input
@@ -460,7 +512,7 @@
           }
         }
       }
-      text += '<th scope="col" class="th-sm">Test ID</th>'
+      text += '<th>Test ID</th>'
       tableNameMap = {
         "faredge": "Far-Edge",
         "telco": "Telco",
@@ -541,15 +593,16 @@
             text += key + '</button></h2>'
             // Now we should populate the item contents
             text += '<div id="' + itemid + '" class="accordion-collapse collapse" aria-labelledby="' + headingid + '">'
-            text += '<div class="accordion-body">'
+            text += '<div class="accordion-body" >'
             // Inside the accordion, 1 table with the following colummns
             text += '<h1>Results</h1>'
-            text += '<table id="myTable-' + key + '"class="table table-bordered table-fixed"><thead><tr>'
-            text += '<th scope="col" class="th-sm">Test ID</th>'
-            text += '<th scope="col" class="th-sm">Test Text</th>'
-            text += '<th scope="col" class="th-sm">Duration</th>'
-            text += '<th scope="col" class="th-sm">State</th>'
-            text += '<th scope="col" class="th-lg">Test output</th>'
+            text += '<div class="table-responsive">'
+            text += '<table id="myTable-' + key + '" class="table table-bordered"><thead><tr>'
+            text += '<th>Test ID</th>'
+            text += '<th class="th-lg">Test Text</th>'
+            text += '<th>Duration</th>'
+            text += '<th>State</th>'
+            text += '<th>Test output</th>'
             text += '</tr></thead><tbody>'
 
             // Note we are skipping some columns for now
@@ -560,10 +613,10 @@
             for (const item of input[key]) {
               const duration = dayjs.duration(item.duration / 1000000)
               formattedDuration = duration.format('D[d] H[h] m[m] s[s] SSS[ms]')
-              text += '<tr><td>' + item.testID.id + '</td>'
-              text += '<td>' + item.testText.replace(/\n/g, '<br>') + '</td>'
+              text += '<tr><td  style="white-space: nowrap;">' + item.testID.id + '</td>'
+              text += '<td class="th-lg">' + item.testText.replace(/\n/g, '<br>') + '</td>'
               text += '<td>' + formattedDuration + '</td>'
-              text += '<td>' + item.state + '</td>'
+              text += '<td style="white-space: nowrap;">' + item.state + '</td>'
               text += '<td>' + ansi_up.ansi_to_html(item.CapturedTestOutput).replace(/\n/g, '<br>') + '</td></tr>'
               jsonObjNonCompliant = NonCompliantReasonTextToJson(item.CapturedTestOutput)
               jsonObjCompliant = CompliantReasonTextToJson(item.CapturedTestOutput)
@@ -572,7 +625,7 @@
             id = id + 1
             if (eqData == "Optional" && tableName != "all") {
               text2 += text
-              text2 += '</tbody></table>'
+              text2 += '</tbody></table></div>'
               for (const item of input[key]) {
                 text2 += '<h1>Feedback</h1><label>Write your feedback for ' + item.testID.id + ' test case</label>'
                 text2 += '<textarea style="width: 100%; margin: 0 auto;" rows = "5" id="source-' + tableName + '-' + item.testID.id + '" type="text" ></textarea>'
@@ -584,7 +637,7 @@
               text2 += '</div></div></div>'
             } else {
               text3 += text
-              text3 += '</tbody></table>'
+              text3 += '</tbody></table></div>'
               for (const item of input[key]) {
                 text3 += '<h1>Feedback</h1><label>Write your feedback for ' + item.testID.id + ' test case</label>'
                 text3 += '<textarea style="width: 100%; margin: 0 auto;" rows = "5" id="source-' + tableName + '-' + item.testID.id + '" type="text"></textarea>'
@@ -606,12 +659,12 @@
       $(text2).appendTo($(element2))
     }
 
-    function fillFeedback(input){
-      for ( key in input) { 
+    function fillFeedback(input) {
+      for (key in input) {
         // copy previus daata
-          document.getElementById(key).textContent = document.getElementById(key).value;
-          document.getElementById(key).textContent = input[key]
-          document.getElementById(key).value=input[key]
+        document.getElementById(key).textContent = document.getElementById(key).value;
+        document.getElementById(key).textContent = input[key]
+        document.getElementById(key).value = input[key]
       }
     }
 
@@ -664,8 +717,20 @@
         let fileUploaded = new FileReader();
         fileUploaded.addEventListener("load", e => {
           json = JSON.parse(fileUploaded.result)
-          fillConfig(json.claim.configurations, '#config-table')
-          fillConfig(json.claim.nodes, '#nodes-table')
+          //fillConfig(json.claim.configurations, '#config-table')
+
+
+          // Create treeview from JSON data
+          var container = document.getElementById("config-table");
+          //var [configurationsArr, childName, childNamespace] = format_for_treeview("", json.claim.configurations, [])
+          //createTreeView(container, configurationsArr, 0);
+          var [data, dummy, dummy] = format_for_fast_treeview(0, json.claim.configurations, [])
+          addOrphans(data, "#config-table");
+          //expandAll(document.querySelector("#config-table"));
+          var [data, dummy, dummy] = format_for_fast_treeview(0, json.claim.nodes, [])
+          addOrphans(data, "#nodes-table");
+          //expandAll(document.querySelector("#nodes-table"));
+          //fillConfig(json.claim.nodes, '#nodes-table')
           fillMetadata(json.claim.metadata, '#metadata-table')
           fillVersions(json.claim.versions, '#versions-table')
           fillResults(json.claim.results, classification, '#results-table', '#optional-', "all")
@@ -746,33 +811,33 @@
       return doc.documentElement.outerHTML
     }
     function downloadjson() {
-      var dict = {}; 
-      const tablesName = ["all","telco","nontelco","extended","faredge"]; // to go over all the feedback and save it
+      var dict = {};
+      const tablesName = ["all", "telco", "nontelco", "extended", "faredge"]; // to go over all the feedback and save it
       for (const key in this.json.claim.results) {
         for (const key2 in this.classification) {
           if (key == key2) {
-            for (let i = 0; i <  tablesName.length; i++) {
-                var keydict='source-'+tablesName[i]+'-'+key
-                var data = document.getElementById(keydict)
-                if (data != null){
-                  dict[keydict]=data.value 
+            for (let i = 0; i < tablesName.length; i++) {
+              var keydict = 'source-' + tablesName[i] + '-' + key
+              var data = document.getElementById(keydict)
+              if (data != null) {
+                dict[keydict] = data.value
               }
             }
-     
+
+          }
         }
       }
-    }
-  
-    var pom = document.createElement('a');
-  pom.setAttribute('href', 'data:text/json;charset=utf-8,' + 
 
-encodeURIComponent(JSON.stringify(dict)));
-  pom.setAttribute('download', "feedback.json");
-  pom.style.display = 'none';
-  document.body.appendChild(pom);
-  pom.click();
-  document.body.removeChild(pom);
-  }
+      var pom = document.createElement('a');
+      pom.setAttribute('href', 'data:text/json;charset=utf-8,' +
+
+        encodeURIComponent(JSON.stringify(dict)));
+      pom.setAttribute('download', "feedback.json");
+      pom.style.display = 'none';
+      document.body.appendChild(pom);
+      pom.click();
+      document.body.removeChild(pom);
+    }
 
     function download() {
       var selectBox = document.getElementById("selectBox");
@@ -870,7 +935,9 @@ encodeURIComponent(JSON.stringify(dict)));
       var allTables = ""
       aTypeMap.forEach(function (value, key) {
         allTables += '<h2> Type: ' + key + '</h2>'
+        allTables += '<div class="table-responsive">'
         allTables += createReasonTableOneType(jsonData, key)
+        allTables += '</div>'
       })
       return allTables
     }
@@ -896,7 +963,7 @@ encodeURIComponent(JSON.stringify(dict)));
           // Create table header
           var thead = document.createElement('thead');
           var headerRow = document.createElement('tr');
-          Object.keys(item.ObjectFields).forEach(function (key) {
+          Object.values(item.ObjectFieldsKeys).forEach(function (key) {
             var th = document.createElement('th');
             th.textContent = key;
             headerRow.appendChild(th);
@@ -906,7 +973,7 @@ encodeURIComponent(JSON.stringify(dict)));
           firstItem = false
         }
         var row = document.createElement('tr');
-        Object.values(item.ObjectFields).forEach(function (value) {
+        Object.values(item.ObjectFieldsValues).forEach(function (value) {
           var cell = document.createElement('td');
           cell.textContent = value;
           row.appendChild(cell);
@@ -917,6 +984,248 @@ encodeURIComponent(JSON.stringify(dict)));
       return table.outerHTML
     }
 
+    function format_for_treeview(parentKey, data, arr) {
+      var objectName = ""
+      var objectNamespace = ""
+      for (var key in data) {
+        if (data[key] == null || key == "managedFields") {
+          continue
+        }
+        if (key.toLowerCase() == "name") {
+          objectName = data[key]
+        }
+        if (key.toLowerCase() == "namespace") {
+          objectNamespace = data[key]
+        }
+        if (Array.isArray(data[key]) || data[key].toString() === "[object Object]") {
+          // when data[key] is an array or object
+          var nodes = [];
+          var [completedNodes, childName, childNamespace] = format_for_treeview(key, data[key], nodes);
+          if (childName != "") {
+            objectName = childName
+            objectNamespace = childNamespace
+          }
+          var nameToPush = key
+          if (isStringInt(key) && objectName != "") {
+            nameToPush = "ns:" + objectNamespace + " name:" + objectName
+            objectName = ""
+            objectNamespace = ""
+          }
+
+          arr.push({
+            name: nameToPush,
+            children: completedNodes
+          });
+        } else {
+          // when data[key] is just strings or integer values
+          arr.push({
+            name: key + " : " + data[key]
+          });
+        }
+      }
+      return [arr, objectName, objectNamespace];
+    }
+
+    function isStringInt(str) {
+      return /^\d+$/.test(str);
+    }
+
+    //Fast tree
+    var uuidNode = 1 // zero is root
+    function format_for_fast_treeview(parentKey, data, arr) {
+      var objectName = ""
+      var objectNamespace = ""
+      for (var key in data) {
+        if (data[key] == null || key == "managedFields") {
+          continue
+        }
+        if (key.toLowerCase() == "name") {
+          objectName = data[key]
+        }
+        if (key.toLowerCase() == "namespace") {
+          objectNamespace = data[key]
+        }
+        var objectID = uuidNode++
+        if (Array.isArray(data[key]) || data[key].toString() === "[object Object]") {
+          // when data[key] is an array or object
+
+          var [arrRet, childName, childNamespace] = format_for_fast_treeview(objectID, data[key], arr);
+          if (childName != "") {
+            objectName = childName
+            objectNamespace = childNamespace
+          }
+          var nameToPush = key
+          if (isStringInt(key) && objectName != "") {
+            nameToPush = "ns:" + objectNamespace + " name:" + objectName
+            objectName = ""
+            objectNamespace = ""
+          }
+
+          arr.push({
+            id: objectID.toString(),
+            name: nameToPush,
+            parent: parentKey.toString()
+          });
+        } else {
+          // when data[key] is just strings or integer values
+          arr.push({
+            id: objectID.toString(),
+            name: key + " : " + data[key],
+            parent: parentKey.toString()
+          });
+        }
+      }
+      return [arr, objectName, objectNamespace];
+    }
+
+    function orphans(data) {
+      return data.filter(function (item) {
+        return item.parent === "0";
+      });
+    }
+
+    function hasChildren(data, parentId) {
+      return data.some(function (item) {
+        return item.parent === parentId;
+      });
+    }
+
+    function getChildren(data, parentId) {
+      return data.filter(function (item) {
+        return item.parent === parentId;
+      });
+    }
+
+    function generateListItem(data, item) {
+      const li = document.createElement('li');
+      li.id = 'item-' + item.id;
+      if (hasChildren(data, item.id)) {
+        const a = document.createElement('a');
+        a.href = '#';
+        a.textContent = '+';
+        a.classList.add('plus');
+        a.title = "hold shift to expand sub tree"
+        a.addEventListener('click', expand.bind(null, data), { once: true });
+        li.appendChild(a);
+      }
+      const span = document.createElement('span');
+      span.textContent = item.name;
+      li.appendChild(span);
+      return li;
+    }
+
+    function expand(data, event) {
+      event.preventDefault();
+      event.stopPropagation();
+      const et = event.target,
+        parent = et.parentElement,
+        id = parent.id.replace('item-', ''),
+        kids = getChildren(data, id),
+        items = kids.map(generateListItem.bind(null, data)),
+        ul = document.createElement('ul');
+      items.forEach(function (li) {
+        ul.appendChild(li);
+      });
+      parent.appendChild(ul);
+      et.classList.remove('plus');
+      et.classList.add('minus');
+      et.textContent = '-';
+      et.addEventListener('click', collapse.bind(null, data), { once: true });
+
+      if (event.shiftKey) {
+        max = countChildren(data, id, 0)
+        console.log(max)
+        initProgressBar()
+        expandAll({ value: ul }, max, { value: 2 })
+        return
+      }
+    }
+
+    function collapse(data, event) {
+      event.preventDefault();
+      event.stopPropagation();
+      const et = event.target,
+        parent = et.parentElement,
+        ul = parent.querySelector('ul');
+      parent.removeChild(ul);
+      et.classList.remove('minus');
+      et.classList.add('plus');
+      et.textContent = '+';
+      et.addEventListener('click', expand.bind(null, data), { once: true });
+    }
+
+    function addOrphans(data, rootObject) {
+      const root = document.querySelector(rootObject),
+        orphansArray = orphans(data);
+      if (orphansArray.length) {
+        const items = orphansArray.map(generateListItem.bind(null, data)),
+          ul = document.createElement('ul');
+        items.forEach(function (li) {
+          ul.appendChild(li);
+        });
+        root.appendChild(ul);
+      }
+    }
+
+    function expandAll(obj, max, count) {
+      if (isAnchorElement(obj.value)) {
+        const clickEvent = new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+          view: window
+        });
+        obj.value.dispatchEvent(clickEvent);
+      }
+      count.value++
+      percent = count.value * 100 / max
+      updateProgressBar(percent)
+      // Check if the object has children
+      if (obj.value.children.length > 0) {
+        // Iterate through the children and recursively process each child
+        setTimeout(function () {
+          for (let i = 0; i < obj.value.children.length; i++) {
+            const child = obj.value.children[i];
+            expandAll({ value: child }, max, count);
+          }
+        }, 0);
+      }
+    }
+
+    function isAnchorElement(obj) {
+      return obj instanceof HTMLAnchorElement;
+    }
+
+    function isListElement(obj) {
+      return obj instanceof HTMLUListElement;
+    }
+
+
+    function countChildren(data, id, count) {
+      kids = getChildren(data, id);
+      count++;
+      if (kids.length > 0) {
+        count += 2
+      }
+      kids.forEach(function (kid) {
+        count = countChildren(data, kid.id, count) + 1
+      });
+      return count;
+    }
+
+    function updateProgressBar(value) {
+      const progressBar = document.querySelector('.progress-bar');
+      const strippedStr = progressBar.style.width.replace(/%/g, '');
+      currentValue = parseInt(strippedStr)
+      if (value >= currentValue + 2) {
+        progressBar.style.width = value.toString() + '%';
+      }
+
+    }
+
+    function initProgressBar() {
+      const progressBar = document.querySelector('.progress-bar');
+      progressBar.style.width = "0%"
+    }
   </script>
 </body>
 


### PR DESCRIPTION
This PR adds the following: 
- failure reason for connectivity tests
- better rendering of failure reason fields. Now the fields are ordered by the addition order. A list is used instead of a map to store the order. Fixed html to better scale
- added fast rendering of configuration items. Added a progress bar when loading large set of objects
Note: the format of the failure reason is changed so new claim files would not be able to be parsed with older pages