### PR TITLE
Added tnf config and abnormal events count to claim comparison tool.

### DIFF
--- a/cmd/tnf/claim/compare/compare.go
+++ b/cmd/tnf/claim/compare/compare.go
@@ -7,6 +7,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/test-network-function/cnf-certification-test/cmd/tnf/claim/compare/configurations"
 	"github.com/test-network-function/cnf-certification-test/cmd/tnf/claim/compare/nodes"
 	"github.com/test-network-function/cnf-certification-test/cmd/tnf/claim/compare/testcases"
 	"github.com/test-network-function/cnf-certification-test/cmd/tnf/pkg/claim"
@@ -79,11 +80,17 @@ func claimCompareFilesfunc(claim1, claim2 string) error {
 
 	// Show test cases results summary and differences.
 	tcsDiffReport := testcases.GetDiffReport(claimFile1Data.Claim.Results, claimFile2Data.Claim.Results)
-	fmt.Println(&tcsDiffReport)
+	fmt.Println(tcsDiffReport)
+
+	// Show CNF Certification Suite configuration differences.
+	claim1Configurations := &claimFile1Data.Claim.Configurations
+	claim2Configurations := &claimFile2Data.Claim.Configurations
+	configurationsDiffReport := configurations.GetDiffReport(claim1Configurations, claim2Configurations)
+	fmt.Println(configurationsDiffReport)
 
 	// Show the cluster differences.
 	nodesDiff := nodes.GetDiffReport(&claimFile1Data.Claim.Nodes, &claimFile2Data.Claim.Nodes)
-	fmt.Printf("%s", nodesDiff)
+	fmt.Print(nodesDiff)
 
 	return nil
 }

--- a/cmd/tnf/claim/compare/configurations/configurations.go
+++ b/cmd/tnf/claim/compare/configurations/configurations.go
@@ -1,0 +1,53 @@
+package configurations
+
+import (
+	"fmt"
+
+	"github.com/test-network-function/cnf-certification-test/cmd/tnf/claim/compare/diff"
+	"github.com/test-network-function/cnf-certification-test/cmd/tnf/pkg/claim"
+)
+
+type AbnormalEventsCount struct {
+	Claim1 int `json:"claim1"`
+	Claim2 int `json:"claim2"`
+}
+
+func (c *AbnormalEventsCount) String() string {
+	const (
+		rowHeaderFmt = "%-12s%-s\n"
+		rowDataFmt   = "%-12d%-d\n"
+	)
+
+	str := "Cluster abnormal events count\n"
+	str += fmt.Sprintf(rowHeaderFmt, "CLAIM 1", "CLAIM 2")
+	str += fmt.Sprintf(rowDataFmt, c.Claim1, c.Claim2)
+
+	return str
+}
+
+type DiffReport struct {
+	Config         *diff.Diffs         `json:"CNFCertSuiteConfig"`
+	AbnormalEvents AbnormalEventsCount `json:"abnormalEventsCount"`
+}
+
+func (d *DiffReport) String() string {
+	str := "CONFIGURATIONS\n"
+	str += "--------------\n\n"
+
+	str += d.Config.String()
+
+	str += "\n"
+	str += d.AbnormalEvents.String()
+
+	return str
+}
+
+func GetDiffReport(claim1Configurations, claim2Configurations *claim.Configurations) *DiffReport {
+	return &DiffReport{
+		Config: diff.Compare("CNF Cert Suite Configuration", claim1Configurations.Config, claim2Configurations.Config),
+		AbnormalEvents: AbnormalEventsCount{
+			Claim1: len(claim1Configurations.AbnormalEvents),
+			Claim2: len(claim2Configurations.AbnormalEvents),
+		},
+	}
+}

--- a/cmd/tnf/claim/compare/configurations/configurations_test.go
+++ b/cmd/tnf/claim/compare/configurations/configurations_test.go
@@ -1,0 +1,140 @@
+package configurations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/cnf-certification-test/cmd/tnf/claim/compare/diff"
+	"github.com/test-network-function/cnf-certification-test/cmd/tnf/pkg/claim"
+)
+
+func TestGetDiffReport(t *testing.T) {
+	tests := []struct {
+		name            string
+		configs1        *claim.Configurations
+		configs2        *claim.Configurations
+		expectedDiff    *DiffReport
+		expectedDiffStr string
+	}{
+		{
+			name:     "empty configs",
+			configs1: &claim.Configurations{},
+			configs2: &claim.Configurations{},
+			expectedDiff: &DiffReport{
+				Config:         &diff.Diffs{Name: "CNF Cert Suite Configuration"},
+				AbnormalEvents: AbnormalEventsCount{},
+			},
+			expectedDiffStr: `CONFIGURATIONS
+--------------
+
+CNF Cert Suite Configuration: Differences
+FIELD     CLAIM 1     CLAIM 2
+<none>
+
+CNF Cert Suite Configuration: Only in CLAIM 1
+<none>
+
+CNF Cert Suite Configuration: Only in CLAIM 2
+<none>
+
+Cluster abnormal events count
+CLAIM 1     CLAIM 2
+0           0
+`,
+		},
+		{
+			name: "same config with one field and two abnormal events",
+			configs1: &claim.Configurations{
+				Config: map[string]interface{}{
+					"field1": "value1",
+				},
+				AbnormalEvents: []interface{}{"event1", "event2"},
+			},
+			configs2: &claim.Configurations{
+				Config: map[string]interface{}{
+					"field1": "value1",
+				},
+				AbnormalEvents: []interface{}{"event1", "event2"},
+			},
+			expectedDiff: &DiffReport{
+				Config: &diff.Diffs{Name: "CNF Cert Suite Configuration"},
+				AbnormalEvents: AbnormalEventsCount{
+					Claim1: 2,
+					Claim2: 2,
+				},
+			},
+			expectedDiffStr: `CONFIGURATIONS
+--------------
+
+CNF Cert Suite Configuration: Differences
+FIELD     CLAIM 1     CLAIM 2
+<none>
+
+CNF Cert Suite Configuration: Only in CLAIM 1
+<none>
+
+CNF Cert Suite Configuration: Only in CLAIM 2
+<none>
+
+Cluster abnormal events count
+CLAIM 1     CLAIM 2
+2           2
+`,
+		},
+		{
+			name: "different configs",
+			configs1: &claim.Configurations{
+				Config: map[string]interface{}{
+					"field1": "value1",
+				},
+				AbnormalEvents: []interface{}{"event1"},
+			},
+			configs2: &claim.Configurations{
+				Config: map[string]interface{}{
+					"field1": "value11",
+					"field2": map[string]interface{}{"subfield1": 58},
+				},
+				AbnormalEvents: []interface{}{"event1", "event2"},
+			},
+			expectedDiff: &DiffReport{
+				Config: &diff.Diffs{
+					Name: "CNF Cert Suite Configuration",
+					Fields: []diff.FieldDiff{{
+						FieldPath:   "/field1",
+						Claim1Value: "value1",
+						Claim2Value: "value11",
+					}},
+					FieldsInClaim2Only: []string{"/field2/subfield1=58"},
+				},
+				AbnormalEvents: AbnormalEventsCount{
+					Claim1: 1,
+					Claim2: 2,
+				},
+			},
+			expectedDiffStr: `CONFIGURATIONS
+--------------
+
+CNF Cert Suite Configuration: Differences
+FIELD       CLAIM 1     CLAIM 2
+/field1     value1      value11
+
+CNF Cert Suite Configuration: Only in CLAIM 1
+<none>
+
+CNF Cert Suite Configuration: Only in CLAIM 2
+/field2/subfield1=58
+
+Cluster abnormal events count
+CLAIM 1     CLAIM 2
+1           2
+`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			diffReport := GetDiffReport(tc.configs1, tc.configs2)
+			assert.Equal(t, tc.expectedDiff, diffReport)
+			assert.Equal(t, tc.expectedDiffStr, diffReport.String())
+		})
+	}
+}

--- a/cmd/tnf/claim/compare/testcases/testcases.go
+++ b/cmd/tnf/claim/compare/testcases/testcases.go
@@ -90,7 +90,7 @@ func getTestCasesResultsSummary(results map[string]string) TcResultsSummary {
 // Process the results from different claim files and return the DiffReport.
 // In case one tc name does not exist in the other claim file, the result will
 // be marked as "not found" in the table.
-func GetDiffReport(resultsClaim1, resultsClaim2 claim.TestSuiteResults) DiffReport {
+func GetDiffReport(resultsClaim1, resultsClaim2 claim.TestSuiteResults) *DiffReport {
 	const tcResultNotFound = "not found"
 
 	report := DiffReport{}
@@ -128,7 +128,7 @@ func GetDiffReport(resultsClaim1, resultsClaim2 claim.TestSuiteResults) DiffRepo
 	report.Claim1ResultsSummary = getTestCasesResultsSummary(claim1Results)
 	report.Claim2ResultsSummary = getTestCasesResultsSummary(claim2Results)
 
-	return report
+	return &report
 }
 
 // Stringer method for the DiffReport. Will return a string with two tables:

--- a/cmd/tnf/claim/compare/testdata/claim_access_control.json
+++ b/cmd/tnf/claim/compare/testdata/claim_access_control.json
@@ -1,5 +1,92 @@
 {
   "claim": {
+    "configurations" : {
+      "AbnormalEvents" : ["EVENT2", "EVENT3"],
+      "Config": {
+        "acceptedKernelTaints": [
+          {
+            "module": "vboxsf"
+          },
+          {
+            "module": "vboxguest"
+          }
+        ],
+        "certifiedcontainerinfo": [
+          {
+            "digest": "",
+            "registry": "",
+            "repository": "registry.connect.redhat.com",
+            "tag": "0.56.0-1"
+          },
+          {
+            "digest": "sha256:03f7f2499233a302351821d6f78f0e813c3f749258184f4133144558097c57b0",
+            "registry": "",
+            "repository": "registry.connect.redhat.com",
+            "tag": "0.56.0-1"
+          }
+        ],
+        "checkDiscoveredContainerCertificationStatus": false,
+        "collectorAppEndPoint": "http://localhost:8080",
+        "collectorAppPassword": "test-password",
+        "debugDaemonSetNamespace": "cnf-suite",
+        "executedBy": "default-executed-by",
+        "managedDeployments": [
+          {
+            "name": "jack"
+          }
+        ],
+        "managedStatefulsets": [
+          {
+            "name": "jack"
+          }
+        ],
+        "operatorsUnderTestLabels": [
+          "test-network-function.com/operator1:new"
+        ],
+        "partnerName": "test-partner-name",
+        "podsUnderTestLabels": [
+          "test-network-function.com/generic: target"
+        ],
+        "servicesignorelist": [
+          "hazelcast-platform-controller-manager-service",
+          "hazelcast-platform-webhook-service",
+          "new-pro-controller-manager-metrics-service"
+        ],
+        "skipHelmChartList": [
+          {
+            "name": "coredns"
+          }
+        ],
+        "skipScalingTestDeployments": [
+          {
+            "name": "deployment1",
+            "namespace": "tnf"
+          }
+        ],
+        "targetCrdFilters": [
+          {
+            "nameSuffix": "group1.test.com",
+            "scalable": false
+          },
+          {
+            "nameSuffix": "test-network-function.com",
+            "scalable": false
+          },
+          {
+            "nameSuffix": "tutorial.my.domain",
+            "scalable": true
+          }
+        ],
+        "targetNameSpaces": [
+          "tnf",
+          "test-ns"
+        ],
+        "validProtocolNames": [
+          "http3",
+          "sctp"
+        ]
+      }
+    },
     "metadata": {
       "endTime": "2023-09-04T14:19:06+00:00",
       "startTime": "2023-09-04T14:18:31+00:00"

--- a/cmd/tnf/claim/compare/testdata/claim_observability.json
+++ b/cmd/tnf/claim/compare/testdata/claim_observability.json
@@ -1,5 +1,91 @@
 {
   "claim": {
+    "configurations" : {
+      "AbnormalEvents" : ["EVENT1"],
+      "Config": {
+        "acceptedKernelTaints": [
+          {
+            "module": "vboxsf"
+          },
+          {
+            "module": "vboxguest"
+          }
+        ],
+        "certifiedcontainerinfo": [
+          {
+            "digest": "",
+            "registry": "",
+            "repository": "registry.connect.redhat.com",
+            "tag": "0.56.0-1"
+          },
+          {
+            "digest": "sha256:03f7f2499233a302351821d6f78f0e813c3f749258184f4133144558097c57b0",
+            "registry": "",
+            "repository": "registry.connect.redhat.com",
+            "tag": "0.56.0-1"
+          }
+        ],
+        "checkDiscoveredContainerCertificationStatus": false,
+        "collectorAppEndPoint": "http://localhost:8080",
+        "collectorAppPassword": "test-password",
+        "debugDaemonSetNamespace": "custom-debugpods-ns",
+        "executedBy": "default-executed-by",
+        "managedDeployments": [
+          {
+            "name": "jack"
+          }
+        ],
+        "managedStatefulsets": [
+          {
+            "name": "jack"
+          }
+        ],
+        "operatorsUnderTestLabels": [
+          "test-network-function.com/operator1:new"
+        ],
+        "partnerName": "test-partner-name",
+        "podsUnderTestLabels": [
+          "test-network-function.com/generic: target"
+        ],
+        "servicesignorelist": [
+          "hazelcast-platform-controller-manager-service",
+          "hazelcast-platform-webhook-service",
+          "new-pro-controller-manager-metrics-service"
+        ],
+        "skipHelmChartList": [
+          {
+            "name": "coredns"
+          }
+        ],
+        "skipScalingTestDeployments": [
+          {
+            "name": "deployment1",
+            "namespace": "tnf"
+          }
+        ],
+        "targetCrdFilters": [
+          {
+            "nameSuffix": "group1.test.com",
+            "scalable": false
+          },
+          {
+            "nameSuffix": "test-network-function.com",
+            "scalable": false
+          },
+          {
+            "nameSuffix": "tutorial.my.domain",
+            "scalable": true
+          }
+        ],
+        "targetNameSpaces": [
+          "tnf"
+        ],
+        "validProtocolNames": [
+          "http3",
+          "sctp"
+        ]
+      }
+    },
     "metadata": {
       "endTime": "2023-09-04T14:18:08+00:00",
       "startTime": "2023-09-04T14:17:48+00:00"

--- a/cmd/tnf/claim/compare/testdata/diff1.txt
+++ b/cmd/tnf/claim/compare/testdata/diff1.txt
@@ -39,6 +39,23 @@ observability-crd-status                                    passed    skipped
 observability-pod-disruption-budget                         passed    skipped
 observability-termination-policy                            failed    skipped
 
+CONFIGURATIONS
+--------------
+
+CNF Cert Suite Configuration: Differences
+FIELD                        CLAIM 1                 CLAIM 2
+/debugDaemonSetNamespace     custom-debugpods-ns     cnf-suite
+
+CNF Cert Suite Configuration: Only in CLAIM 1
+<none>
+
+CNF Cert Suite Configuration: Only in CLAIM 2
+/targetNameSpaces/1=test-ns
+
+Cluster abnormal events count
+CLAIM 1     CLAIM 2
+1           2
+
 CLUSTER NODES DIFFERENCES
 -------------------------
 

--- a/cmd/tnf/claim/compare/testdata/diff1_reverse.txt
+++ b/cmd/tnf/claim/compare/testdata/diff1_reverse.txt
@@ -39,6 +39,23 @@ observability-crd-status                                    skipped   passed
 observability-pod-disruption-budget                         skipped   passed
 observability-termination-policy                            skipped   failed
 
+CONFIGURATIONS
+--------------
+
+CNF Cert Suite Configuration: Differences
+FIELD                        CLAIM 1       CLAIM 2
+/debugDaemonSetNamespace     cnf-suite     custom-debugpods-ns
+
+CNF Cert Suite Configuration: Only in CLAIM 1
+/targetNameSpaces/1=test-ns
+
+CNF Cert Suite Configuration: Only in CLAIM 2
+<none>
+
+Cluster abnormal events count
+CLAIM 1     CLAIM 2
+2           1
+
 CLUSTER NODES DIFFERENCES
 -------------------------
 

--- a/cmd/tnf/claim/compare/testdata/diff2_same_claims.txt
+++ b/cmd/tnf/claim/compare/testdata/diff2_same_claims.txt
@@ -9,6 +9,23 @@ RESULTS DIFFERENCES
 -------------------
 <none>
 
+CONFIGURATIONS
+--------------
+
+CNF Cert Suite Configuration: Differences
+FIELD     CLAIM 1     CLAIM 2
+<none>
+
+CNF Cert Suite Configuration: Only in CLAIM 1
+<none>
+
+CNF Cert Suite Configuration: Only in CLAIM 2
+<none>
+
+Cluster abnormal events count
+CLAIM 1     CLAIM 2
+1           1
+
 CLUSTER NODES DIFFERENCES
 -------------------------
 

--- a/cmd/tnf/pkg/claim/claim.go
+++ b/cmd/tnf/pkg/claim/claim.go
@@ -63,8 +63,15 @@ type Nodes struct {
 	CsiDriver    interface{}             `json:"csiDriver"`
 }
 
+type Configurations struct {
+	Config         interface{}   `json:"Config"`
+	AbnormalEvents []interface{} `json:"AbnormalEvents"`
+}
+
 type Schema struct {
 	Claim struct {
+		Configurations `json:"configurations"`
+
 		Nodes Nodes `json:"nodes"`
 
 		RawResults struct {


### PR DESCRIPTION
The tnf config, in claim.configurations.Config, is compared using the agnostic traversal of the json nodes.

As it doesn't make sense to compare abnormal events, the comparison tool will just show the number of abnormal events in the cluster that appear on each claim file.