### PR TITLE
Update tnf_config.yml file with the correct fields for certifiedcontainerinfo

### DIFF
--- a/cnf-certification-test/tnf_config.yml
+++ b/cnf-certification-test/tnf_config.yml
@@ -22,12 +22,12 @@ managedDeployments:
 managedStatefulsets:
   - name: jack
 certifiedcontainerinfo:
-  - name: rocketchat/rocketchat
-    repository: registry.connect.redhat.com
+  - repository: rocketchat/rocketchat
+    registry: registry.connect.redhat.com
     tag: 0.56.0-1 # optional, "latest" assumed if empty
     digest: # if set, takes precedence over tag. e.g. "sha256:aa34453a6417f8f76423ffd2cf874e9c4a1a5451ac872b78dc636ab54a0ebbc3"
-  - name: rocketchat/rocketchat
-    repository: registry.connect.redhat.com
+  - repository: rocketchat/rocketchat
+    registry: registry.connect.redhat.com
     tag: 0.56.0-1
     digest: sha256:03f7f2499233a302351821d6f78f0e813c3f749258184f4133144558097c57b0
 checkDiscoveredContainerCertificationStatus: false


### PR DESCRIPTION
The structure of this field was updated on https://github.com/test-network-function/cnf-certification-test/pull/1313, but the tnf_config.yml example was not updated. Doing it here