### PR TITLE
Improve Dockerfile building speed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,13 +161,13 @@ delete-db:
 	rm -rf ${REPO_DIR}/offline-db
 
 build-image-local:
-	docker build --pull --no-cache \
+	docker build --pull \
 		-t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
 		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
 		-f Dockerfile .
 
 build-image-tnf:
-	docker build --pull --no-cache \
+	docker build --pull \
 		-t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
 		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
 		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${TNF_VERSION} \


### PR DESCRIPTION
Compress the number of layers to improve the speed of building the Dockerfile.  Also removing the --no-cache because I'm not sure why it's needed.