### PR TITLE
Remove skips for testContainerCertificationStatus

### DIFF
--- a/cnf-certification-test/certification/suite.go
+++ b/cnf-certification-test/certification/suite.go
@@ -114,18 +114,14 @@ func testContainerCertificationStatus(env *provider.TestEnvironment, validator c
 	testhelper.SkipIfEmptyAny(ginkgo.Skip, testhelper.NewSkipObject(containersToQuery, "containersToQuery"))
 
 	ginkgo.By(fmt.Sprintf("Getting certification status. Number of containers to check: %d", len(containersToQuery)))
-	allContainersToQueryEmpty := true
 	for c := range containersToQuery {
-		allContainersToQueryEmpty = false
 		if !testContainerCertification(c, validator) {
 			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewCertifiedContainerReportObject(c, "Container is not certified", false))
 		} else {
 			compliantObjects = append(compliantObjects, testhelper.NewCertifiedContainerReportObject(c, "Container is certified", true))
 		}
 	}
-	if allContainersToQueryEmpty {
-		ginkgo.Skip("No containers to check because either container name or repository is empty for all containers in tnf_config.yml")
-	}
+
 	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 


### PR DESCRIPTION
This is an unnecessary skip and can be removed.

EDIT: I know we are actively working to remove these test cases but its a good cleanup until they are gone.

cc https://github.com/test-network-function/cnf-certification-test/pull/1455