### PR TITLE
Fix regression for short image names

### DIFF
--- a/cnf-certification-test/certification/suite.go
+++ b/cnf-certification-test/certification/suite.go
@@ -98,9 +98,9 @@ func getContainersToQuery(env *provider.TestEnvironment) map[configuration.Conta
 }
 
 func testContainerCertification(c configuration.ContainerImageIdentifier, validator certdb.CertificationStatusValidator) bool {
-	ans := validator.IsContainerCertified(c.Repository, c.Name, c.Tag, c.Digest)
+	ans := validator.IsContainerCertified(c.Registry, c.Repository, c.Tag, c.Digest)
 	if !ans {
-		tnf.ClaimFilePrintf("%s/%s:%s is not listed in certified containers", c.Repository, c.Name, c.Tag)
+		tnf.ClaimFilePrintf("%s/%s:%s is not listed in certified containers", c.Registry, c.Repository, c.Tag)
 	}
 	return ans
 }
@@ -112,8 +112,8 @@ func testContainerCertificationStatus(env *provider.TestEnvironment, validator c
 	failedContainers := []configuration.ContainerImageIdentifier{}
 	allContainersToQueryEmpty := true
 	for c := range containersToQuery {
-		if c.Name == "" || c.Repository == "" {
-			tnf.ClaimFilePrintf("Container name = \"%s\" or repository = \"%s\" is missing, skipping this container to query", c.Name, c.Repository)
+		if c.Repository == "" || c.Registry == "" {
+			tnf.ClaimFilePrintf("Container name = \"%s\" or repository = \"%s\" is missing, skipping this container to query", c.Repository, c.Registry)
 			continue
 		}
 		allContainersToQueryEmpty = false
@@ -189,22 +189,22 @@ func testContainerCertificationStatusByDigest(env *provider.TestEnvironment, val
 	var compliantObjects []*testhelper.ReportObject
 	var nonCompliantObjects []*testhelper.ReportObject
 	for _, c := range env.Containers {
-		if c.ContainerImageIdentifier.Name == "" || c.ContainerImageIdentifier.Repository == "" {
-			tnf.ClaimFilePrintf("Container name = %q or repository = %q is missing, skipping this container to query", c.ContainerImageIdentifier.Name, c.ContainerImageIdentifier.Repository)
+		if c.ContainerImageIdentifier.Repository == "" || c.ContainerImageIdentifier.Registry == "" {
+			tnf.ClaimFilePrintf("Container name = %q or repository = %q is missing, skipping this container to query", c.ContainerImageIdentifier.Repository, c.ContainerImageIdentifier.Registry)
 			continue
 		}
 
 		switch {
 		case c.ContainerImageIdentifier.Digest == "":
-			tnf.ClaimFilePrintf("%s is missing digest field, failing validation (repo=%s image=%s)", c, c.ContainerImageIdentifier.Repository, c.ContainerImageIdentifier.Name)
+			tnf.ClaimFilePrintf("%s is missing digest field, failing validation (repo=%s image=%s)", c, c.ContainerImageIdentifier.Registry, c.ContainerImageIdentifier.Repository)
 			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(c.Namespace, c.Podname, c.Name, "Missing digest field", false).
-				AddField(testhelper.Repository, c.ContainerImageIdentifier.Repository).
-				AddField(testhelper.ImageName, c.ContainerImageIdentifier.Name))
+				AddField(testhelper.Repository, c.ContainerImageIdentifier.Registry).
+				AddField(testhelper.ImageName, c.ContainerImageIdentifier.Repository))
 		case !testContainerCertification(c.ContainerImageIdentifier, validator):
-			tnf.ClaimFilePrintf("%s digest not found in database, failing validation (repo=%s image=%s)", c, c.ContainerImageIdentifier.Repository, c.ContainerImageIdentifier.Name)
+			tnf.ClaimFilePrintf("%s digest not found in database, failing validation (repo=%s image=%s)", c, c.ContainerImageIdentifier.Registry, c.ContainerImageIdentifier.Repository)
 			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(c.Namespace, c.Podname, c.Name, "Digest not found in database", false).
-				AddField(testhelper.Repository, c.ContainerImageIdentifier.Repository).
-				AddField(testhelper.ImageName, c.ContainerImageIdentifier.Name))
+				AddField(testhelper.Repository, c.ContainerImageIdentifier.Registry).
+				AddField(testhelper.ImageName, c.ContainerImageIdentifier.Repository))
 		default:
 			compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(c.Namespace, c.Podname, c.Name, "Container is certified", true))
 		}

--- a/cnf-certification-test/certification/suite_test.go
+++ b/cnf-certification-test/certification/suite_test.go
@@ -31,16 +31,16 @@ func TestGetContainersToQuery(t *testing.T) {
 				CheckDiscoveredContainerCertificationStatus: certStatus,
 				CertifiedContainerInfo: []configuration.ContainerImageIdentifier{
 					{
-						Name:       "test2",
-						Repository: "repo1",
+						Repository: "test2",
+						Registry:   "repo1",
 					},
 				},
 			},
 			Containers: []*provider.Container{
 				{
 					ContainerImageIdentifier: configuration.ContainerImageIdentifier{
-						Name:       "test1",
-						Repository: "repo1",
+						Repository: "test1",
+						Registry:   "repo1",
 					},
 				},
 			},
@@ -55,12 +55,12 @@ func TestGetContainersToQuery(t *testing.T) {
 			testCertStatus: true,
 			expectedOutput: map[configuration.ContainerImageIdentifier]bool{
 				{
-					Name:       "test1",
-					Repository: "repo1",
+					Repository: "test1",
+					Registry:   "repo1",
 				}: true,
 				{
-					Name:       "test2",
-					Repository: "repo1",
+					Repository: "test2",
+					Registry:   "repo1",
 				}: true,
 			},
 		},
@@ -68,8 +68,8 @@ func TestGetContainersToQuery(t *testing.T) {
 			testCertStatus: false,
 			expectedOutput: map[configuration.ContainerImageIdentifier]bool{
 				{
-					Name:       "test2",
-					Repository: "repo1",
+					Repository: "test2",
+					Registry:   "repo1",
 				}: true,
 			},
 		},

--- a/internal/certdb/onlinecheck/onlinecheck.go
+++ b/internal/certdb/onlinecheck/onlinecheck.go
@@ -345,9 +345,9 @@ func CreateContainerCatalogQueryURL(id configuration.ContainerImageIdentifier) s
 			id.Tag = defaultTag
 		}
 		url = fmt.Sprintf("%s/%s/%s/images?filter=architecture==%s;repositories.repository==%s/%s;repositories.tags.name==%s",
-			apiCatalogByRepositoriesBaseEndPoint, id.Repository, id.Name, arch, id.Repository, id.Name, id.Tag)
+			apiCatalogByRepositoriesBaseEndPoint, id.Registry, id.Repository, arch, id.Registry, id.Repository, id.Tag)
 	} else {
-		url = fmt.Sprintf("%s/%s/%s/images?filter=architecture==%s;image_id==%s", apiCatalogByRepositoriesBaseEndPoint, id.Repository, id.Name, arch, id.Digest)
+		url = fmt.Sprintf("%s/%s/%s/images?filter=architecture==%s;image_id==%s", apiCatalogByRepositoriesBaseEndPoint, id.Registry, id.Repository, arch, id.Digest)
 	}
 	return url
 }

--- a/internal/certdb/onlinecheck/onlinecheck_test.go
+++ b/internal/certdb/onlinecheck/onlinecheck_test.go
@@ -37,8 +37,8 @@ func TestCreateContainerCatalogQueryURL(t *testing.T) {
 	}{
 		{
 			testContainerImageID: configuration.ContainerImageIdentifier{
-				Name:       "name1",
-				Repository: "repo1",
+				Repository: "name1",
+				Registry:   "repo1",
 				Tag:        "tag1",
 				Digest:     "digest1",
 			},
@@ -46,8 +46,8 @@ func TestCreateContainerCatalogQueryURL(t *testing.T) {
 		},
 		{
 			testContainerImageID: configuration.ContainerImageIdentifier{
-				Name:       "name1",
-				Repository: "repo1",
+				Repository: "name1",
+				Registry:   "repo1",
 				Tag:        "tag1",
 				// Digest:     "digest1",
 			},
@@ -55,8 +55,8 @@ func TestCreateContainerCatalogQueryURL(t *testing.T) {
 		},
 		{
 			testContainerImageID: configuration.ContainerImageIdentifier{
-				Name:       "name1",
-				Repository: "repo1",
+				Repository: "name1",
+				Registry:   "repo1",
 				// Tag:        "tag1",
 				// Digest:     "digest1",
 			},

--- a/pkg/configuration/config_test.go
+++ b/pkg/configuration/config_test.go
@@ -73,7 +73,7 @@ func TestLoadConfiguration(t *testing.T) {
 	assert.Contains(t, env.CrdFilters, crd2)
 	// check if certifiedcontainerinfo section is parsed properly
 	assert.Equal(t, containers, len(env.CertifiedContainerInfo))
-	containerInfo := configuration.ContainerImageIdentifier{Name: containerInfoName, Repository: containerRepo, Tag: "", Digest: ""}
+	containerInfo := configuration.ContainerImageIdentifier{Repository: containerInfoName, Registry: containerRepo, Tag: "", Digest: ""}
 	assert.Contains(t, env.CertifiedContainerInfo, containerInfo)
 	// check if certifiedoperatorinfo section is parsed properly
 	assert.Equal(t, operators, len(env.CertifiedOperatorInfo))

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -91,12 +91,12 @@ type ManagedDeploymentsStatefulsets struct {
 
 // Tag and Digest should not be populated at the same time. Digest takes precedence if both are populated
 type ContainerImageIdentifier struct {
-	// Name is the name of the image that you want to check if exists in the RedHat catalog
-	Name string `yaml:"name" json:"name"`
-
-	// Repository is the name of the repository `rhel8` of the container
-	// This is valid for container only and required field
+	// Repository is the name of the image that you want to check if exists in the RedHat catalog
 	Repository string `yaml:"repository" json:"repository"`
+
+	// Registry is the name of the registry `docker.io` of the container
+	// This is valid for container only and required field
+	Registry string `yaml:"registry" json:"registry"`
 
 	// Tag is the optional image tag. "latest" is implied if not specified
 	Tag string `yaml:"tag" json:"tag"`

--- a/pkg/configuration/testdata/tnf_test_config.yml
+++ b/pkg/configuration/testdata/tnf_test_config.yml
@@ -22,8 +22,8 @@ targetCrdFilters:
   - nameSuffix: "group1.test.com"
   - nameSuffix: "group2.test.com"
 certifiedcontainerinfo:
-  - name: nginx-116  # working example
-    repository: rhel8
+  - repository: nginx-116  # working example
+    registry: rhel8
 certifiedoperatorinfo:
   - name: etcd
     organization: community-operators # working example

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -393,15 +393,22 @@ func IsOCPCluster() bool {
 }
 
 func buildContainerImageSource(urlImage, urlImageID string) (source configuration.ContainerImageIdentifier) {
-	const regexImageWithTag = `([^/]*)/([^@]*):(.*)`
-	const regexImageDigest = `([^/]*)/(.*)@(.*:.*)`
+	const regexImageWithTag = `^([^/]*)/*([^@]*):(.*)`
+	const regexImageDigest = `^([^/]*)/(.*)@(.*:.*)`
 
 	// get image repository, Name and tag if present
 	re := regexp.MustCompile(regexImageWithTag)
 	match := re.FindStringSubmatch(urlImage)
 
 	if match != nil {
-		source.Tag = match[3]
+		if match[2] != "" {
+			source.Registry = match[1]
+			source.Repository = match[2]
+			source.Tag = match[3]
+		} else {
+			source.Repository = match[1]
+			source.Tag = match[3]
+		}
 	}
 
 	// get image Digest based on imageID only
@@ -409,14 +416,12 @@ func buildContainerImageSource(urlImage, urlImageID string) (source configuratio
 	match = re.FindStringSubmatch(urlImageID)
 
 	if match != nil {
-		source.Repository = match[1]
-		source.Name = match[2]
 		source.Digest = match[3]
 	}
 
 	logrus.Debugf("parsed image, repo: %s, name:%s, tag: %s, digest: %s",
+		source.Registry,
 		source.Repository,
-		source.Name,
 		source.Tag,
 		source.Digest)
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -334,7 +334,7 @@ func getPodContainers(aPod *corev1.Pod, useIgnoreList bool) (containerList []*Co
 
 		container := Container{Podname: aPod.Name, Namespace: aPod.Namespace,
 			NodeName: aPod.Spec.NodeName, Container: cut, Status: status, Runtime: aRuntime, UID: uid,
-			ContainerImageIdentifier: buildContainerImageSource(cutStatus.Image, cutStatus.ImageID)}
+			ContainerImageIdentifier: buildContainerImageSource(aPod.Spec.Containers[j].Image, cutStatus.ImageID)}
 
 		// Warn if readiness probe did not succeeded yet.
 		if !status.Ready {

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -814,27 +814,39 @@ func Test_buildContainerImageSource(t *testing.T) {
 		args       args
 		wantSource configuration.ContainerImageIdentifier
 	}{
-		{name: "image has tag",
+		{name: "image has tag and registry",
 			args: args{
 				urlImage:   "quay.io/testnetworkfunction/cnf-test-partner:latest",
 				urlImageID: "quay.io/testnetworkfunction/cnf-test-partner@sha256:2341c96eba68e2dbf9498a2fe7b95e6f9b84f6ac15fa2d0d811168667a919a49",
 			},
 			wantSource: configuration.ContainerImageIdentifier{
-				Repository: "quay.io",
-				Name:       "testnetworkfunction/cnf-test-partner",
+				Registry:   "quay.io",
+				Repository: "testnetworkfunction/cnf-test-partner",
 				Tag:        "latest",
 				Digest:     "sha256:2341c96eba68e2dbf9498a2fe7b95e6f9b84f6ac15fa2d0d811168667a919a49",
 			},
 		},
-		{name: "digest and imageID do not match and no tag",
+		{name: "digest in image and imageID do not match and no tag",
 			args: args{
-				urlImage:   "quay.io/testnetworkfunction/cnf-test-partner@sha256:2341c96eba68e2dbf9498a2fe7b96465665465465a2d0d811168667a919a49",
+				urlImage:   "quay.io/testnetworkfunction/cnf-test-partner@sha256:2341c96eba68e2dbf9498a2fe7b96465665465465a2d0d811168667a919345",
 				urlImageID: "quay.io/testnetworkfunction/cnf-test-partner@sha256:2341c96eba68e2dbf9498a2fe7b95e6f9b84f6ac15fa2d0d811168667a919a49",
 			},
 			wantSource: configuration.ContainerImageIdentifier{
-				Repository: "quay.io",
-				Name:       "testnetworkfunction/cnf-test-partner",
+				Registry:   "",
+				Repository: "",
 				Tag:        "",
+				Digest:     "sha256:2341c96eba68e2dbf9498a2fe7b95e6f9b84f6ac15fa2d0d811168667a919a49",
+			},
+		},
+		{name: "image with no tag and no registry",
+			args: args{
+				urlImage:   "httpd:2.4.57",
+				urlImageID: "quay.io/httpd:2.4.57@sha256:2341c96eba68e2dbf9498a2fe7b95e6f9b84f6ac15fa2d0d811168667a919a49",
+			},
+			wantSource: configuration.ContainerImageIdentifier{
+				Registry:   "",
+				Repository: "httpd",
+				Tag:        "2.4.57",
 				Digest:     "sha256:2341c96eba68e2dbf9498a2fe7b95e6f9b84f6ac15fa2d0d811168667a919a49",
 			},
 		},


### PR DESCRIPTION
Re-add support for short image names such as httpd:2.4.57
revert https://github.com/test-network-function/cnf-certification-test/pull/1305 to use the spec version of the image name as the user entered it
Rename the following:
- ContainerImageIdentifier.Name to ContainerImageIdentifier.Repository -> e.g. "testnetworkfunction/cnf-test-partner"
- ContainerImageIdentifier.Repository to ContainerImageIdentifier.Registry -> e.g. "quay.io"

