### PR TITLE
Enable networking QE PR tests

### DIFF
--- a/.github/workflows/qe.yaml
+++ b/.github/workflows/qe.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix: 
         # suite: [accesscontrol, affiliatedcertification, lifecycle, networking, observability, platformalteration, performance, operator]
-        suite: [lifecycle, manageability]
+        suite: [lifecycle, manageability, networking]
     env:
       SHELL: /bin/bash
       DEBUG_TNF: true # More verbose output from the TNF


### PR DESCRIPTION
All networking QE tests are [now passing](https://github.com/test-network-function/cnfcert-tests-verification/pull/418) in Kind so they can be enabled for PR testing.  🎉 