### PR TITLE
Fix report objects for sysctl config test

### DIFF
--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -523,8 +523,8 @@ func testSysctlConfigs(env *provider.TestEnvironment) {
 		}
 
 		mcKernelArgumentsMap := bootparams.GetMcKernelArguments(env, cut.NodeName)
+		validSettings := true
 		for key, sysctlConfigVal := range sysctlSettings {
-			validSettings := true
 			if mcVal, ok := mcKernelArgumentsMap[key]; ok {
 				if mcVal != sysctlConfigVal {
 					tnf.ClaimFilePrintf(fmt.Sprintf("Kernel config mismatch in node %s for %s (sysctl value: %s, machine config value: %s)",
@@ -533,9 +533,9 @@ func testSysctlConfigs(env *provider.TestEnvironment) {
 					validSettings = false
 				}
 			}
-			if validSettings {
-				compliantObjects = append(compliantObjects, testhelper.NewNodeReportObject(cut.NodeName, "Passed the sysctl config check", true))
-			}
+		}
+		if validSettings {
+			compliantObjects = append(compliantObjects, testhelper.NewNodeReportObject(cut.NodeName, "Passed the sysctl config check", true))
 		}
 	}
 


### PR DESCRIPTION
We should only need to list the node once in compliant objects.

Compliant objects are spamming the output in the html parser:

![image](https://github.com/test-network-function/cnf-certification-test/assets/4563082/d837f409-d0c9-4ccf-8356-5cc413509dae)
