### PR TITLE
Only chmod if Linux runner

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -68,6 +68,7 @@ jobs:
         if: runner.os == 'macOS'
 
       - run: chmod +x $CM_BIN
+        if: runner.os == 'Linux'
 
       - name: Install hadolint (Linux)
         run: |


### PR DESCRIPTION
We don't need to `chmod` the binary if not linux based runner.