### PR TITLE
Fix go directive to include patch version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/cnf-certification-test
 
-go 1.21
+go 1.21.1
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
Related to:
- https://github.com/golang/go/issues/62278
- https://github.com/dependabot/dependabot-core/issues/7895

Seems like there is a bug upstream where "go1.21" is not a valid toolchain(?).  Not exactly sure why this changed but we can switch it back if it is ever fixed.