### PR TITLE
config: use a string slice to hold the target namespaces

### DIFF
--- a/cnf-certification-test/tnf_config.yml
+++ b/cnf-certification-test/tnf_config.yml
@@ -1,5 +1,5 @@
-targetNameSpaces:
-  - name: tnf
+targetNamespaces:
+  - tnf
 #DEPRECATED
 #targetPodLabels:
 #  - prefix: test-network-function.com

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -152,7 +152,7 @@ func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData 
 	data.AllCsvs = getAllOperators(oc.OlmClient)
 	data.AllInstallPlans = getAllInstallPlans(oc.OlmClient)
 	data.AllCatalogSources = getAllCatalogSources(oc.OlmClient)
-	data.Namespaces = namespacesListToStringList(config.TargetNameSpaces)
+	data.Namespaces = config.TargetNamespaces
 	data.Pods, data.AllPods = findPodsByLabel(oc.K8sClient.CoreV1(), config.PodsUnderTestLabelsObjects, data.Namespaces)
 	data.AbnormalEvents = findAbnormalEvents(oc.K8sClient.CoreV1(), data.Namespaces)
 	debugLabels := []configuration.LabelObject{{LabelKey: debugHelperPodsLabelName, LabelValue: debugHelperPodsLabelValue}}
@@ -172,7 +172,7 @@ func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData 
 	}
 	data.Crds = FindTestCrdNames(config.CrdFilters)
 	data.ScaleCrUnderTest = GetScaleCrUnderTest(data.Namespaces, data.Crds)
-	data.Csvs = findOperatorsByLabel(oc.OlmClient, config.OperatorsUnderTestLabelsObjects, config.TargetNameSpaces)
+	data.Csvs = findOperatorsByLabel(oc.OlmClient, config.OperatorsUnderTestLabelsObjects, config.TargetNamespaces)
 	data.Subscriptions = findSubscriptions(oc.OlmClient, data.Namespaces)
 	data.HelmChartReleases = getHelmList(oc.RestConfig, data.Namespaces)
 
@@ -240,13 +240,6 @@ func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData 
 	data.PartnerName = config.PartnerName
 	data.CollectorAppPassword = config.CollectorAppPassword
 	return data
-}
-
-func namespacesListToStringList(namespaceList []configuration.Namespace) (stringList []string) {
-	for _, ns := range namespaceList {
-		stringList = append(stringList, ns.Name)
-	}
-	return stringList
 }
 
 func getOpenshiftVersion(oClient clientconfigv1.ConfigV1Interface) (ver string, err error) {

--- a/pkg/autodiscover/autodiscover_operators.go
+++ b/pkg/autodiscover/autodiscover_operators.go
@@ -63,7 +63,7 @@ func isIstioServiceMeshInstalled(allNs []string) bool {
 	return true
 }
 
-func findOperatorsByLabel(olmClient clientOlm.Interface, labels []configuration.LabelObject, namespaces []configuration.Namespace) []*olmv1Alpha.ClusterServiceVersion {
+func findOperatorsByLabel(olmClient clientOlm.Interface, labels []configuration.LabelObject, namespaces []string) []*olmv1Alpha.ClusterServiceVersion {
 	csvs := []*olmv1Alpha.ClusterServiceVersion{}
 	for _, ns := range namespaces {
 		logrus.Debugf("Searching CSVs in namespace %s", ns)
@@ -74,7 +74,7 @@ func findOperatorsByLabel(olmClient clientOlm.Interface, labels []configuration.
 				label += "=" + aLabelObject.LabelValue
 			}
 			logrus.Debugf("Searching CSVs with label %s", label)
-			csvList, err := olmClient.OperatorsV1alpha1().ClusterServiceVersions(ns.Name).List(context.TODO(), metav1.ListOptions{
+			csvList, err := olmClient.OperatorsV1alpha1().ClusterServiceVersions(ns).List(context.TODO(), metav1.ListOptions{
 				LabelSelector: label,
 			})
 			if err != nil {

--- a/pkg/autodiscover/autodiscover_test.go
+++ b/pkg/autodiscover/autodiscover_test.go
@@ -105,37 +105,3 @@ func TestBuildLabelKeyValue(t *testing.T) {
 		assert.Equal(t, tc.expectedVal, v)
 	}
 }
-
-func TestNamespacesListToStringList(t *testing.T) {
-	testCases := []struct {
-		testList       []configuration.Namespace
-		expectedOutput []string
-	}{
-		{
-			testList: []configuration.Namespace{
-				{
-					Name: "ns1",
-				},
-				{
-					Name: "ns2",
-				},
-			},
-			expectedOutput: []string{"ns1", "ns2"},
-		},
-		{
-			testList:       []configuration.Namespace{},
-			expectedOutput: nil,
-		},
-		{
-			testList: []configuration.Namespace{
-				{Name: "name1"},
-				{Name: "name1"},
-			},
-			expectedOutput: []string{"name1", "name1"},
-		},
-	}
-
-	for _, tc := range testCases {
-		assert.Equal(t, tc.expectedOutput, namespacesListToStringList(tc.testList))
-	}
-}

--- a/pkg/configuration/config_test.go
+++ b/pkg/configuration/config_test.go
@@ -34,11 +34,9 @@ func TestLoadConfiguration(t *testing.T) {
 	env, err := configuration.LoadConfiguration(filePath)
 	assert.Nil(t, err)
 	// check if targetNameSpaces section is parsed properly
-	assert.Equal(t, nsLength, len(env.TargetNameSpaces))
-	ns := configuration.Namespace{Name: ns1}
-	assert.Contains(t, env.TargetNameSpaces, ns)
-	ns.Name = ns2
-	assert.Contains(t, env.TargetNameSpaces, ns)
+	assert.Equal(t, nsLength, len(env.TargetNamespaces))
+	assert.Contains(t, env.TargetNamespaces, ns1)
+	assert.Contains(t, env.TargetNamespaces, ns2)
 	// check if targetPodlabels section is parsed properly
 	assert.Equal(t, labels, len(env.TargetPodLabels))
 	podlabel1 := configuration.Label{Prefix: label1Prefix, Name: label1Name, Value: label1Value}

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -75,11 +75,6 @@ type Label struct {
 	Value  string `yaml:"value" json:"value"`
 }
 
-// Namespace struct defines namespace properties
-type Namespace struct {
-	Name string `yaml:"name" json:"name"`
-}
-
 // CrdFilter defines a CustomResourceDefinition config filter.
 type CrdFilter struct {
 	NameSuffix string `yaml:"nameSuffix" json:"nameSuffix"`
@@ -113,7 +108,7 @@ type LabelObject struct {
 // TestConfiguration provides test related configuration
 type TestConfiguration struct {
 	// targetNameSpaces to be used in
-	TargetNameSpaces []Namespace `yaml:"targetNameSpaces" json:"targetNameSpaces"`
+	TargetNamespaces []string `yaml:"targetNamespaces" json:"targetNamespaces"`
 	// DEPRECATED - Custom Pod labels for discovering containers/pods under test
 	TargetPodLabels []Label `yaml:"targetPodLabels,omitempty" json:"targetPodLabels,omitempty"`
 	// labels identifying pods under test

--- a/pkg/configuration/testdata/tnf_test_config.yml
+++ b/pkg/configuration/testdata/tnf_test_config.yml
@@ -1,6 +1,6 @@
-targetNameSpaces:
-  - name: tnf
-  - name: test2
+targetNamespaces:
+  - tnf
+  - test2
 targetPodLabels:
   - prefix: targetPod1.com
     name: name1


### PR DESCRIPTION
It substitutes the previous struct which only had one field for the namespace name.

Also, targetNamespaces is used instead of targetNameSpaces in the config file.