### PR TITLE
Avoid zipping junit xml file in diagnostic mode.

### DIFF
--- a/cnf-certification-test/suite_test.go
+++ b/cnf-certification-test/suite_test.go
@@ -212,9 +212,12 @@ func TestTest(t *testing.T) {
 		log.Errorf("Failed to create results web files: %v", err)
 	}
 
-	allArtifactsFilePaths := []string{
-		filepath.Join(*claimPath, results.ClaimFileName),
-		filepath.Join(*junitPath, results.JunitXMLFileName)}
+	allArtifactsFilePaths := []string{filepath.Join(*claimPath, results.ClaimFileName)}
+
+	// Add the junit xml file only if we're not in diagnostic mode.
+	if !diagnosticMode {
+		allArtifactsFilePaths = append(allArtifactsFilePaths, filepath.Join(*junitPath, results.JunitXMLFileName))
+	}
 
 	// Add all the web artifacts file paths.
 	allArtifactsFilePaths = append(allArtifactsFilePaths, webFilePaths...)
@@ -223,7 +226,7 @@ func TestTest(t *testing.T) {
 	if !configuration.GetTestParameters().OmitArtifactsZipFile {
 		err = results.CompressResultsArtifacts(resultsOutputDir, allArtifactsFilePaths)
 		if err != nil {
-			log.Errorf("Failed to compress results artifacts: %v", err)
+			log.Fatalf("Failed to compress results artifacts: %v", err)
 		}
 	}
 
@@ -232,7 +235,7 @@ func TestTest(t *testing.T) {
 		for _, file := range webFilePaths {
 			err := os.Remove(file)
 			if err != nil {
-				log.Errorf("failed to remove web file %s: %v", file, err)
+				log.Fatalf("failed to remove web file %s: %v", file, err)
 			}
 		}
 	}


### PR DESCRIPTION
An ERROR message was appearing at the end when the test suite was launched in diagnostic mode (no labels used), because the archiver package was trying to read a non-existent xml junit file.

```
ERROR  [Jul 25 19:36:43.837][suite_test.go: 226] Failed to compress results artifacts: failed to get file info from cnf-certification-tests_junit.xml: stat cnf-certification-tests_junit.xml: no such file or directory
```

The error itself was not making the program to return any error code, thus it was not detected in github ci.

As that file is never created in diagnostic mode, this change just avoids adding it to the list of files to zip at the end. Also, the program will return with error code if there's some error while creating the results+html zip file.