### PR TITLE
Prepare for version v4.3.4

### DIFF
--- a/docs/runtime-env.md
+++ b/docs/runtime-env.md
@@ -68,4 +68,4 @@ export TNF_PARTNER_REPO=registry.dfwt5g.lab:5000/testnetworkfunction
 ```
 
 Note that you can also specify the debug pod image to use with `SUPPORT_IMAGE`
-environment variable, default to `debug-partner:4.3.3`.
+environment variable, default to `debug-partner:4.3.4`.

--- a/docs/test-container.md
+++ b/docs/test-container.md
@@ -112,8 +112,8 @@ Two env vars allow to control the web artifacts and the the new tar.gz file gene
 ### Build locally
 
 ```shell
-podman build -t cnf-certification-test:v4.3.3 \
-  --build-arg TNF_VERSION=v4.3.3 \
+podman build -t cnf-certification-test:v4.3.4 \
+  --build-arg TNF_VERSION=v4.3.4 \
 ```
 
 * `TNF_VERSION` value is set to a branch, a tag, or a hash of a commit that will be installed into the image
@@ -125,8 +125,8 @@ The unofficial source could be a fork of the TNF repository.
 Use the `TNF_SRC_URL` build argument to override the URL to a source repository.
 
 ```shell
-podman build -t cnf-certification-test:v4.3.3 \
-  --build-arg TNF_VERSION=v4.3.3 \
+podman build -t cnf-certification-test:v4.3.4 \
+  --build-arg TNF_VERSION=v4.3.4 \
   --build-arg TNF_SRC_URL=https://github.com/test-network-function/cnf-certification-test .
 ```
 
@@ -135,7 +135,7 @@ podman build -t cnf-certification-test:v4.3.3 \
 Specify the custom TNF image using the `-i` parameter.
 
 ```shell
-./run-tnf-container.sh -i cnf-certification-test:v4.3.3
+./run-tnf-container.sh -i cnf-certification-test:v4.3.4
 -t ~/tnf/config -o ~/tnf/output -l "networking,access-control"
 ```
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -60,7 +60,7 @@ const (
 	cscosName                        = "CentOS Stream CoreOS"
 	rhelName                         = "Red Hat Enterprise Linux"
 	tnfPartnerRepoDef                = "quay.io/testnetworkfunction"
-	supportImageDef                  = "debug-partner:4.3.3"
+	supportImageDef                  = "debug-partner:4.3.4"
 )
 
 // Node's roles labels. Node is role R if it has **any** of the labels of each list.

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -788,7 +788,7 @@ func TestBuildImageWithVersion(t *testing.T) {
 		{
 			repoVar:         "",
 			supportImageVar: "",
-			expectedOutput:  "quay.io/testnetworkfunction/debug-partner:4.3.3",
+			expectedOutput:  "quay.io/testnetworkfunction/debug-partner:4.3.4",
 		},
 	}
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "partner_tag": "v4.3.3",
+  "partner_tag": "v4.3.4",
   "claimFormat": "v0.1.0",
   "parserTag": "v0.1.1"
 }


### PR DESCRIPTION
Partner release: https://github.com/test-network-function/cnf-certification-test-partner/releases/tag/v4.3.4