### PR TITLE
Check claim file format version before attempting rendering results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,12 @@ COMMON_GO_ARGS=-race
 GIT_COMMIT=$(shell script/create-version-files.sh)
 GIT_RELEASE=$(shell script/get-git-release.sh)
 GIT_PREVIOUS_RELEASE=$(shell script/get-git-previous-release.sh)
+CLAIM_FORMAT_VERSION=$(shell script/get-claim-version.sh)
 GOLANGCI_VERSION=v1.53.3
 LINKER_TNF_RELEASE_FLAGS=-X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitCommit=${GIT_COMMIT}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitRelease=${GIT_RELEASE}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitPreviousRelease=${GIT_PREVIOUS_RELEASE}
+LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.ClaimFormatVersion=${CLAIM_FORMAT_VERSION}
 
 all: build
 

--- a/cnf-certification-test/results/html/results-embed.html
+++ b/cnf-certification-test/results/html/results-embed.html
@@ -1288,50 +1288,51 @@ classification=  {
 
   <script>
     var uuidNode = 1 // zero is root
-    // Load initial json, if available
-    if (typeof initialjson !== 'undefined') {
-      claimGlobal = initialjson
-    }
-    if (typeof feedback !== 'undefined') {
-      feedbackGlobal = feedback
-    }
-    // Get the URL
-    const queryString = window.location.search;
-    const urlParams = new URLSearchParams(queryString);
-
-    // Get the claim file URL
-    const claimFileParam = urlParams.get('claimfile');
-    const feedbackFileParam = urlParams.get('feedback');
-
-    console.log("claimfile via url:", claimFileParam);
-    console.log("feedbackfile via url:", feedbackFileParam);
-
-    fetchRenderClaimFile(claimFileParam)
-    fetchRenderFeedbackFile(feedbackFileParam)
-
-    // First render if local files or url provided files are present
-    if (typeof claimGlobal != 'undefined') {
-      renderResultsWithModal()
-    }
-    const inputElement1 = document.getElementById("feedbackFile");
-    inputElement1.addEventListener("change", handleFeedbackFiles, false);
-    function handleFeedbackFiles() {
-      const fileList = this.files; /* now you can work with the file list */
-      if (fileList.length) {
-        // We have a file to load
-        let fileUploaded = new FileReader();
-        fileUploaded.addEventListener("load", e => {
-          input = JSON.parse(fileUploaded.result)
-          fillFeedback(input)
-        });
-        fileUploaded.readAsText(fileList[0]);
+    $(document).ready(function () {
+      // Load initial json, if available
+      if (typeof initialjson !== 'undefined') {
+        claimGlobal = initialjson
       }
-      this.value = null;
-    }
+      if (typeof feedback !== 'undefined') {
+        feedbackGlobal = feedback
+      }
+      // Get the URL
+      const queryString = window.location.search;
+      const urlParams = new URLSearchParams(queryString);
 
-    const inputElement = document.getElementById("formFile");
-    inputElement.addEventListener("change", handleFiles, false);
+      // Get the claim file URL
+      const claimFileParam = urlParams.get('claimfile');
+      const feedbackFileParam = urlParams.get('feedback');
 
+      console.log("claimfile via url:", claimFileParam);
+      console.log("feedbackfile via url:", feedbackFileParam);
+
+      fetchRenderClaimFile(claimFileParam)
+      fetchRenderFeedbackFile(feedbackFileParam)
+
+      // First render if local files or url provided files are present
+      if (typeof claimGlobal != 'undefined') {
+        renderResultsWithModal()
+      }
+      const inputElement1 = document.getElementById("feedbackFile");
+      inputElement1.addEventListener("change", handleFeedbackFiles, false);
+      function handleFeedbackFiles() {
+        const fileList = this.files; /* now you can work with the file list */
+        if (fileList.length) {
+          // We have a file to load
+          let fileUploaded = new FileReader();
+          fileUploaded.addEventListener("load", e => {
+            input = JSON.parse(fileUploaded.result)
+            fillFeedback(input)
+          });
+          fileUploaded.readAsText(fileList[0]);
+        }
+        this.value = null;
+      }
+
+      const inputElement = document.getElementById("formFile");
+      inputElement.addEventListener("change", handleFiles, false);
+    });
 
     function handleFiles() {
       const fileList = this.files; /* now you can work with the file list */

--- a/cnf-certification-test/results/html/results-embed.html
+++ b/cnf-certification-test/results/html/results-embed.html
@@ -1311,7 +1311,7 @@ classification=  {
 
     // First render if local files or url provided files are present
     if (typeof claimGlobal != 'undefined') {
-      renderResults()
+      renderResultsWithModal()
     }
     const inputElement1 = document.getElementById("feedbackFile");
     inputElement1.addEventListener("change", handleFeedbackFiles, false);
@@ -1339,23 +1339,26 @@ classification=  {
         // We have a file to load
         let fileUploaded = new FileReader();
         fileUploaded.addEventListener("load", e => {
-          globalClaimJSON = JSON.parse(fileUploaded.result)
-          claimVersion = getClaimVersion(globalClaimJSON.claim.versions)
-          const modalBody = document.getElementById('modalBody');
-          if (expectedClaimVersion != claimVersion) {
-            $('#staticBackdrop').modal('show');
-            modalBody.textContent = 'Unsupported claim format. Expecting: ' + expectedClaimVersion + ' but got: ' + claimVersion
-            // Get a reference to the button element
-            const myButton = document.getElementById('continueLoadingClaim');
-
-            // Add an event listener to the button
-            myButton.addEventListener('click', renderClaim);
-          } else {
-            renderResults()
-          }
-
+          claimGlobal = JSON.parse(fileUploaded.result)
+          renderResultsWithModal()
         });
         fileUploaded.readAsText(fileList[0]);
+      }
+    }
+
+    function renderResultsWithModal() {
+      claimVersion = getClaimVersion(claimGlobal.claim.versions)
+      const modalBody = document.getElementById('modalBody');
+      if (expectedClaimVersion != claimVersion) {
+        $('#staticBackdrop').modal('show');
+        modalBody.textContent = 'Unsupported claim format. Expecting: ' + expectedClaimVersion + ' but got: ' + claimVersion
+        // Get a reference to the button element
+        const myButton = document.getElementById('continueLoadingClaim');
+
+        // Add an event listener to the button
+        myButton.addEventListener('click', renderResults);
+      } else {
+        renderResults()
       }
     }
 
@@ -1372,7 +1375,7 @@ classification=  {
         })
         .then((data) => {
           claimGlobal = data
-          renderResults()
+          renderResultsWithModal()
         })
         .catch((error) => {
           console.log(`Error: ${error.message}`);
@@ -1392,7 +1395,7 @@ classification=  {
         })
         .then((data) => {
           feedbackGlobal = data
-          renderResults()
+          renderResultsWithModal()
         })
         .catch((error) => {
           console.log(`Error: ${error.message}`);

--- a/cnf-certification-test/results/html/results-embed.html
+++ b/cnf-certification-test/results/html/results-embed.html
@@ -224,9 +224,30 @@
   </div>
   </div>
 
+  <!-- Modal -->
+  <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1"
+    aria-labelledby="staticBackdropLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="staticBackdropLabel">Warning</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body" id="modalBody">
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Stop Loading</button>
+          <button type="button" id="continueLoadingClaim" data-bs-dismiss="modal"
+            class="btn btn-primary">Continue</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- We should extract the javascript code to a separate file, but if we include it here we can just use a single file HTMl, which is handy -->
   <!--    <script src="./utils.js"></script> -->
   <script>
+    const expectedClaimVersion = "v0.0.1"
     var buttonElementId = "non"
     var claimGlobal
     var feedbackGlobal
@@ -384,6 +405,19 @@
 
       text = '</tbody>'
       $(text).appendTo($(element))
+    }
+
+    function getClaimVersion(input) {
+      const claimVersion = input["claimFormat"]
+      if (typeof claimVersion === 'undefined') {
+        return "nil - claimFormat version not present in claim file"
+      }
+      const regex = /(v[0-9]\.[0-9]\.[0-9])/;
+      const matches = claimVersion.match(regex);
+      if (matches != null && matches.length > 1) {
+        return matches[1]
+      }
+      return "nil - claimFormat version is not in a valid format, check claim file"
     }
 
     function fillMetadata(input, element) {
@@ -1297,15 +1331,29 @@ classification=  {
 
     const inputElement = document.getElementById("formFile");
     inputElement.addEventListener("change", handleFiles, false);
+
+
     function handleFiles() {
       const fileList = this.files; /* now you can work with the file list */
       if (fileList.length) {
         // We have a file to load
         let fileUploaded = new FileReader();
         fileUploaded.addEventListener("load", e => {
-          claimGlobal = JSON.parse(fileUploaded.result)
+          globalClaimJSON = JSON.parse(fileUploaded.result)
+          claimVersion = getClaimVersion(globalClaimJSON.claim.versions)
+          const modalBody = document.getElementById('modalBody');
+          if (expectedClaimVersion != claimVersion) {
+            $('#staticBackdrop').modal('show');
+            modalBody.textContent = 'Unsupported claim format. Expecting: ' + expectedClaimVersion + ' but got: ' + claimVersion
+            // Get a reference to the button element
+            const myButton = document.getElementById('continueLoadingClaim');
 
-          renderResults()
+            // Add an event listener to the button
+            myButton.addEventListener('click', renderClaim);
+          } else {
+            renderResults()
+          }
+
         });
         fileUploaded.readAsText(fileList[0]);
       }

--- a/cnf-certification-test/results/html/results.html
+++ b/cnf-certification-test/results/html/results.html
@@ -763,50 +763,51 @@
 
   <script>
     var uuidNode = 1 // zero is root
-    // Load initial json, if available
-    if (typeof initialjson !== 'undefined') {
-      claimGlobal = initialjson
-    }
-    if (typeof feedback !== 'undefined') {
-      feedbackGlobal = feedback
-    }
-    // Get the URL
-    const queryString = window.location.search;
-    const urlParams = new URLSearchParams(queryString);
-
-    // Get the claim file URL
-    const claimFileParam = urlParams.get('claimfile');
-    const feedbackFileParam = urlParams.get('feedback');
-
-    console.log("claimfile via url:", claimFileParam);
-    console.log("feedbackfile via url:", feedbackFileParam);
-
-    fetchRenderClaimFile(claimFileParam)
-    fetchRenderFeedbackFile(feedbackFileParam)
-
-    // First render if local files or url provided files are present
-    if (typeof claimGlobal != 'undefined') {
-      renderResultsWithModal()
-    }
-    const inputElement1 = document.getElementById("feedbackFile");
-    inputElement1.addEventListener("change", handleFeedbackFiles, false);
-    function handleFeedbackFiles() {
-      const fileList = this.files; /* now you can work with the file list */
-      if (fileList.length) {
-        // We have a file to load
-        let fileUploaded = new FileReader();
-        fileUploaded.addEventListener("load", e => {
-          input = JSON.parse(fileUploaded.result)
-          fillFeedback(input)
-        });
-        fileUploaded.readAsText(fileList[0]);
+    $(document).ready(function () {
+      // Load initial json, if available
+      if (typeof initialjson !== 'undefined') {
+        claimGlobal = initialjson
       }
-      this.value = null;
-    }
+      if (typeof feedback !== 'undefined') {
+        feedbackGlobal = feedback
+      }
+      // Get the URL
+      const queryString = window.location.search;
+      const urlParams = new URLSearchParams(queryString);
 
-    const inputElement = document.getElementById("formFile");
-    inputElement.addEventListener("change", handleFiles, false);
+      // Get the claim file URL
+      const claimFileParam = urlParams.get('claimfile');
+      const feedbackFileParam = urlParams.get('feedback');
 
+      console.log("claimfile via url:", claimFileParam);
+      console.log("feedbackfile via url:", feedbackFileParam);
+
+      fetchRenderClaimFile(claimFileParam)
+      fetchRenderFeedbackFile(feedbackFileParam)
+
+      // First render if local files or url provided files are present
+      if (typeof claimGlobal != 'undefined') {
+        renderResultsWithModal()
+      }
+      const inputElement1 = document.getElementById("feedbackFile");
+      inputElement1.addEventListener("change", handleFeedbackFiles, false);
+      function handleFeedbackFiles() {
+        const fileList = this.files; /* now you can work with the file list */
+        if (fileList.length) {
+          // We have a file to load
+          let fileUploaded = new FileReader();
+          fileUploaded.addEventListener("load", e => {
+            input = JSON.parse(fileUploaded.result)
+            fillFeedback(input)
+          });
+          fileUploaded.readAsText(fileList[0]);
+        }
+        this.value = null;
+      }
+
+      const inputElement = document.getElementById("formFile");
+      inputElement.addEventListener("change", handleFiles, false);
+    });
 
     function handleFiles() {
       const fileList = this.files; /* now you can work with the file list */

--- a/cnf-certification-test/results/html/results.html
+++ b/cnf-certification-test/results/html/results.html
@@ -786,7 +786,7 @@
 
     // First render if local files or url provided files are present
     if (typeof claimGlobal != 'undefined') {
-      renderResults()
+      renderResultsWithModal()
     }
     const inputElement1 = document.getElementById("feedbackFile");
     inputElement1.addEventListener("change", handleFeedbackFiles, false);
@@ -814,23 +814,26 @@
         // We have a file to load
         let fileUploaded = new FileReader();
         fileUploaded.addEventListener("load", e => {
-          globalClaimJSON = JSON.parse(fileUploaded.result)
-          claimVersion = getClaimVersion(globalClaimJSON.claim.versions)
-          const modalBody = document.getElementById('modalBody');
-          if (expectedClaimVersion != claimVersion) {
-            $('#staticBackdrop').modal('show');
-            modalBody.textContent = 'Unsupported claim format. Expecting: ' + expectedClaimVersion + ' but got: ' + claimVersion
-            // Get a reference to the button element
-            const myButton = document.getElementById('continueLoadingClaim');
-
-            // Add an event listener to the button
-            myButton.addEventListener('click', renderClaim);
-          } else {
-            renderResults()
-          }
-
+          claimGlobal = JSON.parse(fileUploaded.result)
+          renderResultsWithModal()
         });
         fileUploaded.readAsText(fileList[0]);
+      }
+    }
+
+    function renderResultsWithModal() {
+      claimVersion = getClaimVersion(claimGlobal.claim.versions)
+      const modalBody = document.getElementById('modalBody');
+      if (expectedClaimVersion != claimVersion) {
+        $('#staticBackdrop').modal('show');
+        modalBody.textContent = 'Unsupported claim format. Expecting: ' + expectedClaimVersion + ' but got: ' + claimVersion
+        // Get a reference to the button element
+        const myButton = document.getElementById('continueLoadingClaim');
+
+        // Add an event listener to the button
+        myButton.addEventListener('click', renderResults);
+      } else {
+        renderResults()
       }
     }
 
@@ -847,7 +850,7 @@
         })
         .then((data) => {
           claimGlobal = data
-          renderResults()
+          renderResultsWithModal()
         })
         .catch((error) => {
           console.log(`Error: ${error.message}`);
@@ -867,7 +870,7 @@
         })
         .then((data) => {
           feedbackGlobal = data
-          renderResults()
+          renderResultsWithModal()
         })
         .catch((error) => {
           console.log(`Error: ${error.message}`);

--- a/cnf-certification-test/results/html/results.html
+++ b/cnf-certification-test/results/html/results.html
@@ -224,9 +224,30 @@
   </div>
   </div>
 
+  <!-- Modal -->
+  <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1"
+    aria-labelledby="staticBackdropLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="staticBackdropLabel">Warning</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body" id="modalBody">
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Stop Loading</button>
+          <button type="button" id="continueLoadingClaim" data-bs-dismiss="modal"
+            class="btn btn-primary">Continue</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- We should extract the javascript code to a separate file, but if we include it here we can just use a single file HTMl, which is handy -->
   <!--    <script src="./utils.js"></script> -->
   <script>
+    const expectedClaimVersion = "v0.0.1"
     var buttonElementId = "non"
     var claimGlobal
     var feedbackGlobal
@@ -384,6 +405,19 @@
 
       text = '</tbody>'
       $(text).appendTo($(element))
+    }
+
+    function getClaimVersion(input) {
+      const claimVersion = input["claimFormat"]
+      if (typeof claimVersion === 'undefined') {
+        return "nil - claimFormat version not present in claim file"
+      }
+      const regex = /(v[0-9]\.[0-9]\.[0-9])/;
+      const matches = claimVersion.match(regex);
+      if (matches != null && matches.length > 1) {
+        return matches[1]
+      }
+      return "nil - claimFormat version is not in a valid format, check claim file"
     }
 
     function fillMetadata(input, element) {
@@ -772,15 +806,29 @@
 
     const inputElement = document.getElementById("formFile");
     inputElement.addEventListener("change", handleFiles, false);
+
+
     function handleFiles() {
       const fileList = this.files; /* now you can work with the file list */
       if (fileList.length) {
         // We have a file to load
         let fileUploaded = new FileReader();
         fileUploaded.addEventListener("load", e => {
-          claimGlobal = JSON.parse(fileUploaded.result)
+          globalClaimJSON = JSON.parse(fileUploaded.result)
+          claimVersion = getClaimVersion(globalClaimJSON.claim.versions)
+          const modalBody = document.getElementById('modalBody');
+          if (expectedClaimVersion != claimVersion) {
+            $('#staticBackdrop').modal('show');
+            modalBody.textContent = 'Unsupported claim format. Expecting: ' + expectedClaimVersion + ' but got: ' + claimVersion
+            // Get a reference to the button element
+            const myButton = document.getElementById('continueLoadingClaim');
 
-          renderResults()
+            // Add an event listener to the button
+            myButton.addEventListener('click', renderClaim);
+          } else {
+            renderResults()
+          }
+
         });
         fileUploaded.readAsText(fileList[0]);
       }

--- a/cnf-certification-test/suite_test.go
+++ b/cnf-certification-test/suite_test.go
@@ -73,6 +73,9 @@ var (
 	// gitDisplayRelease is a string used to hold the text to display
 	// the version on screen and in the claim file
 	gitDisplayRelease string
+	// ClaimFormat is the current version for the claim file format to be produced by the TNF test suite.
+	// A client decoding this claim file must support decoding its specific version.
+	ClaimFormatVersion string
 )
 
 func init() {
@@ -135,6 +138,7 @@ func TestTest(t *testing.T) {
 
 	ginkgoConfig, _ := ginkgo.GinkgoConfiguration()
 	log.Infof("TNF Version         : %v", getGitVersion())
+	log.Infof("Claim Format Version: %s", ClaimFormatVersion)
 	log.Infof("Ginkgo Version      : %v", ginkgo.GINKGO_VERSION)
 	log.Infof("Focused test suites : %v", ginkgoConfig.FocusStrings)
 	log.Infof("TC skip patterns    : %v", ginkgoConfig.SkipStrings)
@@ -242,5 +246,6 @@ func incorporateVersions(claimData *claim.Claim) {
 		OcClient:     diagnostics.GetVersionOcClient(),
 		Ocp:          diagnostics.GetVersionOcp(),
 		K8s:          diagnostics.GetVersionK8s(),
+		ClaimFormat:  ClaimFormatVersion,
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/test-network-function/cnf-certification-test
 
 go 1.20
 
+replace github.com/test-network-function/test-network-function-claim => ../test-network-function-claim
+
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/basgys/goxml2json v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/test-network-function/cnf-certification-test
 
 go 1.20
 
-replace github.com/test-network-function/test-network-function-claim => ../test-network-function-claim
-
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/basgys/goxml2json v1.1.0

--- a/script/get-claim-version.sh
+++ b/script/get-claim-version.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 #set -x
 
-cat version.json | jq .claimFormat
+jq .claimFormat < version.json

--- a/script/get-claim-version.sh
+++ b/script/get-claim-version.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+#set -x
+
+cat version.json | jq .claimFormat

--- a/script/get-claim-version.sh
+++ b/script/get-claim-version.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 #set -x
 
-jq .claimFormat < version.json
+jq .claimFormat <version.json

--- a/version.json
+++ b/version.json
@@ -1,3 +1,4 @@
 {
-  "partner_tag": "v4.3.1"
+  "partner_tag": "v4.3.1",
+  "claimFormat": "v0.0.1"
 }


### PR DESCRIPTION
Claim file version added to the version.json file
The new version is integrated as a static variable in the tnf exec and added to the claim file in the versions section. 
The result.html check the claim file version with its own hard coded supported version before rendering any results.
If there is a mismatch, a warning modal is displayed with the option to continue or stop.
needs https://github.com/test-network-function/test-network-function-claim/pull/94 to merge