### PR TITLE
Switch context.Background() to TODO() for consistency

### DIFF
--- a/pkg/provider/containers.go
+++ b/pkg/provider/containers.go
@@ -96,7 +96,7 @@ func (c *Container) SetPreflightResults(preflightImageCache map[string]plibRunti
 	if err != nil {
 		return err
 	}
-	ctx := artifacts.ContextWithWriter(context.Background(), artifactsWriter)
+	ctx := artifacts.ContextWithWriter(context.TODO(), artifactsWriter)
 
 	// Add logger output to the context
 	logbytes := bytes.NewBuffer([]byte{})

--- a/pkg/provider/operators.go
+++ b/pkg/provider/operators.go
@@ -84,7 +84,7 @@ func (op *Operator) SetPreflightResults(env *TestEnvironment) error {
 	if err != nil {
 		return err
 	}
-	ctx := artifacts.ContextWithWriter(context.Background(), artifactsWriter)
+	ctx := artifacts.ContextWithWriter(context.TODO(), artifactsWriter)
 	opts := []plibOperator.Option{}
 	opts = append(opts, plibOperator.WithDockerConfigJSONFromFile(env.GetDockerConfigFile()))
 	if env.IsPreflightInsecureAllowed() {


### PR DESCRIPTION
Similar to #681 

These were some stragglers I found that were using `Background()` instead of `TODO()`.  These are essentially the same function but I like conformity.  😄 