### PR TITLE
operator: fix the process to check if an operator is ready

### DIFF
--- a/cnf-certification-test/operator/phasecheck/phasecheck.go
+++ b/cnf-certification-test/operator/phasecheck/phasecheck.go
@@ -47,9 +47,13 @@ func waitOperatorReady(csv *v1alpha1.ClusterServiceVersion) bool {
 
 		// update old csv and check status again
 		*csv = *freshCsv
-		if csv.Status.Phase == v1alpha1.CSVPhaseSucceeded {
+		switch csv.Status.Phase { //nolint:exhaustive
+		case v1alpha1.CSVPhaseSucceeded:
 			tnf.ClaimFilePrintf("%s is ready", provider.CsvToString(csv))
 			return true
+		case v1alpha1.CSVPhaseFailed, v1alpha1.CSVPhaseUnknown, v1alpha1.CSVPhaseAny:
+			tnf.ClaimFilePrintf("%s failed to be ready, status=%s", provider.CsvToString(csv), csv.Status.Phase)
+			return false
 		}
 
 		tnf.ClaimFilePrintf("Waiting for %s to be in Succeeded phase: %s", provider.CsvToString(freshCsv), csv.Status.Phase)

--- a/cnf-certification-test/operator/phasecheck/phasecheck.go
+++ b/cnf-certification-test/operator/phasecheck/phasecheck.go
@@ -69,22 +69,13 @@ func IsOperatorPhaseSucceeded(csv *v1alpha1.ClusterServiceVersion) bool {
 	switch csv.Status.Phase {
 	case v1alpha1.CSVPhaseSucceeded:
 		return true
-	case v1alpha1.CSVPhaseFailed:
-		fallthrough
-	case v1alpha1.CSVPhaseUnknown:
+	case v1alpha1.CSVPhaseFailed, v1alpha1.CSVPhaseUnknown, v1alpha1.CSVPhaseAny:
 		return false
 	// Operator is not ready, but we need to take into account that its pods
 	// could have been deleted by some of the lifecycle test cases, so they
 	// could be restarting. Let's give it some time before declaring it failed.
-	case v1alpha1.CSVPhasePending:
-		fallthrough
-	case v1alpha1.CSVPhaseInstalling:
-		fallthrough
-	case v1alpha1.CSVPhaseInstallReady:
-		fallthrough
-	case v1alpha1.CSVPhaseDeleting:
-		fallthrough
-	case v1alpha1.CSVPhaseReplacing:
+	case v1alpha1.CSVPhasePending, v1alpha1.CSVPhaseInstalling, v1alpha1.CSVPhaseInstallReady,
+		v1alpha1.CSVPhaseDeleting, v1alpha1.CSVPhaseReplacing:
 		return waitOperatorReady(csv)
 	default:
 		return false

--- a/cnf-certification-test/operator/phasecheck/phasecheck_test.go
+++ b/cnf-certification-test/operator/phasecheck/phasecheck_test.go
@@ -51,7 +51,68 @@ func Test_isOperatorSucceeded(t *testing.T) {
 					Namespace: "aNamespace",
 				},
 				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhaseInstalling,
+				},
+			}},
+			wantIsReady: false,
+		},
+		{name: "nok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhaseDeleting,
+				},
+			}},
+			wantIsReady: false,
+		},
+		{name: "nok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhaseInstallReady,
+				},
+			}},
+
+			wantIsReady: false,
+		},
+		{name: "nok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
 					Phase: v1alpha1.CSVPhaseUnknown,
+				},
+			}},
+			wantIsReady: false,
+		},
+		{name: "nok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhasePending,
+				},
+			}},
+			wantIsReady: false,
+		},
+		{name: "nok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhaseReplacing,
 				},
 			}},
 			wantIsReady: false,
@@ -81,12 +142,94 @@ func Test_isOperatorSucceeded(t *testing.T) {
 
 			wantIsReady: false,
 		},
+		{name: "nok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhaseNone,
+				},
+			}},
+
+			wantIsReady: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if gotIsReady := IsOperatorPhaseSucceeded(tt.args.csv); gotIsReady != tt.wantIsReady {
 				t.Errorf("isOperatorSucceeded() = %v, want %v", gotIsReady, tt.wantIsReady)
+			}
+		})
+	}
+}
+
+func Test_isOperatorFailedOrUnknown(t *testing.T) {
+	type args struct {
+		csv *v1alpha1.ClusterServiceVersion
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantIsReady bool
+	}{
+		{name: "ok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhaseFailed,
+				},
+			}},
+			wantIsReady: true,
+		},
+		{name: "ok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhaseUnknown,
+				},
+			}},
+			wantIsReady: true,
+		},
+		{name: "nok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhaseDeleting,
+				},
+			}},
+			wantIsReady: false,
+		},
+		{name: "nok",
+			args: args{csv: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "aCSV",
+					Namespace: "aNamespace",
+				},
+				Status: v1alpha1.ClusterServiceVersionStatus{
+					Phase: v1alpha1.CSVPhaseInstallReady,
+				},
+			}},
+
+			wantIsReady: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotIsReady := IsOperatorPhaseFailedOrUnknown(tt.args.csv); gotIsReady != tt.wantIsReady {
+				t.Errorf("isOperatorFailedOrUnknown() = %v, want %v", gotIsReady, tt.wantIsReady)
 			}
 		})
 	}

--- a/cnf-certification-test/operator/phasecheck/phasecheck_test.go
+++ b/cnf-certification-test/operator/phasecheck/phasecheck_test.go
@@ -159,7 +159,7 @@ func Test_isOperatorSucceeded(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if gotIsReady := IsOperatorPhaseSucceeded(tt.args.csv); gotIsReady != tt.wantIsReady {
+			if gotIsReady := isOperatorPhaseSucceeded(tt.args.csv); gotIsReady != tt.wantIsReady {
 				t.Errorf("isOperatorSucceeded() = %v, want %v", gotIsReady, tt.wantIsReady)
 			}
 		})
@@ -228,7 +228,7 @@ func Test_isOperatorFailedOrUnknown(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if gotIsReady := IsOperatorPhaseFailedOrUnknown(tt.args.csv); gotIsReady != tt.wantIsReady {
+			if gotIsReady := isOperatorPhaseFailedOrUnknown(tt.args.csv); gotIsReady != tt.wantIsReady {
 				t.Errorf("isOperatorFailedOrUnknown() = %v, want %v", gotIsReady, tt.wantIsReady)
 			}
 		})

--- a/cnf-certification-test/operator/phasecheck/phasecheck_test.go
+++ b/cnf-certification-test/operator/phasecheck/phasecheck_test.go
@@ -51,66 +51,7 @@ func Test_isOperatorSucceeded(t *testing.T) {
 					Namespace: "aNamespace",
 				},
 				Status: v1alpha1.ClusterServiceVersionStatus{
-					Phase: v1alpha1.CSVPhaseInstalling,
-				},
-			}},
-			wantIsReady: false,
-		},
-		{name: "nok",
-			args: args{csv: &v1alpha1.ClusterServiceVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "aCSV",
-					Namespace: "aNamespace",
-				},
-				Status: v1alpha1.ClusterServiceVersionStatus{
-					Phase: v1alpha1.CSVPhaseDeleting,
-				},
-			}},
-			wantIsReady: false,
-		},
-		{name: "nok",
-			args: args{csv: &v1alpha1.ClusterServiceVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "aCSV",
-					Namespace: "aNamespace",
-				},
-				Status: v1alpha1.ClusterServiceVersionStatus{
-					Phase: v1alpha1.CSVPhaseInstallReady,
-				},
-			}},
-		},
-		{name: "nok",
-			args: args{csv: &v1alpha1.ClusterServiceVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "aCSV",
-					Namespace: "aNamespace",
-				},
-				Status: v1alpha1.ClusterServiceVersionStatus{
 					Phase: v1alpha1.CSVPhaseUnknown,
-				},
-			}},
-			wantIsReady: false,
-		},
-		{name: "nok",
-			args: args{csv: &v1alpha1.ClusterServiceVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "aCSV",
-					Namespace: "aNamespace",
-				},
-				Status: v1alpha1.ClusterServiceVersionStatus{
-					Phase: v1alpha1.CSVPhasePending,
-				},
-			}},
-			wantIsReady: false,
-		},
-		{name: "nok",
-			args: args{csv: &v1alpha1.ClusterServiceVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "aCSV",
-					Namespace: "aNamespace",
-				},
-				Status: v1alpha1.ClusterServiceVersionStatus{
-					Phase: v1alpha1.CSVPhaseReplacing,
 				},
 			}},
 			wantIsReady: false,
@@ -135,19 +76,6 @@ func Test_isOperatorSucceeded(t *testing.T) {
 				},
 				Status: v1alpha1.ClusterServiceVersionStatus{
 					Phase: v1alpha1.CSVPhaseFailed,
-				},
-			}},
-
-			wantIsReady: false,
-		},
-		{name: "nok",
-			args: args{csv: &v1alpha1.ClusterServiceVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "aCSV",
-					Namespace: "aNamespace",
-				},
-				Status: v1alpha1.ClusterServiceVersionStatus{
-					Phase: v1alpha1.CSVPhaseNone,
 				},
 			}},
 

--- a/cnf-certification-test/operator/suite.go
+++ b/cnf-certification-test/operator/suite.go
@@ -65,21 +65,13 @@ func testOperatorInstallationPhaseSucceeded(env *provider.TestEnvironment) {
 	for i := range env.Operators {
 		csv := env.Operators[i].Csv
 		if phasecheck.IsOperatorPhaseSucceeded(csv) {
-			continue
-		}
-
-		// Operator is not ready, but we need to take into account that its pods
-		// could have been deleted by some of the lifecycle test cases, so they
-		// could be restarting. Let's give it some time before declaring it failed.
-		phase := phasecheck.WaitOperatorReady(csv)
-		if phase != v1alpha1.CSVPhaseSucceeded {
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewOperatorReportObject(env.Operators[i].Namespace, env.Operators[i].Name,
-				"Operator not in Succeeded state ", false).AddField(testhelper.OperatorPhase, string(phase)))
-			tnf.ClaimFilePrintf("%s is in phase %s. Expected phase is %s",
-				&env.Operators[i], phase, v1alpha1.CSVPhaseSucceeded)
-		} else {
 			compliantObjects = append(compliantObjects, testhelper.NewOperatorReportObject(env.Operators[i].Namespace, env.Operators[i].Name,
-				"Operator on Succeeded state ", true).AddField(testhelper.OperatorPhase, string(phase)))
+				"Operator on Succeeded state ", true).AddField(testhelper.OperatorPhase, string(csv.Status.Phase)))
+		} else {
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewOperatorReportObject(env.Operators[i].Namespace, env.Operators[i].Name,
+				"Operator not in Succeeded state ", false).AddField(testhelper.OperatorPhase, string(csv.Status.Phase)))
+			tnf.ClaimFilePrintf("%s is in phase %s. Expected phase is %s",
+				&env.Operators[i], csv.Status.Phase, v1alpha1.CSVPhaseSucceeded)
 		}
 	}
 

--- a/cnf-certification-test/operator/suite.go
+++ b/cnf-certification-test/operator/suite.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/common"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/identifiers"
@@ -64,22 +63,7 @@ func testOperatorInstallationPhaseSucceeded(env *provider.TestEnvironment) {
 	var nonCompliantObjects []*testhelper.ReportObject
 	for i := range env.Operators {
 		csv := env.Operators[i].Csv
-
-		var isCompliant bool
-		switch {
-		case phasecheck.IsOperatorPhaseSucceeded(csv):
-			isCompliant = true
-		case phasecheck.IsOperatorPhaseFailedOrUnknown(csv):
-			isCompliant = false
-			tnf.ClaimFilePrintf("%s is in phase %s. Expected phase is %s", &env.Operators[i], csv.Status.Phase, v1alpha1.CSVPhaseSucceeded)
-		default:
-			// Operator is not ready, but we need to take into account that its pods
-			// could have been deleted by some of the lifecycle test cases, so they
-			// could be restarting. Let's give it some time before declaring it failed.
-			isCompliant = phasecheck.WaitOperatorReady(csv)
-		}
-
-		if isCompliant {
+		if phasecheck.WaitOperatorReady(csv) {
 			compliantObjects = append(compliantObjects, testhelper.NewOperatorReportObject(env.Operators[i].Namespace, env.Operators[i].Name,
 				"Operator on Succeeded state ", true).AddField(testhelper.OperatorPhase, string(csv.Status.Phase)))
 		} else {


### PR DESCRIPTION
The two main modifications are:

* Only wait for an operator to be ready when it's in a state that could potentially lead to a Succeeded state. For instance, it does not make sense to wait when it's in the Failed state.

* Do not log with logrus.Faltalf() the timeout condition, as this causes the CNF Certification Suite to return with an error exit status. It should set the operator as non compliant but continue with the remaining tests.

The combination of these two points cause the CNF Certification Suite to fail and stop executing if an operator never reaches the Succeeded state, when only a test case failure should occur.

The only test case affected is operator-install-status-succeeded.