### PR TITLE
Add report objects for testContainerCertificationStatus

### DIFF
--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 
 	"github.com/sirupsen/logrus"
+	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 )
 
 const (
@@ -196,6 +197,10 @@ const (
 	Error                        = "Error"
 	OperatorPermission           = "Operator Cluster Permission"
 	TaintType                    = "Taint"
+	ImageDigest                  = "Image Digest"
+	ImageRepo                    = "Image Repo"
+	ImageTag                     = "Image Tag"
+	ImageRegistry                = "Image Registry"
 )
 
 func (obj *ReportObject) SetContainerProcessValues(aPolicy, aPriority, aCommandLine string) *ReportObject {
@@ -211,6 +216,15 @@ func NewContainerReportObject(aNamespace, aPodName, aContainerName, aReason stri
 	out.AddField(Namespace, aNamespace)
 	out.AddField(PodName, aPodName)
 	out.AddField(ContainerName, aContainerName)
+	return out
+}
+
+func NewCertifiedContainerReportObject(cii configuration.ContainerImageIdentifier, aReason string, isCompliant bool) (out *ReportObject) {
+	out = NewReportObject(aReason, ContainerType, isCompliant)
+	out.AddField(ImageDigest, cii.Digest)
+	out.AddField(ImageRepo, cii.Repository)
+	out.AddField(ImageTag, cii.Tag)
+	out.AddField(ImageRegistry, cii.Registry)
 	return out
 }
 

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -176,6 +176,7 @@ const (
 	HelmType                     = "Helm"
 	OperatorType                 = "Operator"
 	ContainerType                = "Container"
+	ContainerImageType           = "Container Image"
 	NodeType                     = "Node"
 	ContainerProcessType         = "ContainerProcess"
 	ContainerCategory            = "ContainerCategory"
@@ -220,7 +221,7 @@ func NewContainerReportObject(aNamespace, aPodName, aContainerName, aReason stri
 }
 
 func NewCertifiedContainerReportObject(cii configuration.ContainerImageIdentifier, aReason string, isCompliant bool) (out *ReportObject) {
-	out = NewReportObject(aReason, ContainerType, isCompliant)
+	out = NewReportObject(aReason, ContainerImageType, isCompliant)
 	out.AddField(ImageDigest, cii.Digest)
 	out.AddField(ImageRepo, cii.Repository)
 	out.AddField(ImageTag, cii.Tag)


### PR DESCRIPTION
This is a leftover from #1218 where this modifications to this test were missing.

* Created a new func `NewCertifiedContainerReportObject` that will print the details of the certified container object to the user.