### PR TITLE
Fix for hardcoded registry registry.redhat.io

### DIFF
--- a/docs/test-standalone.md
+++ b/docs/test-standalone.md
@@ -126,7 +126,6 @@ To run the tests in an offline environment, skip the tests using the `l` option.
 
 Alternatively, if an offline DB for containers, helm charts and operators is available, there is no need to skip those tests if the environment variable `TNF_OFFLINE_DB` is set to the DB location. This DB can be generated using the [OCT tool](https://github.com/test-network-function/oct).
 
-
 Note: Only partner certified images are stored in the offline database. If Redhat images are checked against the offline database, they will show up as not certified. The online database includes both Partner and Redhat images.
 
 #### Output tar.gz file with results and web viewer files

--- a/docs/test-standalone.md
+++ b/docs/test-standalone.md
@@ -126,6 +126,9 @@ To run the tests in an offline environment, skip the tests using the `l` option.
 
 Alternatively, if an offline DB for containers, helm charts and operators is available, there is no need to skip those tests if the environment variable `TNF_OFFLINE_DB` is set to the DB location. This DB can be generated using the [OCT tool](https://github.com/test-network-function/oct).
 
+
+Note: Only partner certified images are stored in the offline database. If Redhat images are checked against the offline database, they will show up as not certified. The online database includes both Partner and Redhat images.
+
 #### Output tar.gz file with results and web viewer files
 
 After running all the test cases, a compressed file will be created with all the results files and web artifacts to review them.

--- a/internal/certdb/config/config.go
+++ b/internal/certdb/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2022 Red Hat, Inc.
+// Copyright (C) 2020-2023 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/internal/certdb/config/config.go
+++ b/internal/certdb/config/config.go
@@ -15,12 +15,6 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 package config
 
-import (
-	"time"
-
-	"github.com/sirupsen/logrus"
-)
-
 const (
 	registryRedhatIo        = "registry.redhat.io"
 	registryAccessRedhatCom = "registry.access.redhat.com"
@@ -30,13 +24,6 @@ const (
 var HardcodedRegistryMapping = map[string]string{registryRedhatIo: registryAccessRedhatCom}
 
 // determines certification status for Redhat images
-func IsRegistryRedhatOnlyImages(registry, publishedDate string) bool {
-	oneYearAgo := time.Now().AddDate(-1, 0, 0)
-	date, err := time.Parse("2006-01-02T15:04:05.999999-07:00", publishedDate)
-	if err != nil {
-		logrus.Errorf("could not parse image published date, container is not certified, err=%s", err)
-		return false
-	}
-
-	return (registry == registryRedhatIo || registry == registryAccessRedhatCom) && date.After(oneYearAgo)
+func IsRegistryRedhatOnlyImages(registry string) bool {
+	return registry == registryRedhatIo || registry == registryAccessRedhatCom
 }

--- a/internal/certdb/config/config.go
+++ b/internal/certdb/config/config.go
@@ -1,0 +1,42 @@
+// Copyright (C) 2020-2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+package config
+
+import (
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	registryRedhatIo        = "registry.redhat.io"
+	registryAccessRedhatCom = "registry.access.redhat.com"
+)
+
+// HardcodedRegistryMapping is map holding hardcoded entries in pyxis
+var HardcodedRegistryMapping = map[string]string{registryRedhatIo: registryAccessRedhatCom}
+
+// determines certification status for Redhat images
+func IsRegistryRedhatOnlyImages(registry, publishedDate string) bool {
+	oneYearAgo := time.Now().AddDate(-1, 0, 0)
+	date, err := time.Parse("2006-01-02T15:04:05.999999-07:00", publishedDate)
+	if err != nil {
+		logrus.Errorf("could not parse image published date, container is not certified, err=%s", err)
+		return false
+	}
+
+	return (registry == registryRedhatIo || registry == registryAccessRedhatCom) && date.After(oneYearAgo)
+}

--- a/internal/certdb/config/config_test.go
+++ b/internal/certdb/config/config_test.go
@@ -1,0 +1,16 @@
+// Copyright (C) 2020-2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+package config

--- a/internal/certdb/offlinecheck/container.go
+++ b/internal/certdb/offlinecheck/container.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
+	"github.com/test-network-function/cnf-certification-test/internal/certdb/config"
 )
 
 var (
@@ -34,17 +35,17 @@ type Tag struct {
 	Name string `json:"name"`
 }
 type Repository struct {
-	Registry   string `json:"registry"`
-	Repository string `json:"repository"`
-	Tags       []Tag  `json:"tags"`
+	Registry      string `json:"registry"`
+	Repository    string `json:"repository"`
+	Tags          []Tag  `json:"tags"`
+	PublishedDate string `json:"push_date"`
 }
 
 type ContainerCatalogEntry struct {
 	ID                string       `json:"_id"`
 	Architecture      string       `json:"architecture"`
 	Certified         bool         `json:"certified"`
-	DockerImageDigest string       `json:"docker_image_digest"`
-	DockerImageID     string       `json:"docker_image_id"` // image digest
+	DockerImageDigest string       `json:"image_id"`
 	Repositories      []Repository `json:"repositories"`
 }
 type ContainerPageCatalog struct {
@@ -95,6 +96,11 @@ func LoadBinary(bytes []byte, db map[string]*ContainerCatalogEntry) (entries int
 func (validator OfflineValidator) IsContainerCertified(registry, repository, tag, digest string) bool {
 	const tagLatest = "latest"
 
+	// overwrite registry value with hardcoded one due to Pyxis implementation
+	value, ok := config.HardcodedRegistryMapping[registry]
+	if ok {
+		registry = value
+	}
 	if digest != "" {
 		if _, ok := containerdb[digest]; ok {
 			logrus.Trace("container is certified based on digest", digest)

--- a/internal/certdb/offlinecheck/container_test.go
+++ b/internal/certdb/offlinecheck/container_test.go
@@ -72,33 +72,7 @@ const containersDBJSON = `{
 			 ]
 		  }
 	   ]
-	},
-	"sha256:d2c996db015285504e1203f33beb5385e9efbe93c34cc4ea69bab6fe5f9df0e4": {
-		"_id": "",
-		"architecture": "amd64",
-		"certified": false,
-		"image_id": "sha256:d2c996db015285504e1203f33beb5385e9efbe93c34cc4ea69bab6fe5f9df0e4",
-		"repositories": [
-		  {
-			"registry": "registry.access.redhat.com",
-			"repository": "openshift4/ose-kube-rbac-proxy",
-			"tags": [
-			  {
-				"name": "latest"
-			  },
-			  {
-				"name": "v4.13.0"
-			  },
-			  {
-				"name": "v4.13"
-			  },
-			  {
-				"name": "v4.13.0-202305262054.p0.g11b1439.assembly.stream"
-			  }
-			]
-		  }
-		]
-	  }
+	}
  }`
 
 func loadContainersDB() error {
@@ -126,14 +100,6 @@ func TestIsCertified(t *testing.T) {
 		digest                      string
 		expectedCertificationStatus bool
 	}{
-		// check hardcoded registry
-		{
-			registry:                    "registry.redhat.io",
-			repository:                  "openshift4/ose-kube-rbac-proxy",
-			tag:                         "v4.13.0-202305262054.p0.g11b1439.assembly.stream",
-			digest:                      "sha256:d2c996db015285504e1203f33beb5385e9efbe93c34cc4ea69bab6fe5f9df0e4",
-			expectedCertificationStatus: true,
-		},
 		// Check status based on the tag.
 		{
 			registry:                    "quay.io",

--- a/internal/certdb/offlinecheck/container_test.go
+++ b/internal/certdb/offlinecheck/container_test.go
@@ -29,7 +29,7 @@ const containersDBJSON = `{
 	   "_id":"",
 	   "architecture":"amd64",
 	   "certified":false,
-	   "docker_image_digest":"sha256:d2f388e163a5126f7112757f0475c8c4e036fe00c76ef8a7fd50848fafdcb96b",
+	   "image_id":"sha256:d2f388e163a5126f7112757f0475c8c4e036fe00c76ef8a7fd50848fafdcb96b",
 	   "docker_image_id":"",
 	   "repositories":[
 		  {
@@ -56,7 +56,7 @@ const containersDBJSON = `{
 	   "_id":"",
 	   "architecture":"amd64",
 	   "certified":false,
-	   "docker_image_digest":"sha256:fa8f2136aed9daf4c5a805068a87dd274016b8dddae36bc0b02e18b391690493",
+	   "image_id":"sha256:fa8f2136aed9daf4c5a805068a87dd274016b8dddae36bc0b02e18b391690493",
 	   "docker_image_id":"",
 	   "repositories":[
 		  {
@@ -72,7 +72,33 @@ const containersDBJSON = `{
 			 ]
 		  }
 	   ]
-	}
+	},
+	"sha256:d2c996db015285504e1203f33beb5385e9efbe93c34cc4ea69bab6fe5f9df0e4": {
+		"_id": "",
+		"architecture": "amd64",
+		"certified": false,
+		"image_id": "sha256:d2c996db015285504e1203f33beb5385e9efbe93c34cc4ea69bab6fe5f9df0e4",
+		"repositories": [
+		  {
+			"registry": "registry.access.redhat.com",
+			"repository": "openshift4/ose-kube-rbac-proxy",
+			"tags": [
+			  {
+				"name": "latest"
+			  },
+			  {
+				"name": "v4.13.0"
+			  },
+			  {
+				"name": "v4.13"
+			  },
+			  {
+				"name": "v4.13.0-202305262054.p0.g11b1439.assembly.stream"
+			  }
+			]
+		  }
+		]
+	  }
  }`
 
 func loadContainersDB() error {
@@ -100,6 +126,14 @@ func TestIsCertified(t *testing.T) {
 		digest                      string
 		expectedCertificationStatus bool
 	}{
+		// check hardcoded registry
+		{
+			registry:                    "registry.redhat.io",
+			repository:                  "openshift4/ose-kube-rbac-proxy",
+			tag:                         "v4.13.0-202305262054.p0.g11b1439.assembly.stream",
+			digest:                      "sha256:d2c996db015285504e1203f33beb5385e9efbe93c34cc4ea69bab6fe5f9df0e4",
+			expectedCertificationStatus: true,
+		},
 		// Check status based on the tag.
 		{
 			registry:                    "quay.io",

--- a/internal/certdb/onlinecheck/api_test.go
+++ b/internal/certdb/onlinecheck/api_test.go
@@ -25,6 +25,10 @@ import (
 func TestIsContainerCertified(t *testing.T) {
 	client := onlinecheck.NewOnlineValidator()
 	var v bool
+
+	// overwritten registry check
+	v = client.IsContainerCertified("registry.redhat.io", "openshift4/ose-kube-rbac-proxy", "v4.13.0-202305262054.p0.g11b1439.assembly.stream", "sha256:d2c996db015285504e1203f33beb5385e9efbe93c34cc4ea69bab6fe5f9df0e4")
+	assert.Equal(t, true, v) // true
 	v = client.IsContainerCertified("registry.connect.redhat.com", "rocketchat/rocketchat", "", "")
 	assert.Equal(t, true, v) // true
 	v = client.IsContainerCertified("registry.connect.redhat.com", "rocketchat/rocketchat", "0.56.0-1", "")

--- a/internal/certdb/onlinecheck/onlinecheck.go
+++ b/internal/certdb/onlinecheck/onlinecheck.go
@@ -100,7 +100,7 @@ func (validator OnlineValidator) getImageByDigest(digest string) (imageID string
 	}
 	if len(containerEntries.Data) > 0 {
 		for _, repo := range containerEntries.Data[0].Repositories {
-			if config.IsRegistryRedhatOnlyImages(repo.Registry, repo.PublishedDate) {
+			if config.IsRegistryRedhatOnlyImages(repo.Registry) {
 				log.Trace("This image is a Redhat provided image and is certified by default")
 				return containerEntries.Data[0].ID, nil
 			}
@@ -134,7 +134,7 @@ func (validator OnlineValidator) getImageByTag(registry, repository, tag string)
 	}
 	for _, v := range db {
 		for _, repo := range v.Repositories {
-			if config.IsRegistryRedhatOnlyImages(repo.Registry, repo.PublishedDate) {
+			if config.IsRegistryRedhatOnlyImages(repo.Registry) {
 				log.Trace("This image is a Redhat provided image and is certified by default")
 				return v.ID, nil
 			}
@@ -168,7 +168,7 @@ func (validator OnlineValidator) getImageByRepository(registry, repository strin
 	}
 	for _, v := range db {
 		for _, repo := range v.Repositories {
-			if config.IsRegistryRedhatOnlyImages(repo.Registry, repo.PublishedDate) {
+			if config.IsRegistryRedhatOnlyImages(repo.Registry) {
 				log.Trace("This image is a Redhat provided image and is certified by default")
 				return v.ID, nil
 			}


### PR DESCRIPTION
build-depends: 28703
The registry.redhat.io is hardcoded internally in Pyxis to registry.access.redhat.com. Rewrites registry when processing requests.
Note: Awaiting clarifications from Pyxis team on the on how to use the docker_image_id and image_id fields to consistently get the image digest value