### PR TITLE
Check for default SA in projected volume test

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -250,7 +250,7 @@ func testProjectedVolumeServiceAccount(env *provider.TestEnvironment) {
 	var nonCompliantObjects []*testhelper.ReportObject
 	for _, put := range env.Pods {
 		// Check if the pod is using a projected volume service account token
-		volumesWithProjectedServiceAccounts := put.GetVolumesUsingProjectedServiceAccounts()
+		volumesWithProjectedServiceAccounts := put.GetVolumesUsingProjectedDefaultServiceAccounts()
 
 		// Pod is compliant if it is not using a projected volume for service account access
 		if len(volumesWithProjectedServiceAccounts) == 0 {

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -404,7 +404,7 @@ func (p *Pod) IsRunAsUserID(uid int64) bool {
 	return *p.Pod.Spec.SecurityContext.RunAsUser == uid
 }
 
-func (p *Pod) GetVolumesUsingProjectedServiceAccounts() []corev1.Volume {
+func (p *Pod) GetVolumesUsingProjectedDefaultServiceAccounts() []corev1.Volume {
 	var volumes []corev1.Volume
 	if p.Pod.Spec.Volumes == nil {
 		return volumes
@@ -415,8 +415,9 @@ func (p *Pod) GetVolumesUsingProjectedServiceAccounts() []corev1.Volume {
 			continue
 		}
 
+		// Find any "default" service account tokens
 		for _, source := range p.Pod.Spec.Volumes[index].Projected.Sources {
-			if source.ServiceAccountToken != nil {
+			if source.ServiceAccountToken != nil && source.ServiceAccountToken.Audience == "system:serviceaccount:default:default" {
 				volumes = append(volumes, p.Pod.Spec.Volumes[index])
 			}
 		}

--- a/pkg/provider/pods_test.go
+++ b/pkg/provider/pods_test.go
@@ -525,7 +525,7 @@ func TestUsesProjectedVolumeServiceAccounts(t *testing.T) {
 			},
 			expectedResult: nil,
 		},
-		{ // Test Case #2 - One volume uses projected volume with service account token, return volume
+		{ // Test Case #2 - One volume uses projected volume with "test-audience" service account token, return empty
 			testPod: Pod{
 				Pod: &corev1.Pod{
 					Spec: corev1.PodSpec{
@@ -548,21 +548,7 @@ func TestUsesProjectedVolumeServiceAccounts(t *testing.T) {
 					},
 				},
 			},
-			expectedResult: []corev1.Volume{
-				{
-					Name: "test-volume1", VolumeSource: corev1.VolumeSource{
-						Projected: &corev1.ProjectedVolumeSource{
-							Sources: []corev1.VolumeProjection{
-								{
-									ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
-										Audience: "test-audience",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			expectedResult: nil,
 		},
 		{ // Test Case #3 - Uses projected volume but not service account token, return empty
 			testPod: Pod{
@@ -587,9 +573,49 @@ func TestUsesProjectedVolumeServiceAccounts(t *testing.T) {
 			},
 			expectedResult: nil,
 		},
+		{ // Test Case #4 - Uses projected volume with default service account token, return volume
+			testPod: Pod{
+				Pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{
+							{
+								Name: "test-volume1",
+								VolumeSource: corev1.VolumeSource{
+									Projected: &corev1.ProjectedVolumeSource{
+										Sources: []corev1.VolumeProjection{
+											{
+												ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+													Audience: "system:serviceaccount:default:default",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: []corev1.Volume{
+				{
+					Name: "test-volume1",
+					VolumeSource: corev1.VolumeSource{
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{
+								{
+									ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+										Audience: "system:serviceaccount:default:default",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
-		assert.Equal(t, tc.expectedResult, tc.testPod.GetVolumesUsingProjectedServiceAccounts())
+		assert.Equal(t, tc.expectedResult, tc.testPod.GetVolumesUsingProjectedDefaultServiceAccounts())
 	}
 }


### PR DESCRIPTION
Changes the projected volume test to only look for `system:serviceaccount:default:default` service account "audiences" to allow for users to use projected service account tokens that aren't default.  This matches other tests where we prevent users from using default service account token references.

We have also discussed completely removing the projected SA and automount tests in #1384.

This discussion is ongoing but we wanted to see the different options.