### PR TITLE
Update instructions for running 'all' suites

### DIFF
--- a/docs/test-standalone.md
+++ b/docs/test-standalone.md
@@ -102,7 +102,7 @@ To select the test to be executed when running `run-cnf-suites.sh` with the foll
 You can run all of the tests (including the intrusive tests and the extended suite) with the following commands:
 
 ```shell
-./run-cnf-suites.sh -l common,extended
+./run-cnf-suites.sh -l all
 ```
 
 #### Run a subset


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test/pull/1176

We should be recommending users to run `all` suites instead of the `common,extended` labels.