### PR TITLE
Mark cluster-role-bindings as QE test covered

### DIFF
--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -926,7 +926,7 @@ tag. (2) It doesn't have any of the following prefixes: default, openshift-, ist
 		PodClusterRoleBindingsBestPracticesRemediation,
 		"Exception possible only for workloads that's cluster wide in nature and absolutely needs cluster level roles & role bindings",
 		TestPodClusterRoleBindingsBestPracticesIdentifierDocLink,
-		false,
+		true,
 		map[string]string{
 			FarEdge:  Mandatory,
 			Telco:    Mandatory,


### PR DESCRIPTION
Update required for [this PR](https://github.com/test-network-function/cnfcert-tests-verification/pull/352)

QE test coverage : 77%