### PR TITLE
Fix network policy tests with empty podSelector

### DIFF
--- a/cnf-certification-test/networking/policies/policies.go
+++ b/cnf-certification-test/networking/policies/policies.go
@@ -62,6 +62,12 @@ func IsNetworkPolicyCompliant(np *networkingv1.NetworkPolicy, policyType network
 
 func LabelsMatch(podSelectorLabels v1.LabelSelector, podLabels map[string]string) bool {
 	labelMatch := false
+
+	// When the pod selector label is empty, it will always match the pod
+	if podSelectorLabels.Size() == 0 {
+		return true
+	}
+
 	for psLabelKey, psLabelValue := range podSelectorLabels.MatchLabels {
 		for podLabelKey, podLabelValue := range podLabels {
 			if psLabelKey == podLabelKey && psLabelValue == podLabelValue {

--- a/cnf-certification-test/networking/policies/policies_test.go
+++ b/cnf-certification-test/networking/policies/policies_test.go
@@ -178,8 +178,7 @@ func TestIsNetworkPolicyCompliant(t *testing.T) {
 					Name: "test1",
 				},
 				Spec: networkingv1.NetworkPolicySpec{
-					PodSelector: metav1.LabelSelector{
-					},
+					PodSelector: metav1.LabelSelector{},
 					PolicyTypes: []networkingv1.PolicyType{
 						networkingv1.PolicyTypeIngress,
 					},
@@ -188,7 +187,6 @@ func TestIsNetworkPolicyCompliant(t *testing.T) {
 			expectedIngressOutput: true,
 			expectedEgressOutput:  false,
 		},
-
 	}
 
 	for _, tc := range testCases {
@@ -237,8 +235,7 @@ func TestLabelsMatch(t *testing.T) {
 			expectedOutput: false,
 		},
 		{ // Test Case #4 - empty pod selector label
-			testPodSelectorLabels: metav1.LabelSelector{
-			},
+			testPodSelectorLabels: metav1.LabelSelector{},
 			testPodLabels: map[string]string{
 				"label1": "value2",
 			},

--- a/cnf-certification-test/networking/policies/policies_test.go
+++ b/cnf-certification-test/networking/policies/policies_test.go
@@ -172,6 +172,23 @@ func TestIsNetworkPolicyCompliant(t *testing.T) {
 			expectedIngressOutput: false,
 			expectedEgressOutput:  false, // ingress spec fails because specified
 		},
+		{ // Test #7 - Network Policy with no label selector, ingress policy types
+			testNP: networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test1",
+				},
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+					},
+					PolicyTypes: []networkingv1.PolicyType{
+						networkingv1.PolicyTypeIngress,
+					},
+				},
+			},
+			expectedIngressOutput: true,
+			expectedEgressOutput:  false,
+		},
+
 	}
 
 	for _, tc := range testCases {
@@ -218,6 +235,14 @@ func TestLabelsMatch(t *testing.T) {
 				"label1": "value2",
 			},
 			expectedOutput: false,
+		},
+		{ // Test Case #4 - empty pod selector label
+			testPodSelectorLabels: metav1.LabelSelector{
+			},
+			testPodLabels: map[string]string{
+				"label1": "value2",
+			},
+			expectedOutput: true,
 		},
 	}
 


### PR DESCRIPTION
Currently, the networking-network-policy-deny-all test case expects network policies to not have an empty pod selector, and fails to detect default deny-all policies like the one described in [1].

This commit changes that behavior, and modifies the pod selector logic, to match the behavior described in the documentation: "An empty podSelector selects all pods in the namespace."

[1] - https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-deny-all-ingress-traffic