### PR TITLE
Github CI: clean up unnamed/dangling container images to save disk space.

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -311,7 +311,7 @@ jobs:
         uses: ./cnf-certification-test-partner/.github/actions/create-local-test-infra-resources
         with:
           working_directory: cnf-certification-test-partner
-            
+
 
       # Perform smoke tests using a TNF container.
       - name: Check out code into the Go module directory
@@ -325,6 +325,15 @@ jobs:
         env:
           IMAGE_TAG: ${TNF_IMAGE_TAG}
 
+      # Clean up unused container image layers. We need to filter out a possible error return code
+      # from docker with "|| true" as some images might still be used by running kind containers and
+      # won't be removed.
+      - name: Remove unnamed/dangling container images to save space. Show disk space before and after removing them.
+        run: |
+          df -h
+          docker rmi $(docker images -f "dangling=true" -q) || true
+          df -h
+
       - name: Create required TNF config files and directories
         run: |
           mkdir -p $TNF_CONFIG_DIR $TNF_OUTPUT_DIR
@@ -333,7 +342,7 @@ jobs:
 
       - name: 'Test: Run without any TS, just get diagnostic information'
         run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./run-tnf-container.sh ${{ env.TESTING_CMD_PARAMS }}
-          
+
       - name: 'Test: Run Smoke Tests in a TNF container'
         run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./run-tnf-container.sh ${{ env.TESTING_CMD_PARAMS }} -l "${SMOKE_TESTS_GINKGO_LABELS_FILTER}"
 


### PR DESCRIPTION
The job that runs tnf using the container was failing due to not enough disk space to untar the preflight image.

Debugging through ssh with tmate action showed that used disk space reached 98-99% right before running the preflight test suite.

Deleting the unnamed/dangling container images right after building the tnf docker image frees around 3.5GB of disk space.