### PR TITLE
Fix for parsing the image ID and image

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -334,7 +334,7 @@ func getPodContainers(aPod *corev1.Pod, useIgnoreList bool) (containerList []*Co
 
 		container := Container{Podname: aPod.Name, Namespace: aPod.Namespace,
 			NodeName: aPod.Spec.NodeName, Container: cut, Status: status, Runtime: aRuntime, UID: uid,
-			ContainerImageIdentifier: buildContainerImageSource(aPod.Spec.Containers[j].Image, cutStatus.ImageID)}
+			ContainerImageIdentifier: buildContainerImageSource(cutStatus.Image, cutStatus.ImageID)}
 
 		// Warn if readiness probe did not succeeded yet.
 		if !status.Ready {


### PR DESCRIPTION
~~Adding support for case where the image ID repo/name is different from Image~~
The original issue was cause by shorten names for the image in the spec, for instance using "httpd:2.4.57" instead of "docker.io/library/httpd:2.4.57" in the spec
Using the status instead of the spec value as the status will render the full url. Removed original fix as it requires further investigation wrt which repo/image name to use when imageID and image fields do not match.