### PR TITLE
Add failure-reason for ocp/partner -reserved-ports and undeclared port usage

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -315,7 +315,7 @@ Tags|common,access-control
 Property|Description
 ---|---
 Unique ID|access-control-pod-service-account
-Description|Tests that each CNF Pod utilizes a valid Service Account.
+Description|Tests that each CNF Pod utilizes a valid Service Account. Default or empty service account is not valid.
 Suggested Remediation|Ensure that the each CNF Pod is configured to use a valid Service Account
 Best Practice Reference|https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-scc-permissions-for-an-application
 Exception Process|No exceptions

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -241,28 +241,11 @@ func testNetworkConnectivity(env *provider.TestEnvironment, aIPVersion netcommon
 
 func testOCPReservedPortsUsage(env *provider.TestEnvironment) {
 	// List of all ports reserved by OpenShift
-	OCPReservedPorts := map[int32]bool{22623: true, 22624: true}
-
-	rogueContainers := netcommons.FindRogueContainersDeclaringPorts(env.Containers, OCPReservedPorts)
-	roguePods, failedContainers := netcommons.FindRoguePodsListeningToPorts(env.Pods, OCPReservedPorts)
-
-	if n := len(rogueContainers); n > 0 {
-		errMsg := fmt.Sprintf("Number of containers declaring ports reserved by OpenShift: %d", n)
-		tnf.ClaimFilePrintf(errMsg)
-		ginkgo.Fail(errMsg)
-	}
-
-	if n := len(roguePods); n > 0 {
-		errMsg := fmt.Sprintf("Number of pods having one or more containers listening on ports reserved by OpenShift: %d", n)
-		tnf.ClaimFilePrintf(errMsg)
-		ginkgo.Fail(errMsg)
-	}
-
-	if failedContainers > 0 {
-		errMsg := fmt.Sprintf("Number of containers in which the test could not be performed due to an error: %d", failedContainers)
-		tnf.ClaimFilePrintf(errMsg)
-		ginkgo.Fail(errMsg)
-	}
+	OCPReservedPorts := map[int32]bool{
+		22623: true,
+		22624: true}
+	compliantObjects, nonCompliantObjects := netcommons.TestReservedPortsUsage(env, OCPReservedPorts, "OCP")
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 func testPartnerSpecificTCPPorts(env *provider.TestEnvironment) {
@@ -278,27 +261,8 @@ func testPartnerSpecificTCPPorts(env *provider.TestEnvironment) {
 		15001: true,
 		15000: true,
 	}
-
-	rogueContainers := netcommons.FindRogueContainersDeclaringPorts(env.Containers, ReservedPorts)
-	roguePods, failedContainers := netcommons.FindRoguePodsListeningToPorts(env.Pods, ReservedPorts)
-
-	if n := len(rogueContainers); n > 0 {
-		errMsg := fmt.Sprintf("Number of containers declaring ports reserved by Partner: %d", n)
-		tnf.ClaimFilePrintf(errMsg)
-		ginkgo.Fail(errMsg)
-	}
-
-	if n := len(roguePods); n > 0 {
-		errMsg := fmt.Sprintf("Number of pods having one or more containers listening on ports reserved by Partner: %d", n)
-		tnf.ClaimFilePrintf(errMsg)
-		ginkgo.Fail(errMsg)
-	}
-
-	if failedContainers > 0 {
-		errMsg := fmt.Sprintf("Number of containers in which the test could not be performed due to an error: %d", failedContainers)
-		tnf.ClaimFilePrintf(errMsg)
-		ginkgo.Fail(errMsg)
-	}
+	compliantObjects, nonCompliantObjects := netcommons.TestReservedPortsUsage(env, ReservedPorts, "Partner")
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 func testDualStackServices(env *provider.TestEnvironment) {

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -18,6 +18,7 @@ package networking
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/sirupsen/logrus"
@@ -158,8 +159,9 @@ func testExecProbDenyAtCPUPinning(dpdkPods []*provider.Pod) {
 
 //nolint:funlen
 func testUndeclaredContainerPortsUsage(env *provider.TestEnvironment) {
+	var compliantObjects []*testhelper.ReportObject
+	var nonCompliantObjects []*testhelper.ReportObject
 	var portInfo netutil.PortInfo
-	var failedPods []*provider.Pod
 	for _, put := range env.Pods {
 		// First get the ports declared in the Pod's containers spec
 		declaredPorts := make(map[netutil.PortInfo]bool)
@@ -176,7 +178,8 @@ func testUndeclaredContainerPortsUsage(env *provider.TestEnvironment) {
 		listeningPorts, err := netutil.GetListeningPorts(firstPodContainer)
 		if err != nil {
 			tnf.ClaimFilePrintf("Failed to get the container's listening ports, err: %v", err)
-			failedPods = append(failedPods, put)
+			nonCompliantObjects = append(nonCompliantObjects,
+				testhelper.NewPodReportObject(put.Namespace, put.Name, fmt.Sprintf("Failed to get the container's listening ports, err: %v", err), false))
 			continue
 		}
 		if len(listeningPorts) == 0 {
@@ -188,20 +191,38 @@ func testUndeclaredContainerPortsUsage(env *provider.TestEnvironment) {
 		failedPod := false
 		for listeningPort := range listeningPorts {
 			if put.ContainsIstioProxy() && netcommons.ReservedIstioPorts[int32(listeningPort.PortNumber)] {
-				tnf.ClaimFilePrintf("%s is listening on port %d protocol %s, but the pod also contains istio-proxy. Ignoring.", put, listeningPort.PortNumber, listeningPort.Protocol)
+				tnf.ClaimFilePrintf("%s is listening on port %d protocol %s, but the pod also contains istio-proxy. Ignoring.",
+					put, listeningPort.PortNumber, listeningPort.Protocol)
 				continue
 			}
 
 			if !declaredPorts[listeningPort] {
-				tnf.ClaimFilePrintf("%s is listening on port %d protocol %s, but that port was not declared in any container spec.", put, listeningPort.PortNumber, listeningPort.Protocol)
+				tnf.ClaimFilePrintf("%s is listening on port %d protocol %s, but that port was not declared in any container spec.",
+					put, listeningPort.PortNumber, listeningPort.Protocol)
 				failedPod = true
+				nonCompliantObjects = append(nonCompliantObjects,
+					testhelper.NewPodReportObject(put.Namespace, put.Name,
+						"Listening port was declared in no container spec", false).
+						SetType(testhelper.ListeningPortType).
+						AddField(testhelper.PortNumber, strconv.Itoa(listeningPort.PortNumber)).
+						AddField(testhelper.PortProtocol, listeningPort.Protocol))
 			}
+			compliantObjects = append(compliantObjects,
+				testhelper.NewPodReportObject(put.Namespace, put.Name,
+					"Listening port was declared in container spec", true).
+					SetType(testhelper.ListeningPortType).
+					AddField(testhelper.PortNumber, strconv.Itoa(listeningPort.PortNumber)).
+					AddField(testhelper.PortProtocol, listeningPort.Protocol))
 		}
 		if failedPod {
-			failedPods = append(failedPods, put)
+			nonCompliantObjects = append(nonCompliantObjects,
+				testhelper.NewPodReportObject(put.Namespace, put.Name, "At least one port was listening but not declared in any container specs", false))
+		} else {
+			compliantObjects = append(compliantObjects,
+				testhelper.NewPodReportObject(put.Namespace, put.Name, "All listening were declared in containers specs", true))
 		}
 	}
-	testhelper.AddTestResultLog("Non-compliant", failedPods, tnf.ClaimFilePrintf, ginkgo.Fail)
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 // testDefaultNetworkConnectivity test the connectivity between the default interfaces of containers under test

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -196,7 +196,7 @@ func testUndeclaredContainerPortsUsage(env *provider.TestEnvironment) {
 				continue
 			}
 
-			if !declaredPorts[listeningPort] {
+			if ok := declaredPorts[listeningPort]; !ok {
 				tnf.ClaimFilePrintf("%s is listening on port %d protocol %s, but that port was not declared in any container spec.",
 					put, listeningPort.PortNumber, listeningPort.Protocol)
 				failedPod = true
@@ -206,13 +206,14 @@ func testUndeclaredContainerPortsUsage(env *provider.TestEnvironment) {
 						SetType(testhelper.ListeningPortType).
 						AddField(testhelper.PortNumber, strconv.Itoa(listeningPort.PortNumber)).
 						AddField(testhelper.PortProtocol, listeningPort.Protocol))
+			} else {
+				compliantObjects = append(compliantObjects,
+					testhelper.NewPodReportObject(put.Namespace, put.Name,
+						"Listening port was declared in container spec", true).
+						SetType(testhelper.ListeningPortType).
+						AddField(testhelper.PortNumber, strconv.Itoa(listeningPort.PortNumber)).
+						AddField(testhelper.PortProtocol, listeningPort.Protocol))
 			}
-			compliantObjects = append(compliantObjects,
-				testhelper.NewPodReportObject(put.Namespace, put.Name,
-					"Listening port was declared in container spec", true).
-					SetType(testhelper.ListeningPortType).
-					AddField(testhelper.PortNumber, strconv.Itoa(listeningPort.PortNumber)).
-					AddField(testhelper.PortProtocol, listeningPort.Protocol))
 		}
 		if failedPod {
 			nonCompliantObjects = append(nonCompliantObjects,

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -155,6 +155,7 @@ const (
 	RoleRuleType                 = "Role Rule"
 	RoleType                     = "Role"
 	ListeningPortType            = "Listening Port"
+	DeclaredPortType             = "Declared Port"
 )
 
 func (obj *ReportObject) SetContainerProcessValues(aPolicy, aPriority, aCommandLine string) *ReportObject {

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -130,6 +130,10 @@ const (
 	Group        = "Group"
 	ResourceName = "Resource Name"
 	Verb         = "Verb"
+
+	// Listening ports
+	PortNumber   = "Port Number"
+	PortProtocol = "Port Protocol"
 )
 
 // When adding new object types, please update the following:
@@ -150,6 +154,7 @@ const (
 	CustomResourceDefinitionType = "Custom Resource Definition"
 	RoleRuleType                 = "Role Rule"
 	RoleType                     = "Role"
+	ListeningPortType            = "Listening Port"
 )
 
 func (obj *ReportObject) SetContainerProcessValues(aPolicy, aPriority, aCommandLine string) *ReportObject {


### PR DESCRIPTION
Added Pod level and Port level reports
This PR is the continuation the closed PR https://github.com/test-network-function/cnf-certification-test/pull/1205