### PR TITLE
Fix: run container-is-certified also in the case of digest only images

### DIFF
--- a/cnf-certification-test/certification/suite.go
+++ b/cnf-certification-test/certification/suite.go
@@ -116,10 +116,6 @@ func testContainerCertificationStatus(env *provider.TestEnvironment, validator c
 	ginkgo.By(fmt.Sprintf("Getting certification status. Number of containers to check: %d", len(containersToQuery)))
 	allContainersToQueryEmpty := true
 	for c := range containersToQuery {
-		if c.Repository == "" || c.Registry == "" {
-			tnf.ClaimFilePrintf("Container name = \"%s\" or repository = \"%s\" is missing, skipping this container to query", c.Repository, c.Registry)
-			continue
-		}
 		allContainersToQueryEmpty = false
 		if !testContainerCertification(c, validator) {
 			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewCertifiedContainerReportObject(c, "Container is not certified", false))
@@ -191,11 +187,6 @@ func testContainerCertificationStatusByDigest(env *provider.TestEnvironment, val
 	var compliantObjects []*testhelper.ReportObject
 	var nonCompliantObjects []*testhelper.ReportObject
 	for _, c := range env.Containers {
-		if c.ContainerImageIdentifier.Repository == "" || c.ContainerImageIdentifier.Registry == "" {
-			tnf.ClaimFilePrintf("Container name = %q or repository = %q is missing, skipping this container to query", c.ContainerImageIdentifier.Repository, c.ContainerImageIdentifier.Registry)
-			continue
-		}
-
 		switch {
 		case c.ContainerImageIdentifier.Digest == "":
 			tnf.ClaimFilePrintf("%s is missing digest field, failing validation (repo=%s image=%s)", c, c.ContainerImageIdentifier.Registry, c.ContainerImageIdentifier.Repository)


### PR DESCRIPTION
This is a regression compared with previous logic. Containers with digest **only** images would not be tested in the container-is-certified test, or in the container-is-certified-digest test. 

For digest images, the repo and name fields are no longer populated since they could be anything, only the digest counts. However, since we skip containers with images that have both empty repository and name we would also skip digest only images. This same check in the container-is-certified-digest test would skip containers that have only a digest defined, only testing the image digest when it was defined using a repository, name and tag. This fix remove the unnecessary check in both container-is-certified and container-is-certified-digest tests.
PR causing regression: https://github.com/test-network-function/cnf-certification-test/pull/1274/files

build-depends: 29479