### PR TITLE
configuration: delete the init function

### DIFF
--- a/cnf-certification-test/suite_test.go
+++ b/cnf-certification-test/suite_test.go
@@ -133,6 +133,11 @@ func TestTest(t *testing.T) {
 		t.Skip("Skipping test suite when running unit tests")
 	}
 
+	err := configuration.LoadEnvironmentVariables()
+	if err != nil {
+		log.Fatalf("could not load the environment variables, error: %v", err)
+	}
+
 	// Set up logging params for logrus
 	loghelper.SetLogFormat()
 	setLogLevel()

--- a/pkg/configuration/utils.go
+++ b/pkg/configuration/utils.go
@@ -17,6 +17,7 @@
 package configuration
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/kelseyhightower/envconfig"
@@ -29,15 +30,6 @@ var (
 	confLoaded    = false
 	parameters    = TestParameters{}
 )
-
-func init() {
-	log.Info("Saving environment variables & parameters.")
-	err := envconfig.Process("tnf", &parameters)
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	log.Infof("Environment: %+v", parameters)
-}
 
 // LoadConfiguration return a function that loads
 // the configuration from a file once
@@ -68,6 +60,16 @@ func LoadConfiguration(filePath string) (TestConfiguration, error) {
 
 	confLoaded = true
 	return configuration, nil
+}
+
+func LoadEnvironmentVariables() error {
+	log.Info("Saving environment variables & parameters.")
+	err := envconfig.Process("tnf", &parameters)
+	if err != nil {
+		return fmt.Errorf("could not process the environment variables values, error: %v", err)
+	}
+	log.Infof("Environment: %+v", parameters)
+	return nil
 }
 
 func GetTestParameters() *TestParameters {


### PR DESCRIPTION
Every time the configuration package is imported the init() function, which process the environment variables for the CNF suite, is called. We don't want this to happen when using it for CNF commands, so the logic has been moved elsewhere in the code.