### PR TITLE
Github CI: Remove oct container image and the go mod cache to save disk space.

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -220,7 +220,7 @@ jobs:
       - name: Remove oct container image and the go mod cache to save disk space.
         run: |
           df -h
-          docker rmi ${REGISTRY}/${OCT_IMAGE_NAME}:${OCT_IMAGE_TAG} || true
+          docker rmi -f ${REGISTRY}/${OCT_IMAGE_NAME}:${OCT_IMAGE_TAG} || true
           go clean -modcache || true
           df -h
 

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -217,6 +217,13 @@ jobs:
       - name: Build CNF test suite binary
         run: make build-cnf-tests
 
+      - name: Remove oct container image and the go mod cache to save disk space.
+        run: |
+          df -h
+          docker rmi ${REGISTRY}/${OCT_IMAGE_NAME}:${OCT_IMAGE_TAG} || true
+          go clean -modcache || true
+          df -h
+
       # Create a Kind cluster for testing.
       - name: Check out `cnf-certification-test-partner`
         uses: actions/checkout@v3


### PR DESCRIPTION
The job "Run Local Smoke Tests" is also running out of free disk space, making the check to fail.

This change will clean the oct container image after it's been used and the go mod cache after the cnf cert suite program has been compiled.