### PR TITLE
Remove 'make install' call from QE jobs

### DIFF
--- a/.github/workflows/qe.yaml
+++ b/.github/workflows/qe.yaml
@@ -65,10 +65,6 @@ jobs:
       - name: Create `local-test-infra` OpenShift resources
         run: make rebuild-cluster
         working-directory: cnf-certification-test-partner
-  
-      - name: Install partner resources
-        run: make install
-        working-directory: cnf-certification-test-partner
 
       - name: Clone the QE repository
         uses: actions/checkout@v3


### PR DESCRIPTION
We don't need the -partner repo resources installed for QE testing.  The QE repo installs all of its necessary testing resources itself.

Builds on: https://github.com/test-network-function/cnf-certification-test-partner/pull/323 