### PR TITLE
Help the self-hosted runner by not pruning images

### DIFF
--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -73,12 +73,12 @@ jobs:
           max_attempts: 3
           command: kind delete cluster
 
-      - name: Prune the local docker system
+      - name: Prune docker resources
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: docker system prune -f
+          command: docker container prune -f; docker network prune -f; docker volume prune -f 
 
       - name: Create `local-test-infra` OpenShift resources
         run: make rebuild-cluster


### PR DESCRIPTION
`docker system prune` cleans everything including images.  We're hitting dockerhub rate limits because we are constantly pulling images so I'm going to help it by not pruning images we have already pulled.