### PR TITLE
Renable QE tests

### DIFF
--- a/.github/workflows/qe.yaml
+++ b/.github/workflows/qe.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix: 
         # suite: [accesscontrol, affiliatedcertification, lifecycle, networking, observability, platformalteration, performance, operator]
-        suite: []
+        suite: [networking, manageability]
     env:
       SHELL: /bin/bash
       DEBUG_TNF: true # More verbose output from the TNF
@@ -78,5 +78,5 @@ jobs:
 
       # Setup is complete.  Time to run the QE tests.
       - name: Run the tests
-        run: FEATURES=${{matrix.suite}} TNF_REPO_PATH=${GITHUB_WORKSPACE} TNF_IMAGE=${{env.TEST_TNF_IMAGE_NAME}} TNF_IMAGE_TAG=${{env.TEST_TNF_IMAGE_TAG}} make test-features
+        run: FEATURES=${{matrix.suite}} TNF_REPO_PATH=${GITHUB_WORKSPACE} TNF_IMAGE=${{env.TEST_TNF_IMAGE_NAME}} TNF_IMAGE_TAG=${{env.TEST_TNF_IMAGE_TAG}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=true make test-features
         working-directory: cnfcert-tests-verification


### PR DESCRIPTION
Builds on the work done in the following PRs:
- https://github.com/test-network-function/cnfcert-tests-verification/pull/459
- https://github.com/test-network-function/cnfcert-tests-verification/pull/456
- https://github.com/test-network-function/cnfcert-tests-verification/pull/455
- https://github.com/test-network-function/cnfcert-tests-verification/pull/446
- https://github.com/test-network-function/cnfcert-tests-verification/pull/445
- https://github.com/test-network-function/cnfcert-tests-verification/pull/444

These three suites now run in parallel mode and cuts the execution time down greatly.  🎉 

For example, the `networking` suite used to run for ~30 minutes and now I have seen it run in 80 seconds.

The QE tests were disabled in #1341 to improve the processing speeds.