### PR TITLE
Add tnf.Log() function to allow log level selection

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -523,7 +523,7 @@ func testPodRoleBindings(env *provider.TestEnvironment) {
 					// If the subject is a service account and the service account is in the same namespace as the pod, then we have a failure
 					//nolint:gocritic
 					if subject.Kind == rbacv1.ServiceAccountKind && subject.Namespace == put.Namespace && subject.Name == put.Spec.ServiceAccountName {
-						tnf.Log(logrus.WarnLevel, "Pod: %s/%s has the following role bindings that do not live in the same namespace: %s", put.Namespace, put.Name, env.RoleBindings[rbIndex].Name)
+						tnf.Logf(logrus.WarnLevel, "Pod: %s/%s has the following role bindings that do not live in the same namespace: %s", put.Namespace, put.Name, env.RoleBindings[rbIndex].Name)
 
 						// Add the pod to the non-compliant list
 						nonCompliantObjects = append(nonCompliantObjects,
@@ -574,7 +574,7 @@ func testPodClusterRoleBindings(env *provider.TestEnvironment) {
 		// Pod was found to be using a cluster role binding.  This is not allowed.
 		// Flagging this pod as a failed pod.
 		if result {
-			tnf.Log(logrus.WarnLevel, "%s is using a cluster role binding", put.String())
+			tnf.Logf(logrus.WarnLevel, "%s is using a cluster role binding", put.String())
 			podIsCompliant = false
 		}
 

--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -523,9 +523,7 @@ func testPodRoleBindings(env *provider.TestEnvironment) {
 					// If the subject is a service account and the service account is in the same namespace as the pod, then we have a failure
 					//nolint:gocritic
 					if subject.Kind == rbacv1.ServiceAccountKind && subject.Namespace == put.Namespace && subject.Name == put.Spec.ServiceAccountName {
-						failMsg := fmt.Sprintf("Pod: %s/%s has the following role bindings that do not live in the same namespace: %s", put.Namespace, put.Name, env.RoleBindings[rbIndex].Name)
-						logrus.Warnf(failMsg)
-						tnf.ClaimFilePrintf(failMsg)
+						tnf.Log(logrus.WarnLevel, "Pod: %s/%s has the following role bindings that do not live in the same namespace: %s", put.Namespace, put.Name, env.RoleBindings[rbIndex].Name)
 
 						// Add the pod to the non-compliant list
 						nonCompliantObjects = append(nonCompliantObjects,
@@ -576,9 +574,7 @@ func testPodClusterRoleBindings(env *provider.TestEnvironment) {
 		// Pod was found to be using a cluster role binding.  This is not allowed.
 		// Flagging this pod as a failed pod.
 		if result {
-			errMsg := fmt.Sprintf("%s is using a cluster role binding", put.String())
-			logrus.Warn(errMsg)
-			tnf.ClaimFilePrintf(errMsg)
+			tnf.Log(logrus.WarnLevel, "%s is using a cluster role binding", put.String())
 			podIsCompliant = false
 		}
 

--- a/cnf-certification-test/operator/phasecheck/phasecheck.go
+++ b/cnf-certification-test/operator/phasecheck/phasecheck.go
@@ -18,7 +18,6 @@ package phasecheck
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -53,9 +52,7 @@ func WaitOperatorReady(csv *v1alpha1.ClusterServiceVersion) bool {
 
 		freshCsv, err := oc.OlmClient.OperatorsV1alpha1().ClusterServiceVersions(csv.Namespace).Get(context.TODO(), csv.Name, metav1.GetOptions{})
 		if err != nil {
-			errMsg := fmt.Sprintf("could not get csv %s, err: %v", provider.CsvToString(freshCsv), err)
-			logrus.Errorf(errMsg)
-			tnf.ClaimFilePrintf(errMsg)
+			tnf.Log(logrus.ErrorLevel, "could not get csv %s, err: %v", provider.CsvToString(freshCsv), err)
 			return false
 		}
 
@@ -63,9 +60,7 @@ func WaitOperatorReady(csv *v1alpha1.ClusterServiceVersion) bool {
 		*csv = *freshCsv
 	}
 	if time.Since(start) > timeout {
-		errMsg := fmt.Sprintf("timeout waiting for csv %s to be ready", provider.CsvToString(csv))
-		logrus.Errorf(errMsg)
-		tnf.ClaimFilePrintf(errMsg)
+		tnf.Log(logrus.ErrorLevel, "timeout waiting for csv %s to be ready", provider.CsvToString(csv))
 	}
 
 	return false

--- a/cnf-certification-test/operator/phasecheck/phasecheck.go
+++ b/cnf-certification-test/operator/phasecheck/phasecheck.go
@@ -52,7 +52,7 @@ func WaitOperatorReady(csv *v1alpha1.ClusterServiceVersion) bool {
 
 		freshCsv, err := oc.OlmClient.OperatorsV1alpha1().ClusterServiceVersions(csv.Namespace).Get(context.TODO(), csv.Name, metav1.GetOptions{})
 		if err != nil {
-			tnf.Log(logrus.ErrorLevel, "could not get csv %s, err: %v", provider.CsvToString(freshCsv), err)
+			tnf.Logf(logrus.ErrorLevel, "could not get csv %s, err: %v", provider.CsvToString(freshCsv), err)
 			return false
 		}
 
@@ -60,7 +60,7 @@ func WaitOperatorReady(csv *v1alpha1.ClusterServiceVersion) bool {
 		*csv = *freshCsv
 	}
 	if time.Since(start) > timeout {
-		tnf.Log(logrus.ErrorLevel, "timeout waiting for csv %s to be ready", provider.CsvToString(csv))
+		tnf.Logf(logrus.ErrorLevel, "timeout waiting for csv %s to be ready", provider.CsvToString(csv))
 	}
 
 	return false

--- a/pkg/tnf/status.go
+++ b/pkg/tnf/status.go
@@ -9,11 +9,16 @@ import (
 
 // ClaimFilePrintf prints to claim and junit report files.
 func ClaimFilePrintf(format string, args ...interface{}) {
+	Log(logrus.TraceLevel, format, args)
+}
+
+// Log prints to stdout and claim and junit report files.
+func Log(level logrus.Level, format string, args ...interface{}) {
 	message := fmt.Sprintf(format+"\n", args...)
 	_, err := ginkgo.GinkgoWriter.Write([]byte(message))
 	if err != nil {
 		logrus.Errorf("Ginkgo writer could not write msg '%s' because: %s", message, err)
-	} else {
-		logrus.Trace(message)
 	}
+
+	logrus.StandardLogger().Log(level, message)
 }

--- a/pkg/tnf/status.go
+++ b/pkg/tnf/status.go
@@ -9,16 +9,15 @@ import (
 
 // ClaimFilePrintf prints to claim and junit report files.
 func ClaimFilePrintf(format string, args ...interface{}) {
-	Log(logrus.TraceLevel, format, args)
+	Logf(logrus.TraceLevel, format, args)
 }
 
-// Log prints to stdout and claim and junit report files.
-func Log(level logrus.Level, format string, args ...interface{}) {
+// Logf prints to stdout and claim and junit report files.
+func Logf(level logrus.Level, format string, args ...interface{}) {
 	message := fmt.Sprintf(format+"\n", args...)
+	logrus.StandardLogger().Log(level, message)
 	_, err := ginkgo.GinkgoWriter.Write([]byte(message))
 	if err != nil {
 		logrus.Errorf("Ginkgo writer could not write msg '%s' because: %s", message, err)
 	}
-
-	logrus.StandardLogger().Log(level, message)
 }


### PR DESCRIPTION
It avoids the common pattern of calling `tnf.ClaimFilePrint()` followed or preceded by a `logrus` function to print a log with a different level than `TRACE`. It also avoids log duplication when doing this.

The issue is fixed in a couple of places as an example, not with the intent of being exhaustive.