### PR TITLE
Add the name of the object responsible for skipping in addition to type

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -65,121 +65,121 @@ var _ = ginkgo.Describe(common.AccessControlTestKey, func() {
 	ginkgo.ReportAfterEach(results.RecordResult)
 	testID, tags := identifiers.GetGinkgoTestIDAndLabels(identifiers.TestSecContextIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testContainerSCC(&env)
 	})
 
 	// Security Context: non-compliant capabilities (SYS_ADMIN)
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestSysAdminIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testSysAdminCapability(&env)
 	})
 
 	// Security Context: non-compliant capabilities (NET_ADMIN)
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestNetAdminIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testNetAdminCapability(&env)
 	})
 
 	// Security Context: non-compliant capabilities (NET_RAW)
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestNetRawIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testNetRawCapability(&env)
 	})
 
 	// Security Context: non-compliant capabilities (IPC_LOCK)
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestIpcLockIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testIpcLockCapability(&env)
 	})
 
 	// Security Context: non-compliant capabilities (BPF)
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestBpfIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testBpfCapability(&env)
 	})
 
 	// container security context: non-root user
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestSecConNonRootUserIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testSecConRootUser(&env)
 	})
 	// container security context: privileged escalation
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestSecConPrivilegeEscalation)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testSecConPrivilegeEscalation(&env)
 	})
 	// container security context: host port
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestContainerHostPort)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testContainerHostPort(&env)
 	})
 	// container security context: host network
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestPodHostNetwork)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		testPodHostNetwork(&env)
 	})
 	// pod host path
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestPodHostPath)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		testPodHostPath(&env)
 	})
 	// pod host ipc
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestPodHostIPC)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		testPodHostIPC(&env)
 	})
 	// pod host pid
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestPodHostPID)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		testPodHostPID(&env)
 	})
 	// Namespace
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestNamespaceBestPracticesIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Namespaces)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Namespaces, "env.Namespaces"))
 		testNamespace(&env)
 	})
 	// pod service account
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestPodServiceAccountBestPracticesIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		testPodServiceAccount(&env)
 	})
 	// pod role bindings
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestPodRoleBindingsBestPracticesIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		testPodRoleBindings(&env)
 	})
 	// pod cluster role bindings
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestPodClusterRoleBindingsBestPracticesIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		testPodClusterRoleBindings(&env)
 	})
 	// automount service token
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestPodAutomountServiceAccountIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		testAutomountServiceToken(&env)
 	})
 	// one process per container
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestOneProcessPerContainerIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		if env.DaemonsetFailedToSpawn {
 			ginkgo.Skip("Debug Daemonset failed to spawn skipping TestOneProcessPerContainer")
 		}
@@ -187,25 +187,25 @@ var _ = ginkgo.Describe(common.AccessControlTestKey, func() {
 	})
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestSYSNiceRealtimeCapabilityIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		testSYSNiceRealtimeCapability(&env)
 	})
 	// SYS_PTRACE capability
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestSysPtraceCapabilityIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
 		shareProcessPods := env.GetShareProcessNamespacePods()
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, shareProcessPods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(shareProcessPods, "shareProcessPods"))
 		testSysPtraceCapability(shareProcessPods)
 	})
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestNamespaceResourceQuotaIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		testNamespaceResourceQuota(&env)
 	})
 	// ssh daemons
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestNoSSHDaemonsAllowedIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		if env.DaemonsetFailedToSpawn {
 			ginkgo.Skip("Debug Daemonset failed to spawn skipping TestNoSSHDaemonsAllowed")
 		}
@@ -214,26 +214,26 @@ var _ = ginkgo.Describe(common.AccessControlTestKey, func() {
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestPodRequestsAndLimitsIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		testPodRequestsAndLimits(&env)
 	})
 
 	// no 1337 UID's being used by pods
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.Test1337UIDIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		test1337UIDs(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestServicesDoNotUseNodeportsIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"), testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		testNodePort(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestCrdRoleIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Crds, env.Roles, env.Namespaces)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Crds, "env.Crds"), testhelper.NewSkipObject(env.Roles, "env.Roles"), testhelper.NewSkipObject(env.Namespaces, "env.Namespaces"))
 		testCrdRoles(&env)
 	})
 })

--- a/cnf-certification-test/certification/suite.go
+++ b/cnf-certification-test/certification/suite.go
@@ -111,7 +111,7 @@ func testContainerCertificationStatus(env *provider.TestEnvironment, validator c
 
 	// Get the list of containers to query
 	containersToQuery := getContainersToQuery(env)
-	testhelper.SkipIfEmptyAny(ginkgo.Skip, containersToQuery)
+	testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(containersToQuery, "containersToQuery"))
 
 	ginkgo.By(fmt.Sprintf("Getting certification status. Number of containers to check: %d", len(containersToQuery)))
 	allContainersToQueryEmpty := true
@@ -135,7 +135,7 @@ func testContainerCertificationStatus(env *provider.TestEnvironment, validator c
 
 func testAllOperatorCertified(env *provider.TestEnvironment, validator certdb.CertificationStatusValidator) {
 	operatorsUnderTest := env.Operators
-	testhelper.SkipIfEmptyAny(ginkgo.Skip, operatorsUnderTest)
+	testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(operatorsUnderTest, "operatorsUnderTest"))
 	ginkgo.By(fmt.Sprintf("Verify operator as certified. Number of operators to check: %d", len(operatorsUnderTest)))
 	var compliantObjects []*testhelper.ReportObject
 	var nonCompliantObjects []*testhelper.ReportObject
@@ -167,7 +167,7 @@ func testAllOperatorCertified(env *provider.TestEnvironment, validator certdb.Ce
 
 func testHelmCertified(env *provider.TestEnvironment, validator certdb.CertificationStatusValidator) {
 	helmchartsReleases := env.HelmChartReleases
-	testhelper.SkipIfEmptyAny(ginkgo.Skip, helmchartsReleases)
+	testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(helmchartsReleases, "helmchartsReleases"))
 	// Collect all of the failed helm charts
 	var compliantObjects []*testhelper.ReportObject
 	var nonCompliantObjects []*testhelper.ReportObject

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -60,7 +60,7 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 
 	testID, tags := identifiers.GetGinkgoTestIDAndLabels(identifiers.TestShutdownIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testContainersPreStop(&env)
 	})
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestCrdScalingIdentifier)
@@ -68,44 +68,44 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 		if !env.IsIntrusive() {
 			ginkgo.Skip(intrusiveTcSkippedReason)
 		}
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.ScaleCrUnderTest)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.ScaleCrUnderTest, "env.ScaleCrUnderTest"))
 		// Note: We skip this test because 'testHighAvailability' in the lifecycle suite is already
 		// testing the replicas and antiaffinity rules that should already be in place for crd.
 		testScaleCrd(&env, timeout)
 	})
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestStartupIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testContainersPostStart(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestImagePullPolicyIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testContainersImagePolicy(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestReadinessProbeIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testContainersReadinessProbe(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestLivenessProbeIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testContainersLivenessProbe(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestStartupProbeIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testContainersStartupProbe(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestPodDeploymentBestPracticesIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		testPodsOwnerReference(&env)
 	})
 
@@ -114,7 +114,7 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 		if env.GetWorkerCount() < minWorkerNodesForLifecycle {
 			ginkgo.Skip("Skipping pod high availability test because invalid number of available workers.")
 		}
-		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Deployments, env.StatefulSets)
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, testhelper.NewSkipObject(env.Deployments, "env.Deployments"), testhelper.NewSkipObject(env.StatefulSets, "env.StatefulSets"))
 		testHighAvailability(&env)
 	})
 
@@ -124,7 +124,7 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 			ginkgo.Skip("Skipping pod scheduling test because invalid number of available workers.")
 		}
 		testPods := env.GetPodsWithoutAffinityRequiredLabel()
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, testPods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(testPods, "testPods"))
 		testPodNodeSelectorAndAffinityBestPractices(testPods)
 	})
 
@@ -133,7 +133,7 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 		if !env.IsIntrusive() {
 			ginkgo.Skip(intrusiveTcSkippedReason)
 		}
-		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Deployments, env.StatefulSets)
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, testhelper.NewSkipObject(env.Deployments, "env.Deployments"), testhelper.NewSkipObject(env.StatefulSets, "env.StatefulSets"))
 		if env.GetWorkerCount() < minWorkerNodesForLifecycle {
 			ginkgo.Skip("Skipping pod recreation scaling test because invalid number of available workers.")
 		}
@@ -146,7 +146,7 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 		if !env.IsIntrusive() {
 			ginkgo.Skip(intrusiveTcSkippedReason)
 		}
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Deployments)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Deployments, "env.Deployments"))
 		if env.GetWorkerCount() < minWorkerNodesForLifecycle {
 			// Note: We skip this test because 'testHighAvailability' in the lifecycle suite is already
 			// testing the replicas and antiaffinity rules that should already be in place for deployments.
@@ -159,7 +159,7 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 		if !env.IsIntrusive() {
 			ginkgo.Skip(intrusiveTcSkippedReason)
 		}
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.StatefulSets)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.StatefulSets, "env.StatefulSets"))
 		if env.GetWorkerCount() < minWorkerNodesForLifecycle {
 			// Note: We skip this test because 'testHighAvailability' in the lifecycle suite is already
 			// testing the replicas and antiaffinity rules that should already be in place for statefulset.
@@ -170,13 +170,13 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestPersistentVolumeReclaimPolicyIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods, env.PersistentVolumes)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"), testhelper.NewSkipObject(env.PersistentVolumes, "env.PersistentVolumes"))
 		testPodPersistentVolumeReclaimPolicy(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestCPUIsolationIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.GetGuaranteedPodsWithExclusiveCPUs())
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.GetGuaranteedPodsWithExclusiveCPUs(), "env.GetGuaranteedPodsWithExclusiveCPUs()"))
 		testCPUIsolation(&env)
 	})
 
@@ -187,7 +187,7 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestPodTolerationBypassIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		testPodTolerationBypass(&env)
 	})
 
@@ -230,7 +230,7 @@ func testContainersPostStart(env *provider.TestEnvironment) {
 }
 
 func testContainersImagePolicy(env *provider.TestEnvironment) {
-	testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Containers)
+	testhelper.SkipIfEmptyAll(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 	var compliantObjects []*testhelper.ReportObject
 	var nonCompliantObjects []*testhelper.ReportObject
 	for _, cut := range env.Containers {
@@ -657,7 +657,7 @@ func testCPUIsolation(env *provider.TestEnvironment) {
 
 func testAffinityRequiredPods(env *provider.TestEnvironment) {
 	ginkgo.By("Testing affinity required pods for ")
-	testhelper.SkipIfEmptyAny(ginkgo.Skip, env.GetAffinityRequiredPods())
+	testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.GetAffinityRequiredPods(), "env.GetAffinityRequiredPods()"))
 
 	var compliantObjects []*testhelper.ReportObject
 	var nonCompliantObjects []*testhelper.ReportObject

--- a/cnf-certification-test/manageability/suite.go
+++ b/cnf-certification-test/manageability/suite.go
@@ -40,13 +40,13 @@ var _ = ginkgo.Describe(common.ManageabilityTestKey, func() {
 
 	testID, tags := identifiers.GetGinkgoTestIDAndLabels(identifiers.TestContainersImageTag)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testContainersImageTag(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestContainerPortNameFormat)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testContainerPortNameFormat(&env)
 	})
 })

--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -59,7 +59,7 @@ var _ = ginkgo.Describe(common.NetworkingTestKey, func() {
 	// Default interface ICMP IPv4 test case
 	testID, tags := identifiers.GetGinkgoTestIDAndLabels(identifiers.TestICMPv4ConnectivityIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"), testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		if env.DaemonsetFailedToSpawn {
 			ginkgo.Skip("Debug Daemonset failed to spawn skipping testNetworkConnectivity ICMP IPv4")
 		}
@@ -68,7 +68,7 @@ var _ = ginkgo.Describe(common.NetworkingTestKey, func() {
 	// Multus interfaces ICMP IPv4 test case
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestICMPv4ConnectivityMultusIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"), testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		if env.DaemonsetFailedToSpawn {
 			ginkgo.Skip("Debug Daemonset failed to spawn skipping testNetworkConnectivity Multus IPv4")
 		}
@@ -77,7 +77,7 @@ var _ = ginkgo.Describe(common.NetworkingTestKey, func() {
 	// Default interface ICMP IPv6 test case
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestICMPv6ConnectivityIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"), testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		if env.DaemonsetFailedToSpawn {
 			ginkgo.Skip("Debug Daemonset failed to spawn skipping testNetworkConnectivity ICMP IPv6")
 		}
@@ -86,7 +86,7 @@ var _ = ginkgo.Describe(common.NetworkingTestKey, func() {
 	// Multus interfaces ICMP IPv6 test case
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestICMPv6ConnectivityMultusIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"), testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		if env.DaemonsetFailedToSpawn {
 			ginkgo.Skip("Debug Daemonset failed to spawn skipping testNetworkConnectivity Multus IPv6")
 		}
@@ -95,7 +95,7 @@ var _ = ginkgo.Describe(common.NetworkingTestKey, func() {
 	// Default interface ICMP IPv6 test case
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestUndeclaredContainerPortsUsage)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"), testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		if env.DaemonsetFailedToSpawn {
 			ginkgo.Skip("Debug Daemonset failed to spawn skipping testUndeclaredContainerPortsUsage")
 		}
@@ -103,7 +103,7 @@ var _ = ginkgo.Describe(common.NetworkingTestKey, func() {
 	})
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestOCPReservedPortsUsage)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"), testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		if env.DaemonsetFailedToSpawn {
 			ginkgo.Skip("Debug Daemonset failed to spawn skipping testOCPReservedPortsUsage")
 		}
@@ -111,17 +111,17 @@ var _ = ginkgo.Describe(common.NetworkingTestKey, func() {
 	})
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestServiceDualStackIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Services)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Services, "env.Services"))
 		testDualStackServices(&env)
 	})
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestNetworkPolicyDenyAllIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		testNetworkPolicyDenyAll(&env)
 	})
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestReservedExtendedPartnerPorts)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		if env.DaemonsetFailedToSpawn {
 			ginkgo.Skip("Debug Daemonset failed to spawn skipping testPartnerSpecificTCPPorts")
 		}
@@ -130,7 +130,7 @@ var _ = ginkgo.Describe(common.NetworkingTestKey, func() {
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestDpdkCPUPinningExecProbe)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
 		dpdkPods := env.GetCPUPinningPodsWithDpdk()
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, dpdkPods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(dpdkPods, "dpdkPods"))
 		testExecProbDenyAtCPUPinning(dpdkPods)
 	})
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestRestartOnRebootLabelOnPodsUsingSRIOV)
@@ -139,7 +139,7 @@ var _ = ginkgo.Describe(common.NetworkingTestKey, func() {
 		if err != nil {
 			ginkgo.Fail(fmt.Sprintf("Failure getting pods using SRIOV: %v", err))
 		}
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, sriovPods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(sriovPods, "sriovPods"))
 		testRestartOnRebootLabelOnPodsUsingSriov(sriovPods)
 	})
 })

--- a/cnf-certification-test/observability/suite.go
+++ b/cnf-certification-test/observability/suite.go
@@ -46,25 +46,25 @@ var _ = ginkgo.Describe(common.ObservabilityTestKey, func() {
 
 	testID, tags := identifiers.GetGinkgoTestIDAndLabels(identifiers.TestLoggingIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testContainersLogging(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestCrdsStatusSubresourceIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Crds)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Crds, "env.Crds"))
 		testCrds(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestTerminationMessagePolicyIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testTerminationMessagePolicy(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestPodDisruptionBudgetIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAll(ginkgo.Skip, env.Deployments, env.StatefulSets)
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, testhelper.NewSkipObject(env.Deployments, "env.Deployments"), testhelper.NewSkipObject(env.StatefulSets, "env.StatefulSets"))
 		testPodDisruptionBudgets(&env)
 	})
 })

--- a/cnf-certification-test/operator/suite.go
+++ b/cnf-certification-test/operator/suite.go
@@ -41,19 +41,19 @@ var _ = ginkgo.Describe(common.OperatorTestKey, func() {
 
 	testID, tags := identifiers.GetGinkgoTestIDAndLabels(identifiers.TestOperatorInstallStatusSucceededIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Operators)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Operators, "env.Operators"))
 		testOperatorInstallationPhaseSucceeded(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestOperatorNoPrivileges)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Operators)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Operators, "env.Operators"))
 		testOperatorInstallationWithoutPrivileges(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestOperatorIsInstalledViaOLMIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Operators)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Operators, "env.Operators"))
 		testOperatorOlmSubscription(&env)
 	})
 })

--- a/cnf-certification-test/performance/suite.go
+++ b/cnf-certification-test/performance/suite.go
@@ -50,14 +50,14 @@ var _ = ginkgo.Describe(common.PerformanceTestKey, func() {
 
 	testID, tags := identifiers.GetGinkgoTestIDAndLabels(identifiers.TestExclusiveCPUPoolIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		testExclusiveCPUPool(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestRtAppNoExecProbes)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
 		var guaranteedPodContainersWithExclusiveCPUs = env.GetGuaranteedPodContainersWithExclusiveCPUs()
-		testhelper.SkipIfEmptyAll(ginkgo.Skip, guaranteedPodContainersWithExclusiveCPUs)
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, testhelper.NewSkipObject(guaranteedPodContainersWithExclusiveCPUs, "guaranteedPodContainersWithExclusiveCPUs"))
 		testRtAppsNoExecProbes(&env, guaranteedPodContainersWithExclusiveCPUs)
 	})
 
@@ -65,27 +65,27 @@ var _ = ginkgo.Describe(common.PerformanceTestKey, func() {
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestSharedCPUPoolSchedulingPolicy)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
 		var nonGuaranteedPodContainers = env.GetNonGuaranteedPodContainersWithoutHostPID()
-		testhelper.SkipIfEmptyAll(ginkgo.Skip, nonGuaranteedPodContainers)
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, testhelper.NewSkipObject(nonGuaranteedPodContainers, "nonGuaranteedPodContainers"))
 		testSchedulingPolicyInCPUPool(&env, nonGuaranteedPodContainers, scheduling.SharedCPUScheduling)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestExclusiveCPUPoolSchedulingPolicy)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
 		var guaranteedPodContainersWithExclusiveCPUs = env.GetGuaranteedPodContainersWithExclusiveCPUsWithoutHostPID()
-		testhelper.SkipIfEmptyAll(ginkgo.Skip, guaranteedPodContainersWithExclusiveCPUs)
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, testhelper.NewSkipObject(guaranteedPodContainersWithExclusiveCPUs, "guaranteedPodContainersWithExclusiveCPUs"))
 		testSchedulingPolicyInCPUPool(&env, guaranteedPodContainersWithExclusiveCPUs, scheduling.ExclusiveCPUScheduling)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestLimitedUseOfExecProbesIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		testLimitedUseOfExecProbes(&env)
 	})
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestIsolatedCPUPoolSchedulingPolicy)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
 		var guaranteedPodContainersWithIsolatedCPUs = env.GetGuaranteedPodContainersWithIsolatedCPUsWithoutHostPID()
-		testhelper.SkipIfEmptyAll(ginkgo.Skip, guaranteedPodContainersWithIsolatedCPUs)
+		testhelper.SkipIfEmptyAll(ginkgo.Skip, testhelper.NewSkipObject(guaranteedPodContainersWithIsolatedCPUs, "guaranteedPodContainersWithIsolatedCPUs"))
 		testSchedulingPolicyInCPUPool(&env, guaranteedPodContainersWithIsolatedCPUs, scheduling.IsolatedCPUScheduling)
 	})
 	// Scheduling related tests ends here

--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -54,7 +54,7 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 	ginkgo.ReportAfterEach(results.RecordResult)
 	testID, tags := identifiers.GetGinkgoTestIDAndLabels(identifiers.TestHyperThreadEnable)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.GetBaremetalNodes())
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.GetBaremetalNodes(), "env.GetBaremetalNodes()"))
 		testHyperThreadingEnabled(&env)
 	})
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestUnalteredBaseImageIdentifier)
@@ -62,7 +62,7 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 		if !provider.IsOCPCluster() {
 			ginkgo.Skip("Non-OCP cluster found, skipping testContainersFsDiff")
 		}
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		if env.DaemonsetFailedToSpawn {
 			ginkgo.Skip("Debug Daemonset failed to spawn skipping testContainersFsDiff")
 		}
@@ -71,7 +71,7 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestNonTaintedNodeKernelsIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.DebugPods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.DebugPods, "env.DebugPods"))
 		if env.DaemonsetFailedToSpawn {
 			ginkgo.Skip("Debug Daemonset failed to spawn skipping testTainted")
 		}
@@ -80,7 +80,7 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestIsRedHatReleaseIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Containers)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Containers, "env.Containers"))
 		testIsRedHatRelease(&env)
 	})
 
@@ -89,7 +89,7 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 		if !provider.IsOCPCluster() {
 			ginkgo.Skip("Non-OCP cluster found, skipping testIsSELinuxEnforcing")
 		}
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.DebugPods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.DebugPods, "env.DebugPods"))
 		if env.DaemonsetFailedToSpawn {
 			ginkgo.Skip("Debug Daemonset failed to spawn skipping testIsSELinuxEnforcing")
 		}
@@ -101,7 +101,7 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 		if !provider.IsOCPCluster() {
 			ginkgo.Skip("Non-OCP cluster found, skipping testHugepages")
 		}
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.DebugPods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.DebugPods, "env.DebugPods"))
 		if env.DaemonsetFailedToSpawn {
 			ginkgo.Skip("Debug Daemonset failed to spawn skipping testHugepages")
 		}
@@ -113,7 +113,7 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 		if !provider.IsOCPCluster() {
 			ginkgo.Skip("Non-OCP cluster found, skipping testUnalteredBootParams")
 		}
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.DebugPods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.DebugPods, "env.DebugPods"))
 		if env.DaemonsetFailedToSpawn {
 			ginkgo.Skip("Debug Daemonset failed to spawn skipping testUnalteredBootParams")
 		}
@@ -125,7 +125,7 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 		if !provider.IsOCPCluster() {
 			ginkgo.Skip("Non-OCP cluster found, skipping testSysctlConfigs")
 		}
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.DebugPods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.DebugPods, "env.DebugPods"))
 		if env.DaemonsetFailedToSpawn {
 			ginkgo.Skip("Debug Daemonset failed to spawn skipping testSysctlConfigs")
 		}
@@ -134,7 +134,7 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestServiceMeshIdentifier)
 	ginkgo.It(testID, ginkgo.Label(tags...), func() {
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.Pods)
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.Pods, "env.Pods"))
 		testServiceMesh(&env)
 	})
 
@@ -159,7 +159,7 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 		if !provider.IsOCPCluster() {
 			ginkgo.Skip("Non-OCP cluster found, skipping testPodHugePagesSize2M")
 		}
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.GetHugepagesPods())
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.GetHugepagesPods(), "env.GetHugepagesPods()"))
 		testPodHugePagesSize(&env, provider.HugePages2Mi)
 	})
 
@@ -168,7 +168,7 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 		if !provider.IsOCPCluster() {
 			ginkgo.Skip("Non-OCP cluster found, skipping testPodHugePagesSize1G")
 		}
-		testhelper.SkipIfEmptyAny(ginkgo.Skip, env.GetHugepagesPods())
+		testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(env.GetHugepagesPods(), "env.GetHugepagesPods()"))
 		testPodHugePagesSize(&env, provider.HugePages1Gi)
 	})
 

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -323,37 +323,60 @@ func ResultToString(result int) (str string) {
 	return ""
 }
 
-func SkipIfEmptyAny(skip func(string, ...int), object ...interface{}) {
+func SkipIfEmptyAny(skip func(string, ...int), object ...[2]interface{}) {
 	for _, o := range object {
-		s := reflect.ValueOf(o)
+		s := reflect.ValueOf(o[0])
 		if s.Kind() != reflect.Slice && s.Kind() != reflect.Map {
 			panic("SkipIfEmpty was given a non slice/map type")
 		}
+		if str, ok := o[1].(string); ok {
+			if s.Len() == 0 {
+				skip(fmt.Sprintf("Test skipped because there are no %s (%s) to test, please check under test labels", reflect.TypeOf(o[0]), str))
+			}
+		} else {
+			panic("Value is not a string")
+		}
 
-		if s.Len() == 0 {
-			skip(fmt.Sprintf("Test skipped because there are no %s to test, please check under test labels", reflect.TypeOf(o)))
+		s = reflect.ValueOf(o[1])
+		if s.Kind() != reflect.String {
+			panic("SkipIfEmpty object name is not a string")
 		}
 	}
 }
 
-func SkipIfEmptyAll(skip func(string, ...int), object ...interface{}) {
+func SkipIfEmptyAll(skip func(string, ...int), object ...[2]interface{}) {
 	countLenZero := 0
 	allTypes := ""
 	for _, o := range object {
-		s := reflect.ValueOf(o)
+		s := reflect.ValueOf(o[0])
 		if s.Kind() != reflect.Slice && s.Kind() != reflect.Map {
 			panic("SkipIfEmpty was given a non slice/map type")
 		}
 
 		if s.Len() == 0 {
 			countLenZero++
-			allTypes = allTypes + reflect.TypeOf(o).String() + ", "
+			if str, ok := o[1].(string); ok {
+				allTypes = allTypes + reflect.TypeOf(o[0]).String() + " (" + str + ")" + ", "
+			} else {
+				panic("Value is not a string")
+			}
+		}
+
+		s = reflect.ValueOf(o[1])
+		if s.Kind() != reflect.String {
+			panic("SkipIfEmpty object name is not a string")
 		}
 	}
 	// all objects have len() of 0
 	if countLenZero == len(object) {
 		skip(fmt.Sprintf("Test skipped because there are no %s to test, please check under test labels", allTypes))
 	}
+}
+
+func NewSkipObject(object interface{}, name string) (skipObject [2]interface{}) {
+	skipObject[0] = object
+	skipObject[1] = name
+	return skipObject
 }
 
 func AddTestResultLog(prefix string, object interface{}, log func(string, ...interface{}), fail func(string, ...int)) {

--- a/pkg/testhelper/testhelper_test.go
+++ b/pkg/testhelper/testhelper_test.go
@@ -81,10 +81,10 @@ func TestSkipIfEmptyFuncs(t *testing.T) {
 
 		if tc.slice1 == nil || tc.map1 == nil {
 			assert.Panics(t, func() {
-				SkipIfEmptyAll(func(s string, i ...int) {}, tc.slice1, tc.map1)
+				SkipIfEmptyAll(func(s string, i ...int) {}, NewSkipObject(tc.slice1, "tc.slice1"), NewSkipObject(tc.map1, "tc.map1"))
 			})
 			assert.Panics(t, func() {
-				SkipIfEmptyAny(func(s string, i ...int) {}, tc.slice1, tc.map1)
+				SkipIfEmptyAny(func(s string, i ...int) {}, NewSkipObject(tc.slice1, "tc.slice1"), NewSkipObject(tc.map1, "tc.map1"))
 			})
 		} else {
 			SkipIfEmptyAll(func(s string, i ...int) {
@@ -93,7 +93,7 @@ func TestSkipIfEmptyFuncs(t *testing.T) {
 				} else {
 					result = false
 				}
-			}, tc.slice1, tc.map1)
+			}, NewSkipObject(tc.slice1, "tc.slice1"), NewSkipObject(tc.map1, "tc.map1"))
 			assert.Equal(t, tc.skippedAll, result)
 
 			SkipIfEmptyAny(func(s string, i ...int) {
@@ -102,7 +102,7 @@ func TestSkipIfEmptyFuncs(t *testing.T) {
 				} else {
 					result = false
 				}
-			}, tc.slice1, tc.map1)
+			}, NewSkipObject(tc.slice1, "tc.slice1"), NewSkipObject(tc.map1, "tc.map1"))
 			assert.Equal(t, tc.skippedAny, result)
 		}
 	}


### PR DESCRIPTION
Currently only the type of objects responsible for skipping test cases is displayed, add also the name of the object
before we had []*Pods, which becomes []*Pods ( env.GetHugepagesPods() )
![Screenshot from 2023-09-15 15-09-02](https://github.com/test-network-function/cnf-certification-test/assets/86730676/0d2a59e9-83bc-4894-899f-ec098ebcf96d)
