### PR TITLE
Remove 'large packages' from disk cleanup

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -206,7 +206,6 @@ jobs:
           android: true
           dotnet: true
           haskell: true
-          large-packages: true
           docker-images: true
           swap-storage: true
 
@@ -342,7 +341,6 @@ jobs:
           android: true
           dotnet: true
           haskell: true
-          large-packages: true
           docker-images: true
           swap-storage: true
 

--- a/.github/workflows/qe-hosted.yml
+++ b/.github/workflows/qe-hosted.yml
@@ -36,7 +36,6 @@ jobs:
           android: true
           dotnet: true
           haskell: true
-          large-packages: true
           docker-images: true
           swap-storage: true
 


### PR DESCRIPTION
The failure with the `google-cloud-sdk` removal happens during the "large packages" section.  So I commented these out temporarily (to see if it clears it up).