### PR TITLE
Mark ssh-daemons as QE test covered

### DIFF
--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -1486,7 +1486,7 @@ tag. (2) It does not have any of the following prefixes: default, openshift-, is
 		NoSSHDaemonsAllowedRemediation,
 		`No exceptions - special consideration can be given to certain containers which run as utility tool daemon`,
 		TestNoSSHDaemonsAllowedIdentifierDocLink,
-		false,
+		true,
 		map[string]string{
 			FarEdge:  Mandatory,
 			Telco:    Mandatory,


### PR DESCRIPTION
Dependant on https://github.com/test-network-function/cnfcert-tests-verification/pull/371