### PR TITLE
Add access-control failure reason objects

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -123,7 +123,7 @@ Tags|telco,access-control
 Property|Description
 ---|---
 Unique ID|access-control-namespace
-Description|Tests that all CNF's resources (PUTs and CRs) belong to valid namespaces. A valid namespace meets the following conditions: (1) It was declared in the yaml config file under the targetNameSpaces tag. (2) It doesn't have any of the following prefixes: default, openshift-, istio- and aspenmesh-
+Description|Tests that all CNF's resources (PUTs and CRs) belong to valid namespaces. A valid namespace meets the following conditions: (1) It was declared in the yaml config file under the targetNameSpaces tag. (2) It does not have any of the following prefixes: default, openshift-, istio- and aspenmesh-
 Suggested Remediation|Ensure that your CNF utilizes namespaces declared in the yaml config file. Additionally, the namespaces should not start with "default, openshift-, istio- or aspenmesh-".
 Best Practice Reference|https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-requirements-cnf-reqs
 Exception Process|No exceptions

--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -356,7 +356,9 @@ func testContainerHostPort(env *provider.TestEnvironment) {
 		for _, aPort := range cut.Ports {
 			if aPort.HostPort != 0 {
 				tnf.ClaimFilePrintf("Host port %d is configured in container %s.", aPort.HostPort, cut.String())
-				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Host port is configured", false).AddField(testhelper.HostPort, strconv.Itoa(int(aPort.HostPort))))
+				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Host port is configured", false).
+					SetType(testhelper.HostPortType).
+					AddField(testhelper.PortNumber, strconv.Itoa(int(aPort.HostPort))))
 			} else {
 				compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Host port is not configured", true))
 			}
@@ -391,7 +393,9 @@ func testPodHostPath(env *provider.TestEnvironment) {
 			vol := &put.Spec.Volumes[idx]
 			if vol.HostPath != nil && vol.HostPath.Path != "" {
 				tnf.ClaimFilePrintf("Hostpath path: %s is set in pod %s.", vol.HostPath.Path, put.Namespace+"."+put.Name)
-				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Hostpath path is set", false).AddField(testhelper.HostPath, vol.HostPath.Path))
+				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Hostpath path is set", false).
+					SetType(testhelper.HostPathType).
+					AddField(testhelper.Path, vol.HostPath.Path))
 			} else {
 				compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Hostpath path is not set", true))
 			}

--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -18,6 +18,7 @@ package accesscontrol
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
@@ -267,33 +268,38 @@ func testProjectedVolumeServiceAccount(env *provider.TestEnvironment) {
 	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
-func checkForbiddenCapability(containers []*provider.Container, capability string) []string {
-	var badContainers []string
+func checkForbiddenCapability(containers []*provider.Container, capability string) (compliantObjects, nonCompliantObjects []*testhelper.ReportObject) {
 	for _, cut := range containers {
 		if cut.SecurityContext != nil && cut.SecurityContext.Capabilities != nil {
 			if strings.Contains(cut.SecurityContext.Capabilities.String(), capability) {
 				tnf.ClaimFilePrintf("Non compliant %s capability detected in container %s. All container caps: %s", capability, cut.String(), cut.SecurityContext.Capabilities.String())
-				badContainers = append(badContainers, cut.String())
+				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Non compliant capability detected in container", false).AddField(testhelper.SCCCapability, capability))
+			} else {
+				compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "No forbidden capabilities detected in container", true))
 			}
 		}
 	}
-	return badContainers
+	return compliantObjects, nonCompliantObjects
 }
 
 func testSysAdminCapability(env *provider.TestEnvironment) {
-	testhelper.AddTestResultLog("Non-compliant", checkForbiddenCapability(env.Containers, "SYS_ADMIN"), tnf.ClaimFilePrintf, ginkgo.Fail)
+	compliantObjects, nonCompliantObjects := checkForbiddenCapability(env.Containers, "SYS_ADMIN")
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 func testNetAdminCapability(env *provider.TestEnvironment) {
-	testhelper.AddTestResultLog("Non-compliant", checkForbiddenCapability(env.Containers, "NET_ADMIN"), tnf.ClaimFilePrintf, ginkgo.Fail)
+	compliantObjects, nonCompliantObjects := checkForbiddenCapability(env.Containers, "NET_ADMIN")
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 func testNetRawCapability(env *provider.TestEnvironment) {
-	testhelper.AddTestResultLog("Non-compliant", checkForbiddenCapability(env.Containers, "NET_RAW"), tnf.ClaimFilePrintf, ginkgo.Fail)
+	compliantObjects, nonCompliantObjects := checkForbiddenCapability(env.Containers, "NET_RAW")
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 func testIpcLockCapability(env *provider.TestEnvironment) {
-	testhelper.AddTestResultLog("Non-compliant", checkForbiddenCapability(env.Containers, "IPC_LOCK"), tnf.ClaimFilePrintf, ginkgo.Fail)
+	compliantObjects, nonCompliantObjects := checkForbiddenCapability(env.Containers, "IPC_LOCK")
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 // testSecConRootUser verifies that the container is not running as root
@@ -326,131 +332,160 @@ func testSecConRootUser(env *provider.TestEnvironment) {
 
 // testSecConPrivilegeEscalation verifies that the container is not allowed privilege escalation
 func testSecConPrivilegeEscalation(env *provider.TestEnvironment) {
-	var badContainers []string
+	var compliantObjects []*testhelper.ReportObject
+	var nonCompliantObjects []*testhelper.ReportObject
 	for _, cut := range env.Containers {
 		if cut.SecurityContext != nil && cut.SecurityContext.AllowPrivilegeEscalation != nil {
 			if *(cut.SecurityContext.AllowPrivilegeEscalation) {
 				tnf.ClaimFilePrintf("AllowPrivilegeEscalation is set to true in container %s.", cut.Podname+"."+cut.Name)
-				badContainers = append(badContainers, cut.Podname+"."+cut.Name)
+				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "AllowPrivilegeEscalation is set to true", false))
+			} else {
+				compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "AllowPrivilegeEscalation is set to false", true))
 			}
 		}
 	}
 
-	testhelper.AddTestResultLog("Non-compliant", badContainers, tnf.ClaimFilePrintf, ginkgo.Fail)
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 // testContainerHostPort tests that containers are not configured with host port privileges
 func testContainerHostPort(env *provider.TestEnvironment) {
-	var badContainers []string
+	var compliantObjects []*testhelper.ReportObject
+	var nonCompliantObjects []*testhelper.ReportObject
 	for _, cut := range env.Containers {
 		for _, aPort := range cut.Ports {
 			if aPort.HostPort != 0 {
 				tnf.ClaimFilePrintf("Host port %d is configured in container %s.", aPort.HostPort, cut.String())
-				badContainers = append(badContainers, cut.String())
+				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Host port is configured", false).AddField(testhelper.HostPort, strconv.Itoa(int(aPort.HostPort))))
+			} else {
+				compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Host port is not configured", true))
 			}
 		}
 	}
 
-	testhelper.AddTestResultLog("Non-compliant", badContainers, tnf.ClaimFilePrintf, ginkgo.Fail)
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 // testPodHostNetwork verifies that the pod hostNetwork parameter is not set to true
 func testPodHostNetwork(env *provider.TestEnvironment) {
-	var badPods []string
+	var compliantObjects []*testhelper.ReportObject
+	var nonCompliantObjects []*testhelper.ReportObject
 	for _, put := range env.Pods {
 		if put.Spec.HostNetwork {
 			tnf.ClaimFilePrintf("Host network is set to true in pod %s.", put.Namespace+"."+put.Name)
-			badPods = append(badPods, put.Namespace+"."+put.Name)
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Host network is set to true", false))
+		} else {
+			compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Host network is not set to true", true))
 		}
 	}
 
-	testhelper.AddTestResultLog("Non-compliant", badPods, tnf.ClaimFilePrintf, ginkgo.Fail)
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 // testPodHostPath verifies that the pod hostpath parameter is not set to true
 func testPodHostPath(env *provider.TestEnvironment) {
-	var badPods []string
+	var compliantObjects []*testhelper.ReportObject
+	var nonCompliantObjects []*testhelper.ReportObject
 	for _, put := range env.Pods {
 		for idx := range put.Spec.Volumes {
 			vol := &put.Spec.Volumes[idx]
 			if vol.HostPath != nil && vol.HostPath.Path != "" {
 				tnf.ClaimFilePrintf("Hostpath path: %s is set in pod %s.", vol.HostPath.Path, put.Namespace+"."+put.Name)
-				badPods = append(badPods, put.Namespace+"."+put.Name)
+				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Hostpath path is set", false).AddField(testhelper.HostPath, vol.HostPath.Path))
+			} else {
+				compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Hostpath path is not set", true))
 			}
 		}
 	}
 
-	testhelper.AddTestResultLog("Non-compliant", badPods, tnf.ClaimFilePrintf, ginkgo.Fail)
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 // testPodHostIPC verifies that the pod hostIpc parameter is not set to true
 func testPodHostIPC(env *provider.TestEnvironment) {
-	var badPods []string
+	var compliantObjects []*testhelper.ReportObject
+	var nonCompliantObjects []*testhelper.ReportObject
 	for _, put := range env.Pods {
 		if put.Spec.HostIPC {
 			tnf.ClaimFilePrintf("HostIpc is set in pod %s.", put.Namespace+"."+put.Name)
-			badPods = append(badPods, put.Namespace+"."+put.Name)
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "HostIpc is set to true", false))
+		} else {
+			compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "HostIpc is not set to true", true))
 		}
 	}
 
-	testhelper.AddTestResultLog("Non-compliant", badPods, tnf.ClaimFilePrintf, ginkgo.Fail)
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 // testPodHostPID verifies that the pod hostPid parameter is not set to true
 func testPodHostPID(env *provider.TestEnvironment) {
-	var badPods []string
+	var compliantObjects []*testhelper.ReportObject
+	var nonCompliantObjects []*testhelper.ReportObject
 	for _, put := range env.Pods {
 		if put.Spec.HostPID {
 			tnf.ClaimFilePrintf("HostPid is set in pod %s.", put.Namespace+"."+put.Name)
-			badPods = append(badPods, put.Namespace+"."+put.Name)
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "HostPid is set to true", false))
+		} else {
+			compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "HostPid is not set to true", true))
 		}
 	}
 
-	testhelper.AddTestResultLog("Non-compliant", badPods, tnf.ClaimFilePrintf, ginkgo.Fail)
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 // Tests namespaces for invalid prefixed and CRs are not defined in namespaces not under test with CRDs under test
 func testNamespace(env *provider.TestEnvironment) {
 	ginkgo.By(fmt.Sprintf("CNF resources' Namespaces should not have any of the following prefixes: %v", invalidNamespacePrefixes))
-	var failedNamespaces []string
+	var compliantObjects []*testhelper.ReportObject
+	var nonCompliantObjects []*testhelper.ReportObject
 	for _, namespace := range env.Namespaces {
 		ginkgo.By(fmt.Sprintf("Checking namespace %s", namespace))
 		for _, invalidPrefix := range invalidNamespacePrefixes {
 			if strings.HasPrefix(namespace, invalidPrefix) {
 				tnf.ClaimFilePrintf("Namespace %s has invalid prefix %s", namespace, invalidPrefix)
-				failedNamespaces = append(failedNamespaces, namespace)
+				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNamespacedReportObject("Namespace has invalid prefix", testhelper.Namespace, false, namespace))
+			} else {
+				compliantObjects = append(compliantObjects, testhelper.NewNamespacedReportObject("Namespace has valid prefix", testhelper.Namespace, true, namespace))
 			}
 		}
 	}
-	if failedNamespacesNum := len(failedNamespaces); failedNamespacesNum > 0 {
-		ginkgo.Fail(fmt.Sprintf("Found %d Namespaces with an invalid prefix.", failedNamespacesNum))
+	if failedNamespacesNum := len(nonCompliantObjects); failedNamespacesNum > 0 {
+		testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 	}
 	ginkgo.By(fmt.Sprintf("CNF pods should belong to any of the configured Namespaces: %v", env.Namespaces))
 	ginkgo.By(fmt.Sprintf("CRs from autodiscovered CRDs should belong only to the configured Namespaces: %v", env.Namespaces))
 	invalidCrs, err := namespace.TestCrsNamespaces(env.Crds, env.Namespaces)
 	if err != nil {
+		// Note: Leaving this as a direct call to Ginkgo fail instead of using the testhelper
 		ginkgo.Fail("error retrieving CRs")
 	}
 
 	invalidCrsNum, claimsLog := namespace.GetInvalidCRsNum(invalidCrs)
 	if invalidCrsNum > 0 && len(claimsLog.GetLogLines()) > 0 {
 		tnf.ClaimFilePrintf("%s", claimsLog.GetLogLines())
-		ginkgo.Fail(fmt.Sprintf("Found %d CRs belonging to invalid namespaces.", invalidCrsNum))
+		nonCompliantObjects = append(nonCompliantObjects, testhelper.NewReportObject("CRs are not in the configured namespaces", testhelper.Namespace, false))
+	} else {
+		compliantObjects = append(compliantObjects, testhelper.NewReportObject("CRs are in the configured namespaces", testhelper.Namespace, true))
 	}
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 // testPodServiceAccount verifies that the pod utilizes a valid service account
 func testPodServiceAccount(env *provider.TestEnvironment) {
 	ginkgo.By("Tests that each pod utilizes a valid service account")
-	failedPods := []string{}
+	var compliantObjects []*testhelper.ReportObject
+	var nonCompliantObjects []*testhelper.ReportObject
 	for _, put := range env.Pods {
 		ginkgo.By(fmt.Sprintf("Testing service account for pod %s (ns: %s)", put.Name, put.Namespace))
 		if put.Spec.ServiceAccountName == defaultServiceAccount {
-			tnf.ClaimFilePrintf("Pod %s (ns: %s) doesn't have a service account name.", put.Name, put.Namespace)
-			failedPods = append(failedPods, put.Name)
+			tnf.ClaimFilePrintf("Pod %s (ns: %s) does not have a service account name.", put.Name, put.Namespace)
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod does not have a service account name", false))
+		} else {
+			compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod has a service account name", true))
 		}
 	}
-	testhelper.AddTestResultLog("Non-compliant", failedPods, tnf.ClaimFilePrintf, ginkgo.Fail)
+
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 // testPodRoleBindings verifies that the pod utilizes a valid role binding that does not cross namespaces
@@ -558,7 +593,8 @@ func testAutomountServiceToken(env *provider.TestEnvironment) {
 	ginkgo.By("Should have automountServiceAccountToken set to false")
 
 	msg := []string{}
-	failedPods := []string{}
+	var compliantObjects []*testhelper.ReportObject
+	var nonCompliantObjects []*testhelper.ReportObject
 	for _, put := range env.Pods {
 		ginkgo.By(fmt.Sprintf("check the existence of pod service account %s (ns= %s )", put.Namespace, put.Name))
 		if put.Spec.ServiceAccountName == defaultServiceAccount {
@@ -569,8 +605,10 @@ func testAutomountServiceToken(env *provider.TestEnvironment) {
 		// Evaluate the pod's automount service tokens and any attached service accounts
 		podPassed, newMsg := rbac.EvaluateAutomountTokens(put.Pod)
 		if !podPassed {
-			failedPods = append(failedPods, put.Name)
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, fmt.Sprintf("Non-compliant because %s", newMsg), false))
 			msg = append(msg, newMsg)
+		} else {
+			compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Compliant because the pod does not have automount service tokens set to true", true))
 		}
 	}
 
@@ -578,11 +616,12 @@ func testAutomountServiceToken(env *provider.TestEnvironment) {
 		tnf.ClaimFilePrintf(strings.Join(msg, ""))
 	}
 
-	testhelper.AddTestResultLog("Non-compliant", failedPods, tnf.ClaimFilePrintf, ginkgo.Fail)
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 func testOneProcessPerContainer(env *provider.TestEnvironment) {
-	var badContainers []string
+	var compliantObjects []*testhelper.ReportObject
+	var nonCompliantObjects []*testhelper.ReportObject
 
 	for _, cut := range env.Containers {
 		// the Istio sidecar container "istio-proxy" launches two processes: "pilot-agent" and "envoy"
@@ -597,27 +636,30 @@ func testOneProcessPerContainer(env *provider.TestEnvironment) {
 		pid, err := crclient.GetPidFromContainer(cut, ocpContext)
 		if err != nil {
 			tnf.ClaimFilePrintf("Could not get PID for: %s, error: %v", cut, err)
-			badContainers = append(badContainers, cut.String())
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, fmt.Sprintf("Non-compliant because %s", err), false))
 			continue
 		}
 
 		nbProcesses, err := getNbOfProcessesInPidNamespace(ocpContext, pid, clientsholder.GetClientsHolder())
 		if err != nil {
 			tnf.ClaimFilePrintf("Could not get number of processes for: %s, error: %v", cut, err)
-			badContainers = append(badContainers, cut.String())
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, fmt.Sprintf("Non-compliant because %s", err), false))
 			continue
 		}
 		if nbProcesses > 1 {
 			tnf.ClaimFilePrintf("%s has more than one process running", cut.String())
-			badContainers = append(badContainers, cut.String())
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Non-compliant because it has more than one process running", false))
+		} else {
+			compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Compliant because it has only one process running", true))
 		}
 	}
 
-	testhelper.AddTestResultLog("Non-compliant", badContainers, tnf.ClaimFilePrintf, ginkgo.Fail)
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 func testSYSNiceRealtimeCapability(env *provider.TestEnvironment) {
-	var containersWithoutSysNice []string
+	var compliantObjects []*testhelper.ReportObject
+	var nonCompliantObjects []*testhelper.ReportObject
 
 	// Loop through all of the labeled containers and compare their security context capabilities and whether
 	// or not the node's kernel is realtime enabled.
@@ -625,15 +667,18 @@ func testSYSNiceRealtimeCapability(env *provider.TestEnvironment) {
 		n := env.Nodes[cut.NodeName]
 		if n.IsRTKernel() && !strings.Contains(cut.SecurityContext.Capabilities.String(), "SYS_NICE") {
 			tnf.ClaimFilePrintf("%s has been found running on a realtime kernel enabled node without SYS_NICE capability.", cut.String())
-			containersWithoutSysNice = append(containersWithoutSysNice, cut.String())
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Non-compliant because it is running on a realtime kernel enabled node without SYS_NICE capability", false))
+		} else {
+			compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Compliant because it is not running on a realtime kernel enabled node", true))
 		}
 	}
 
-	testhelper.AddTestResultLog("Non-compliant", containersWithoutSysNice, tnf.ClaimFilePrintf, ginkgo.Fail)
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 func testSysPtraceCapability(shareProcessPods []*provider.Pod) {
-	var podsWithoutSysPtrace []string
+	var compliantObjects []*testhelper.ReportObject
+	var nonCompliantObjects []*testhelper.ReportObject
 	for _, put := range shareProcessPods {
 		sysPtraceEnabled := false
 		for _, cut := range put.Containers {
@@ -649,14 +694,17 @@ func testSysPtraceCapability(shareProcessPods []*provider.Pod) {
 		}
 		if !sysPtraceEnabled {
 			tnf.ClaimFilePrintf("Pod %s has process namespace sharing enabled but no container allowing the SYS_PTRACE capability.", put.String())
-			podsWithoutSysPtrace = append(podsWithoutSysPtrace, put.String())
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Non-compliant because it has process namespace sharing enabled but no container allowing the SYS_PTRACE capability", false))
+		} else {
+			compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Compliant because it has process namespace sharing enabled and at least one container allowing the SYS_PTRACE capability", true))
 		}
 	}
-	testhelper.AddTestResultLog("Non-compliant", podsWithoutSysPtrace, tnf.ClaimFilePrintf, ginkgo.Fail)
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 func testNamespaceResourceQuota(env *provider.TestEnvironment) {
-	var namespacesMissingQuotas []string
+	var compliantObjects []*testhelper.ReportObject
+	var nonCompliantObjects []*testhelper.ReportObject
 	ginkgo.By("Testing namespace resource quotas")
 
 	for _, put := range env.Pods {
@@ -674,12 +722,14 @@ func testNamespaceResourceQuota(env *provider.TestEnvironment) {
 		}
 
 		if !foundPodNamespaceRQ {
-			namespacesMissingQuotas = append(namespacesMissingQuotas, put.String())
 			tnf.ClaimFilePrintf("Pod %s is running in a namespace that does not have a ResourceQuota applied.", put.String())
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Non-compliant because it is running in a namespace that does not have a ResourceQuota applied", false))
+		} else {
+			compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Compliant because it is running in a namespace that has a ResourceQuota applied", true))
 		}
 	}
 
-	testhelper.AddTestResultLog("Non-compliant", namespacesMissingQuotas, tnf.ClaimFilePrintf, ginkgo.Fail)
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 const (
@@ -688,8 +738,8 @@ const (
 )
 
 func testNoSSHDaemonsAllowed(env *provider.TestEnvironment) {
-	var badPods []string
-	var errPods []string
+	var compliantObjects []*testhelper.ReportObject
+	var nonCompliantObjects []*testhelper.ReportObject
 
 	sshPortInfo := netutil.PortInfo{PortNumber: sshServicePortNumber, Protocol: sshServicePortProtocol}
 
@@ -699,33 +749,37 @@ func testNoSSHDaemonsAllowed(env *provider.TestEnvironment) {
 		listeningPorts, err := netutil.GetListeningPorts(cut)
 		if err != nil {
 			tnf.ClaimFilePrintf("Failed to get the listening ports on %s, err: %v", cut, err)
-			errPods = append(errPods, put.String())
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Non-compliant because it failed to get the listening ports", false))
 			continue
 		}
 
 		if _, ok := listeningPorts[sshPortInfo]; ok {
 			tnf.ClaimFilePrintf("Pod %s is running an SSH daemon", put)
-			badPods = append(badPods, put.String())
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Non-compliant because it is running an SSH daemon", false))
+		} else {
+			compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Compliant because it is not running an SSH daemon", true))
 		}
 	}
 
-	testhelper.AddTestResultLog("Non-compliant", badPods, tnf.ClaimFilePrintf, ginkgo.Fail)
-	testhelper.AddTestResultLog("Error", errPods, tnf.ClaimFilePrintf, ginkgo.Fail)
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 func testPodRequestsAndLimits(env *provider.TestEnvironment) {
-	var containersMissingRequestsOrLimits []string
+	var compliantObjects []*testhelper.ReportObject
+	var nonCompliantObjects []*testhelper.ReportObject
 	ginkgo.By("Testing container resource requests and limits")
 
 	// Loop through the containers, looking for containers that are missing requests or limits.
 	// These need to be defined in order to pass.
 	for _, cut := range env.Containers {
 		if !resources.HasRequestsAndLimitsSet(cut) {
-			containersMissingRequestsOrLimits = append(containersMissingRequestsOrLimits, cut.String())
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Non-compliant because it is missing resource requests or limits", false))
+		} else {
+			compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Compliant because it has resource requests and limits", true))
 		}
 	}
 
-	testhelper.AddTestResultLog("Non-compliant", containersMissingRequestsOrLimits, tnf.ClaimFilePrintf, ginkgo.Fail)
+	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
 func test1337UIDs(env *provider.TestEnvironment) {

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -778,7 +778,7 @@ func InitCatalog() map[claim.Identifier]claim.TestCaseDescription {
 		common.AccessControlTestKey,
 		`Tests that all CNF's resources (PUTs and CRs) belong to valid namespaces. A valid namespace meets
 the following conditions: (1) It was declared in the yaml config file under the targetNameSpaces
-tag. (2) It doesn't have any of the following prefixes: default, openshift-, istio- and aspenmesh-`,
+tag. (2) It does not have any of the following prefixes: default, openshift-, istio- and aspenmesh-`,
 		NamespaceBestPracticesRemediation,
 		NoExceptions,
 		TestNamespaceBestPracticesIdentifierDocLink,

--- a/cnf-certification-test/platform/hugepages/hugepages_test.go
+++ b/cnf-certification-test/platform/hugepages/hugepages_test.go
@@ -566,7 +566,7 @@ func TestPositiveMachineConfigKernelArgsHugepages(t *testing.T) {
 									 /host/sys/devices/system/node/node1/hugepages/hugepages-1048576kB/nr_hugepages count:8`,
 			mcKernelArgs: []string{"hugepagesz=2M", "hugepages=256", "hugepagesz=1G", "hugepages=16"},
 		},
-		// Node has two numas and two sizes, with hugepages count on the first numa only. The second numa doesn't have any
+		// Node has two numas and two sizes, with hugepages count on the first numa only. The second numa does not have any
 		// hugepages for any size.
 		{
 			nodeHugePagesCmdOutput: `/host/sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages count:256
@@ -575,7 +575,7 @@ func TestPositiveMachineConfigKernelArgsHugepages(t *testing.T) {
 									 /host/sys/devices/system/node/node1/hugepages/hugepages-1048576kB/nr_hugepages count:0`,
 			mcKernelArgs: []string{"hugepagesz=1G", "hugepages=16", "hugepagesz=2M", "hugepages=256"},
 		},
-		// Node has two numas and two sizes, with hugepages count on the second numa only. The first numa doesn't have any
+		// Node has two numas and two sizes, with hugepages count on the second numa only. The first numa does not have any
 		// hugepages for any size.
 		{
 			nodeHugePagesCmdOutput: `/host/sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages count:0

--- a/cnf-certification-test/platform/nodetainted/nodetainted.go
+++ b/cnf-certification-test/platform/nodetainted/nodetainted.go
@@ -145,7 +145,7 @@ func DecodeKernelTaintsFromLetters(letters string) []string {
 			}
 		}
 
-		// The letter doesn't belong to any known (yet) taint...
+		// The letter does not belong to any known (yet) taint...
 		if !found {
 			taints = append(taints, fmt.Sprintf("unknown taint (letter %s)", taintLetter))
 		}

--- a/cnf-certification-test/preflight/suite.go
+++ b/cnf-certification-test/preflight/suite.go
@@ -38,7 +38,7 @@ var _ = ginkgo.Describe(common.PreflightTestKey, func() {
 	})
 	ginkgo.ReportAfterEach(results.RecordResult)
 
-	// Add safeguard against running the tests if the docker config doesn't exist.
+	// Add safeguard against running the tests if the docker config does not exist.
 	if env.GetDockerConfigFile() == "" || env.GetDockerConfigFile() == "NA" {
 		logrus.Debug("Skipping the preflight suite because the Docker Config file is not provided.")
 		return

--- a/cnf-certification-test/suite_test.go
+++ b/cnf-certification-test/suite_test.go
@@ -223,7 +223,7 @@ func TestTest(t *testing.T) {
 		}
 	}
 
-	// Remove web artifacts if user doesn't want them.
+	// Remove web artifacts if user does not want them.
 	if !configuration.GetTestParameters().IncludeWebFilesInOutputFolder {
 		for _, file := range webFilePaths {
 			err := os.Remove(file)

--- a/internal/certdb/onlinecheck/onlinecheck.go
+++ b/internal/certdb/onlinecheck/onlinecheck.go
@@ -33,7 +33,7 @@ import (
 
 // Endpoints document can be found here
 // https://docs.engineering.redhat.com/pages/viewpage.action?spaceKey=EXD&title=Pyxis
-// There are external and internal endpoints. External doesn't need authentication
+// There are external and internal endpoints. External does not need authentication
 // Here we are using only External endpoint to collect published containers and operator information
 
 const apiCatalogByRepositoriesBaseEndPoint = "https://catalog.redhat.com/api/containers/v1/repositories/registry/registry.access.redhat.com/repository"

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -117,6 +117,7 @@ const (
 	CustomResourceDefinitionName    = "Custom Resource Definition Name"
 	CustomResourceDefinitionVersion = "Custom Resource Definition Version"
 	SCCCapability                   = "SCC Capability"
+	Path                            = "Path"
 
 	// ICMP tests
 	NetworkName              = "Network Name"
@@ -158,8 +159,8 @@ const (
 	ListeningPortType            = "Listening Port"
 	DeclaredPortType             = "Declared Port"
 	ContainerPort                = "Container Port"
-	HostPort                     = "Host Port"
-	HostPath                     = "Host Path"
+	HostPortType                 = "Host Port"
+	HostPathType                 = "Host Path"
 )
 
 func (obj *ReportObject) SetContainerProcessValues(aPolicy, aPriority, aCommandLine string) *ReportObject {

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -116,6 +116,7 @@ const (
 	PodDisruptionBudgetReference    = "Pod Disruption Budget Reference"
 	CustomResourceDefinitionName    = "Custom Resource Definition Name"
 	CustomResourceDefinitionVersion = "Custom Resource Definition Version"
+	SCCCapability                   = "SCC Capability"
 
 	// ICMP tests
 	NetworkName              = "Network Name"
@@ -157,6 +158,8 @@ const (
 	ListeningPortType            = "Listening Port"
 	DeclaredPortType             = "Declared Port"
 	ContainerPort                = "Container Port"
+	HostPort                     = "Host Port"
+	HostPath                     = "Host Path"
 )
 
 func (obj *ReportObject) SetContainerProcessValues(aPolicy, aPriority, aCommandLine string) *ReportObject {


### PR DESCRIPTION
Covers all of the tests in the `access-control` test suite with compliant/non-compliant objects.

Bonus contraction removal `doesn't` to `does not` similar to #264 