### PR TITLE
Remove 'results-html' from 'make test' path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ lint: go.sum
 	shfmt -d *.sh script
 
 # Builds and runs unit tests
-test: go.sum coverage-qe results-html
+test: go.sum coverage-qe
 	./script/create-missing-test-files.sh
 	go build ${COMMON_GO_ARGS} ./...
 	UNIT_TEST=true go test -coverprofile=cover.out.tmp ./...


### PR DESCRIPTION
I don't believe we need to run the `results-html` make path here when running `make test`.  We do it on other make paths but this one seems unneeded.