### PR TITLE
Remove gradetool image to save space

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -203,6 +203,12 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Cleanup the runner
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+
       # Update the CNF containers, helm charts and operators DB
 
       - name: Update the CNF DB
@@ -253,6 +259,9 @@ jobs:
           path: |
             cnf-certification-test/*.tar.gz
 
+      - name: Remove tarball(s) to save disk space.
+        run: rm -f cnf-certification-test/*.tar.gz
+
       - name: Run gradetool on the claim.json
         run: |
           docker pull ${REGISTRY}/${GRADETOOL_IMAGE_NAME}:${GRADETOOL_IMAGE_TAG}
@@ -271,7 +280,7 @@ jobs:
       - name: Remove gradetool container image and the go mod cache to save disk space.
         run: |
           df -h
-          docker rmi -f ${REGISTRY}/${GRADETOOL_IMAGE_NAME}:${GRADETOOL_IMAGE_TAG}|| true
+          docker rmi -f ${REGISTRY}/${GRADETOOL_IMAGE_NAME}:${GRADETOOL_IMAGE_TAG} || true
           go clean -modcache || true
           df -h
 
@@ -285,6 +294,9 @@ jobs:
           name: preflight-smoke-tests
           path: |
             cnf-certification-test/*.tar.gz
+      
+      - name: Remove tarball(s) to save disk space
+        run: rm -f cnf-certification-test/*.tar.gz
 
   smoke-tests-container:
     name: Run Container Smoke Tests
@@ -325,6 +337,12 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Cleanup the runner
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+
       - name: Build the `cnf-certification-test` image
         run: |
           make build-image-local
@@ -360,6 +378,9 @@ jobs:
           path: |
             ${{ env.TNF_OUTPUT_DIR }}/*.tar.gz
 
+      - name: Remove tarball(s) to save disk space.
+        run: rm -f ${{ env.TNF_OUTPUT_DIR }}/*.tar.gz
+
       - name: Run gradetool on the claim.json
         run: |
           docker pull ${REGISTRY}/${GRADETOOL_IMAGE_NAME}:${GRADETOOL_IMAGE_TAG}
@@ -378,7 +399,7 @@ jobs:
       - name: Remove gradetool container image and the go mod cache to save disk space.
         run: |
           df -h
-          docker rmi -f ${REGISTRY}/${GRADETOOL_IMAGE_NAME}:${GRADETOOL_IMAGE_TAG}|| true
+          docker rmi -f ${REGISTRY}/${GRADETOOL_IMAGE_NAME}:${GRADETOOL_IMAGE_TAG} || true
           go clean -modcache || true
           df -h
 
@@ -392,6 +413,9 @@ jobs:
           name: preflight-smoke-tests-container
           path: |
             ${{ env.TNF_OUTPUT_DIR }}/*.tar.gz
+      
+      - name: Remove tarball(s) to save disk space.
+        run: rm -f ${{ env.TNF_OUTPUT_DIR }}/*.tar.gz
 
       # Push the new unstable TNF image to Quay.io.
       - name: (if on main and upstream) Authenticate against Quay.io

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -268,6 +268,13 @@ jobs:
             exit 1
           fi
 
+      - name: Remove gradetool container image and the go mod cache to save disk space.
+        run: |
+          df -h
+          docker rmi -f ${REGISTRY}/${GRADETOOL_IMAGE_NAME}:${GRADETOOL_IMAGE_TAG}|| true
+          go clean -modcache || true
+          df -h
+
       - name: 'Test: Run preflight specific test suite'
         run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./run-cnf-suites.sh -l "preflight"
 
@@ -367,6 +374,13 @@ jobs:
             jq '.[] | .Fail | .[].id' "${GITHUB_WORKSPACE}"/results.txt
             exit 1
           fi
+
+      - name: Remove gradetool container image and the go mod cache to save disk space.
+        run: |
+          df -h
+          docker rmi -f ${REGISTRY}/${GRADETOOL_IMAGE_NAME}:${GRADETOOL_IMAGE_TAG}|| true
+          go clean -modcache || true
+          df -h
 
       - name: 'Test: Run Preflight Specific Smoke Tests in a TNF container'
         run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./run-tnf-container.sh ${{ env.TESTING_CMD_PARAMS }} -l "preflight"


### PR DESCRIPTION
Similar to how we cleanup the `oct` image.