### PR TITLE
Continue on error

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -203,11 +203,13 @@ jobs:
         uses: edcdavid/free-disk-space@main
         with:
           tool-cache: false
+          large-packages: true
           android: true
           dotnet: true
           haskell: true
           docker-images: true
           swap-storage: true
+        continue-on-error: true
 
       - name: Write temporary docker file
         run: |
@@ -338,11 +340,13 @@ jobs:
         uses: edcdavid/free-disk-space@main
         with:
           tool-cache: false
+          large-packages: true
           android: true
           dotnet: true
           haskell: true
           docker-images: true
           swap-storage: true
+        continue-on-error: true
 
       - name: Write temporary docker file
         run: |

--- a/.github/workflows/qe-hosted.yml
+++ b/.github/workflows/qe-hosted.yml
@@ -33,11 +33,13 @@ jobs:
         uses: edcdavid/free-disk-space@main
         with:
           tool-cache: false
+          large-packages: true
           android: true
           dotnet: true
           haskell: true
           docker-images: true
           swap-storage: true
+        continue-on-error: true
 
       - name: Write temporary docker file
         run: |


### PR DESCRIPTION
Follow up to #1478 

Adding `continue-on-error` to allow this to fail and not fail our CI runs.