### PR TITLE
Add report objects for manageability suite tests

### DIFF
--- a/cnf-certification-test/manageability/suite.go
+++ b/cnf-certification-test/manageability/suite.go
@@ -17,7 +17,6 @@
 package manageability
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
@@ -58,10 +57,10 @@ func testContainersImageTag(env *provider.TestEnvironment) {
 	for _, cut := range env.Containers {
 		logrus.Debugln("check container ", cut.String(), " image should be tagged ")
 		if cut.IsTagEmpty() {
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, fmt.Sprintf("Container %s is missing image tag(s)", cut.String()), false))
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container is missing image tag(s)", false))
 			tnf.ClaimFilePrintf("Container %s is missing image tag(s)", cut.String())
 		} else {
-			compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, fmt.Sprintf("Container %s is tagged", cut.String()), true))
+			compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container is tagged", true))
 		}
 	}
 	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
@@ -86,9 +85,9 @@ func testContainerPortNameFormat(env *provider.TestEnvironment) {
 		for _, port := range cut.Ports {
 			if !containerPortNameFormatCheck(port.Name) {
 				tnf.ClaimFilePrintf("%s: ContainerPort %s does not follow the partner naming conventions", cut, port.Name)
-				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, fmt.Sprintf("ContainerPort %s does not follow the partner naming conventions", port.Name), false))
+				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "ContainerPort does not follow the partner naming conventions", false))
 			} else {
-				compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, fmt.Sprintf("ContainerPort %s follows the partner naming conventions", port.Name), true))
+				compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "ContainerPort follows the partner naming conventions", true))
 			}
 		}
 	}

--- a/cnf-certification-test/manageability/suite.go
+++ b/cnf-certification-test/manageability/suite.go
@@ -85,9 +85,11 @@ func testContainerPortNameFormat(env *provider.TestEnvironment) {
 		for _, port := range cut.Ports {
 			if !containerPortNameFormatCheck(port.Name) {
 				tnf.ClaimFilePrintf("%s: ContainerPort %s does not follow the partner naming conventions", cut, port.Name)
-				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "ContainerPort does not follow the partner naming conventions", false))
+				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "ContainerPort does not follow the partner naming conventions", false).
+					AddField(testhelper.ContainerPort, port.Name))
 			} else {
-				compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "ContainerPort follows the partner naming conventions", true))
+				compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "ContainerPort follows the partner naming conventions", true).
+					AddField(testhelper.ContainerPort, port.Name))
 			}
 		}
 	}

--- a/pkg/provider/containers.go
+++ b/pkg/provider/containers.go
@@ -158,3 +158,7 @@ func (c *Container) HasExecProbes() bool {
 		c.ReadinessProbe != nil && c.ReadinessProbe.Exec != nil ||
 		c.StartupProbe != nil && c.StartupProbe.Exec != nil
 }
+
+func (c *Container) IsTagEmpty() bool {
+	return c.ContainerImageIdentifier.Tag == ""
+}

--- a/pkg/provider/containers_test.go
+++ b/pkg/provider/containers_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -174,5 +175,33 @@ func TestHasIgnoredContainerName(t *testing.T) {
 
 	for _, tc := range testCases {
 		assert.Equal(t, tc.expectedOutput, tc.testContainer.HasIgnoredContainerName())
+	}
+}
+
+func TestIsTagEmpty(t *testing.T) {
+	testCases := []struct {
+		testContainer  Container
+		expectedOutput bool
+	}{
+		{ // Test Case #1 - Container image tag is empty
+			testContainer: Container{
+				ContainerImageIdentifier: configuration.ContainerImageIdentifier{
+					Tag: "",
+				},
+			},
+			expectedOutput: true,
+		},
+		{ // Test Case #2 - Container image tag is not empty
+			testContainer: Container{
+				ContainerImageIdentifier: configuration.ContainerImageIdentifier{
+					Tag: "test",
+				},
+			},
+			expectedOutput: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedOutput, tc.testContainer.IsTagEmpty())
 	}
 }

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -156,6 +156,7 @@ const (
 	RoleType                     = "Role"
 	ListeningPortType            = "Listening Port"
 	DeclaredPortType             = "Declared Port"
+	ContainerPort                = "Container Port"
 )
 
 func (obj *ReportObject) SetContainerProcessValues(aPolicy, aPriority, aCommandLine string) *ReportObject {


### PR DESCRIPTION
build-depends: 28703
- Add compliant/nonCompliant objects for these two tests.
- Add Container.IsTagEmpty() func with corresponding unit tests.