### PR TITLE
Add non compliant object for internal error when getting PID namespace

### DIFF
--- a/cnf-certification-test/performance/suite.go
+++ b/cnf-certification-test/performance/suite.go
@@ -123,6 +123,8 @@ func testSchedulingPolicyInCPUPool(env *provider.TestEnvironment,
 		if err != nil {
 			logrus.Errorf("unable to get pid namespace due to: %v", err)
 			tnf.ClaimFilePrintf("Failed", "Incomplete processing for %v while getting pid namespace err %v", testContainer, err)
+			nonCompliantContainersPids = append(nonCompliantContainersPids,
+				testhelper.NewContainerReportObject(testContainer.Namespace, testContainer.Podname, testContainer.Name, fmt.Sprintf("Internal error, err=%s", err), false))
 			continue
 		}
 		logrus.Debugf("Obtained pidNamespace for %s is %s", testContainer, pidNamespace)


### PR DESCRIPTION
If debug pods are not available this test would pass when it should fail. Adding an internal error non compliant container object to report the failure.