### PR TITLE
85% QE coverage : with storage-required-pods + helm-chart-certified

### DIFF
--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -332,7 +332,7 @@ func InitCatalog() map[claim.Identifier]claim.TestCaseDescription {
 		StorageRequiredPods,
 		NoExceptions,
 		TestStorageRequiredPodsDocLink,
-		false,
+		true,
 		map[string]string{
 			FarEdge:  Mandatory,
 			Telco:    Mandatory,
@@ -862,7 +862,7 @@ tag. (2) It does not have any of the following prefixes: default, openshift-, is
 		HelmIsCertifiedRemediation,
 		AffiliatedCert,
 		TestHelmIsCertifiedIdentifierDocLink,
-		false,
+		true,
 		map[string]string{
 			FarEdge:  Mandatory,
 			Telco:    Mandatory,


### PR DESCRIPTION
With these, we get 85% of test covered.

Dependant on the merge of https://github.com/test-network-function/cnfcert-tests-verification/pull/396

and https://github.com/test-network-function/cnfcert-tests-verification/pull/385