### PR TITLE
Update GolangCI to 1.53.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - depguard
     - dogsled
     - errcheck
     - exhaustive
@@ -70,7 +69,6 @@ linters:
     - ineffassign
     - lll
     - misspell
-    - nakedret
     - nolintlint
     - revive
     - rowserrcheck
@@ -83,6 +81,7 @@ linters:
     - whitespace
   # do not enable:
   # - asciicheck
+  # - depguard
   # - dupl
   # - gochecknoglobals
   # - gochecknoinits
@@ -91,6 +90,7 @@ linters:
   # - godox
   # - goerr113
   # - maligned
+  # - nakedret
   # - nestif
   # - noctx
   # - prealloc
@@ -121,6 +121,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.52.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.53.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ COMMON_GO_ARGS=-race
 GIT_COMMIT=$(shell script/create-version-files.sh)
 GIT_RELEASE=$(shell script/get-git-release.sh)
 GIT_PREVIOUS_RELEASE=$(shell script/get-git-previous-release.sh)
-GOLANGCI_VERSION=v1.52.2
+GOLANGCI_VERSION=v1.53.2
 LINKER_TNF_RELEASE_FLAGS=-X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitCommit=${GIT_COMMIT}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitRelease=${GIT_RELEASE}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitPreviousRelease=${GIT_PREVIOUS_RELEASE}

--- a/docs/test-standalone.md
+++ b/docs/test-standalone.md
@@ -34,7 +34,7 @@ make install-tools
 Dependency|Minimum Version
 ---|---
 [GoLang](https://golang.org/dl/)|1.20
-[golangci-lint](https://golangci-lint.run/usage/install/)|1.52.2
+[golangci-lint](https://golangci-lint.run/usage/install/)|1.53.2
 [jq](https://stedolan.github.io/jq/)|1.6
 [OpenShift Client](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/)|4.12
 


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.53.2

I also had to remove `depguard` and `nakeret` from the config as there were new failures. 