### PR TITLE
Always --pull when building Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,13 +161,13 @@ delete-db:
 	rm -rf ${REPO_DIR}/offline-db
 
 build-image-local:
-	docker build --no-cache \
+	docker build --pull --no-cache \
 		-t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
 		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
 		-f Dockerfile .
 
 build-image-tnf:
-	docker build --no-cache \
+	docker build --pull --no-cache \
 		-t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
 		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
 		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${TNF_VERSION} \


### PR DESCRIPTION
Because the `oct` image is tagged as latest, we should always --pull our base images:

https://docs.docker.com/engine/reference/commandline/pull/ 