### PR TITLE
Send gchat alert message to dev team if unstable image creation failed.

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -464,9 +464,10 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
           JOB_RUN_ID: ${{ github.run_id }}
           JOB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GITHUB_REPO: https://github.com/test-network-function/cnf-certification-test
         run: |
           curl -X POST --data "{
-              \"text\": \"🚨⚠️  Failed to create \`unstable\` container image from commit \<https://github.com/greyerof/test_releases/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<https://github.com/greyerof/test_releases/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"
+              \"text\": \"🚨⚠️  Failed to create \`unstable\` container image from commit \<$GITHUB_REPO/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<$GITHUB_REPO/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"
           }" -H 'Content-type: application/json; charset=UTF-8' ${{ secrets.GCHAT_WEBHOOK_URL }}
 
       # Push the new unstable TNF image to Quay.io.

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -458,6 +458,17 @@ jobs:
       - name: Remove tarball(s) to save disk space.
         run: rm -f ${{ env.TNF_OUTPUT_DIR }}/*.tar.gz
 
+      - name: (if on main and upstream) Send chat msg to dev team if failed to create container image.
+        if: ${{ failure() && github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          JOB_RUN_ID: ${{ github.run_id }}
+          JOB_RUN_ATTEMPT:  ${{ github.run_attempt }}
+        run: |
+          curl -X POST --data "{
+              \"text\": \"🚨⚠️  Failed to create \`unstable\` container image from commit \<https://github.com/greyerof/test_releases/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<https://github.com/greyerof/test_releases/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"
+          }" -H 'Content-type: application/json; charset=UTF-8' ${{ secrets.GCHAT_WEBHOOK_URL }}
+
       # Push the new unstable TNF image to Quay.io.
       - name: (if on main and upstream) Authenticate against Quay.io
         if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -463,7 +463,7 @@ jobs:
         env:
           COMMIT_SHA: ${{ github.sha }}
           JOB_RUN_ID: ${{ github.run_id }}
-          JOB_RUN_ATTEMPT:  ${{ github.run_attempt }}
+          JOB_RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           curl -X POST --data "{
               \"text\": \"🚨⚠️  Failed to create \`unstable\` container image from commit \<https://github.com/greyerof/test_releases/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<https://github.com/greyerof/test_releases/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"


### PR DESCRIPTION
When a PR is submitted, pre-main.yaml workflow will create the container and push it into quay.io. This change will notify via gchat msg whenever there is an issue with one of the steps that resulted in that new unstable image not being created (hence not pushed) properly.