### PR TITLE
Fix report objects for toleration bypass test

### DIFF
--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -679,6 +679,7 @@ func testPodTolerationBypass(env *provider.TestEnvironment) {
 	var nonCompliantObjects []*testhelper.ReportObject
 
 	for _, put := range env.Pods {
+		podIsCompliant := true
 		for _, t := range put.Spec.Tolerations {
 			// Check if the tolerations fall outside the 'default' and are modified versions
 			// Take also into account the qosClass applied to the pod
@@ -687,9 +688,12 @@ func testPodTolerationBypass(env *provider.TestEnvironment) {
 				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod has non-default toleration", false).
 					AddField(testhelper.TolerationKey, t.Key).
 					AddField(testhelper.TolerationEffect, string(t.Effect)))
-			} else {
-				compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod has default toleration", true))
+				podIsCompliant = false
 			}
+		}
+
+		if podIsCompliant {
+			compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod has default toleration", true))
 		}
 	}
 


### PR DESCRIPTION
Similar to: #1433 

Multiple compliant pod objects listed here when they only need to be listed once.