### PR TITLE
check for all possible states instead of matching container name with container name in status field

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -333,9 +333,17 @@ func getPodContainers(aPod *corev1.Pod, useIgnoreList bool) (containerList []*Co
 		aRuntime, uid := GetRuntimeUID(&status)
 		var cutStatus corev1.ContainerStatus
 
-		// get Status for current container
+		// get Status for current container in any states available in order: running, then Terminated, then waiting
 		for index := range aPod.Status.ContainerStatuses {
-			if status.Name == cut.Name {
+			if status.State.Running != nil {
+				cutStatus = aPod.Status.ContainerStatuses[index]
+				break
+			}
+			if status.State.Terminated != nil {
+				cutStatus = aPod.Status.ContainerStatuses[index]
+				break
+			}
+			if status.State.Waiting != nil {
 				cutStatus = aPod.Status.ContainerStatuses[index]
 				break
 			}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -931,3 +931,177 @@ func TestGetBaremetalNodes(t *testing.T) {
 		})
 	}
 }
+
+func generatePodContainer(imageID, state string) *corev1.Pod {
+	aPod := corev1.Pod{}
+	aPod.Name = "podname"
+	aPod.Namespace = "namespace"
+	aContainer := corev1.Container{}
+	aContainer.Name = "aName"
+	aContainer.Image = "quay.io/testnetworkfunction/cnf-test-partner:latest"
+	aPod.Spec.Containers = append(aPod.Spec.Containers, aContainer)
+	aStatus := corev1.ContainerStatus{}
+	aStatus.ImageID = imageID
+	aStatus.Name = "anotherName"
+	aState := corev1.ContainerState{}
+	switch state {
+	case "running":
+		aState = corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}
+	case "terminated":
+		aState = corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}}
+	case "waiting":
+		aState = corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{}}
+	}
+
+	aStatus.State = aState
+	aPod.Status.ContainerStatuses = append(aPod.Status.ContainerStatuses, aStatus)
+	return &aPod
+}
+func podEqual(container1, container2 *Container, state string) bool {
+	return container1.ContainerImageIdentifier == container2.ContainerImageIdentifier &&
+		container1.Container.Name == container2.Container.Name &&
+		container1.Container.Image == container2.Container.Image &&
+		container1.Status.ImageID == container2.Status.ImageID &&
+		container1.Status.Name == container2.Status.Name &&
+		container1.Podname == container2.Podname &&
+		container1.Name == container2.Name &&
+		container1.Namespace == container2.Namespace &&
+		(state == "running" && (container1.Status.State.Running != nil) ||
+			state == "terminated" && (container1.Status.State.Terminated != nil) ||
+			state == "waiting" && (container1.Status.State.Waiting != nil))
+}
+
+func Test_getPodContainers(t *testing.T) {
+	type args struct {
+		useIgnoreList bool
+	}
+	tests := []struct {
+		state, imageID, name string
+		args                 args
+		wantContainerList    []*Container
+	}{
+		{
+			name:    "ok-running",
+			state:   "running",
+			imageID: "quay.io/testnetworkfunction/cnf-test-partner@sha256:2341c96eba68e2dbf9498a2fe7b95e6f9b84f6ac15fa2d0d811168667a919a49",
+			wantContainerList: []*Container{
+				{
+					Podname:   "podname",
+					Namespace: "namespace",
+					ContainerImageIdentifier: ContainerImageIdentifier{
+						Repository: "testnetworkfunction/cnf-test-partner",
+						Registry:   "quay.io",
+						Tag:        "latest",
+						Digest:     "sha256:2341c96eba68e2dbf9498a2fe7b95e6f9b84f6ac15fa2d0d811168667a919a49",
+					},
+					Container: &corev1.Container{
+						Name:  "aName",
+						Image: "quay.io/testnetworkfunction/cnf-test-partner:latest",
+					},
+					Status: corev1.ContainerStatus{
+						Name:    "anotherName",
+						State:   corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						ImageID: "quay.io/testnetworkfunction/cnf-test-partner@sha256:2341c96eba68e2dbf9498a2fe7b95e6f9b84f6ac15fa2d0d811168667a919a49",
+					},
+				},
+			},
+		},
+		{
+			name:    "ok-terminated",
+			state:   "terminated",
+			imageID: "quay.io/testnetworkfunction/cnf-test-partner@sha256:2341c96eba68e2dbf9498a2fe7b95e6f9b84f6ac15fa2d0d811168667a919a49",
+			wantContainerList: []*Container{
+				{
+					Podname:   "podname",
+					Namespace: "namespace",
+					ContainerImageIdentifier: ContainerImageIdentifier{
+						Repository: "testnetworkfunction/cnf-test-partner",
+						Registry:   "quay.io",
+						Tag:        "latest",
+						Digest:     "sha256:2341c96eba68e2dbf9498a2fe7b95e6f9b84f6ac15fa2d0d811168667a919a49",
+					},
+					Container: &corev1.Container{
+						Name:  "aName",
+						Image: "quay.io/testnetworkfunction/cnf-test-partner:latest",
+					},
+					Status: corev1.ContainerStatus{
+						Name: "anotherName",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{},
+						},
+						ImageID: "quay.io/testnetworkfunction/cnf-test-partner@sha256:2341c96eba68e2dbf9498a2fe7b95e6f9b84f6ac15fa2d0d811168667a919a49",
+					},
+				},
+			},
+		},
+		{
+			name:    "ok-waiting",
+			state:   "waiting",
+			imageID: "quay.io/testnetworkfunction/cnf-test-partner@sha256:2341c96eba68e2dbf9498a2fe7b95e6f9b84f6ac15fa2d0d811168667a919a49",
+			wantContainerList: []*Container{
+				{
+					Podname:   "podname",
+					Namespace: "namespace",
+					ContainerImageIdentifier: ContainerImageIdentifier{
+						Repository: "testnetworkfunction/cnf-test-partner",
+						Registry:   "quay.io",
+						Tag:        "latest",
+						Digest:     "sha256:2341c96eba68e2dbf9498a2fe7b95e6f9b84f6ac15fa2d0d811168667a919a49",
+					},
+					Container: &corev1.Container{
+						Name:  "aName",
+						Image: "quay.io/testnetworkfunction/cnf-test-partner:latest",
+					},
+					Status: corev1.ContainerStatus{
+						Name: "anotherName",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{},
+						},
+						ImageID: "quay.io/testnetworkfunction/cnf-test-partner@sha256:2341c96eba68e2dbf9498a2fe7b95e6f9b84f6ac15fa2d0d811168667a919a49",
+					},
+				},
+			},
+		},
+		{
+			name:    "no digest",
+			state:   "running",
+			imageID: "",
+			wantContainerList: []*Container{
+				{
+					Podname:   "podname",
+					Namespace: "namespace",
+					ContainerImageIdentifier: ContainerImageIdentifier{
+						Repository: "testnetworkfunction/cnf-test-partner",
+						Registry:   "quay.io",
+						Tag:        "latest",
+						Digest:     "",
+					},
+					Container: &corev1.Container{
+						Name:  "aName",
+						Image: "quay.io/testnetworkfunction/cnf-test-partner:latest",
+					},
+					Status: corev1.ContainerStatus{
+						Name:    "anotherName",
+						State:   corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						ImageID: "",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotContainerList := getPodContainers(generatePodContainer(tt.imageID, tt.state), tt.args.useIgnoreList); !podEqual(
+				gotContainerList[0],
+				tt.wantContainerList[0],
+				tt.state,
+			) {
+				t.Errorf(
+					"getPodContainers() = %#v, want %#v",
+					gotContainerList[0],
+					tt.wantContainerList[0],
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is to support the case when the status.containerStatuses[].name is different from the spec.containers[].name (is it a best practice?). Instead get the imageID from any of the available states.
added a unit test for the getPodContainers function






