### PR TITLE
DO NOT MERGE: Using tmate to debug a github ci issue.

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -302,6 +302,11 @@ jobs:
           repository: test-network-function/cnf-certification-test-partner
           path: cnf-certification-test-partner
 
+      - name: Setup tmate session for debugging through ssh.
+        uses: mxschmitt/action-tmate@v3
+        with:
+          detached: true
+
       - name: Start the Kind cluster for `local-test-infra`
         uses: ./cnf-certification-test-partner/.github/actions/start-k8s-cluster
         with:

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -330,6 +330,13 @@ jobs:
         env:
           IMAGE_TAG: ${TNF_IMAGE_TAG}
 
+      - name: Remove temp/dangling container images to save space.
+        run: |
+          df -h
+          docker images
+          docker rmi $(docker images -f "dangling=true" -q) || true
+          df -h
+
       - name: Create required TNF config files and directories
         run: |
           mkdir -p $TNF_CONFIG_DIR $TNF_OUTPUT_DIR


### PR DESCRIPTION
Added tmate to debug the github issue related to preflight:
```
ERROR  [Jul 21 07:31:35.495][containers.go: 111] failed to extract tarball: write /tmp/preflight-3137928138/fs/usr/lib64/security/pam_systemd.so: no space left on device 
FATAL  [Jul 21 07:31:35.495][suite.go: 102] failed running preflight on image: quay.io/testnetworkfunction/cnf-test-partner:latest error: failed to extract tarball: write /tmp/preflight-3137928138/fs/usr/lib64/security/pam_systemd.so: no space left on device 
```