### PR TITLE
Add emptystring test case for getIPVersion()

### DIFF
--- a/cnf-certification-test/networking/netcommons/netcommons_test.go
+++ b/cnf-certification-test/networking/netcommons/netcommons_test.go
@@ -56,6 +56,12 @@ func Test_getIPVersion(t *testing.T) {
 			want:    Undefined,
 			wantErr: true,
 		},
+		{
+			name:    "EmptyString",
+			args:    args{aIP: ""},
+			want:    Undefined,
+			wantErr: true,
+		},
 		// TODO: Add test cases.
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Adds an expected error test case for the getIPVersion() function.  I noticed we don't test for empty strings.

As a background, there is discussion about whether or not to support headless services when it comes to the best practices.  This test case doesn't handle the "None" string required for headless, but rather an empty string case which _shouldn't_ happen but might as well test for it.

If further changes are needed for supporting headless services, we will add that as well.

https://kubernetes.io/docs/concepts/services-networking/service/#headless-services