### PR TITLE
lifecycle: fix bug preventing dumping test info after a failure

### DIFF
--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -593,10 +593,10 @@ func testPodsRecreation(env *provider.TestEnvironment) { //nolint:funlen
 		if err != nil {
 			logrus.Fatalf("error uncordoning the node: %s", n)
 		}
-
-		// Reached end of TC, which means no ginkgo.Fail() was called.
-		needsPostMortemInfo = false
 	}
+
+	// Reached end of TC, which means no ginkgo.Fail() was called.
+	needsPostMortemInfo = false
 }
 
 func testPodPersistentVolumeReclaimPolicy(env *provider.TestEnvironment) {


### PR DESCRIPTION
If a node has passed the test properly before another node fails it, the test info won't be dumped as the bool controlling this would be already set to false.