### PR TITLE
check for local storage provisioners for SNO clusters

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -825,13 +825,13 @@ Tags|common,lifecycle
 |Non-Telco|Mandatory|
 |Telco|Mandatory|
 
-#### lifecycle-storage-required-pods
+#### lifecycle-storage-provisioner
 
 Property|Description
 ---|---
-Unique ID|lifecycle-storage-required-pods
-Description|Checks that pods do not place persistent volumes on local storage.
-Suggested Remediation|If pod is StatefulSet, make sure servicename is not local-storage (persistent volumes should not be on local storage).
+Unique ID|lifecycle-storage-provisioner
+Description|Checks that pods do not place persistent volumes on local storage in multinode clusters. Local storage is recommended for single node clusters, but only one type of local storage should be installed (lvms or noprovisioner).
+Suggested Remediation|Use a non-local storage (e.g. no kubernetes.io/no-provisioner and no  topolvm.io provisioners) in multinode clusters. Local storage are recommended for single node clusters only, but a single local provisioner should be installed.
 Best Practice Reference|https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-local-storage
 Exception Process|No exceptions
 Tags|common,lifecycle

--- a/cnf-certification-test/identifiers/doclinks.go
+++ b/cnf-certification-test/identifiers/doclinks.go
@@ -73,7 +73,7 @@ const (
 
 	// Lifecycle Suite
 	TestAffinityRequiredPodsDocLink                    = "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations"
-	TestStorageRequiredPodsDocLink                     = "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-local-storage"
+	TestStorageProvisionerDocLink                      = "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-local-storage"
 	TestStartupIdentifierDocLink                       = "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cloud-native-design-best-practices"
 	TestShutdownIdentifierDocLink                      = "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cloud-native-design-best-practices"
 	TestPodNodeSelectorAndAffinityBestPracticesDocLink = "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations"

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -90,7 +90,7 @@ var (
 	TestNetRawIdentifier                              claim.Identifier
 	TestIpcLockIdentifier                             claim.Identifier
 	TestBpfIdentifier                                 claim.Identifier
-	TestStorageRequiredPods                           claim.Identifier
+	TestStorageProvisioner                            claim.Identifier
 	TestExclusiveCPUPoolIdentifier                    claim.Identifier
 	TestSharedCPUPoolSchedulingPolicy                 claim.Identifier
 	TestExclusiveCPUPoolSchedulingPolicy              claim.Identifier
@@ -326,13 +326,13 @@ func InitCatalog() map[claim.Identifier]claim.TestCaseDescription {
 		},
 		TagTelco)
 
-	TestStorageRequiredPods = AddCatalogEntry(
-		"storage-required-pods",
+	TestStorageProvisioner = AddCatalogEntry(
+		"storage-provisioner",
 		common.LifecycleTestKey,
-		`Checks that pods do not place persistent volumes on local storage.`,
-		StorageRequiredPods,
+		`Checks that pods do not place persistent volumes on local storage in multinode clusters. Local storage is recommended for single node clusters, but only one type of local storage should be installed (lvms or noprovisioner).`,
+		CheckStorageProvisionerRemediation,
 		NoExceptions,
-		TestStorageRequiredPodsDocLink,
+		TestStorageProvisionerDocLink,
 		true,
 		map[string]string{
 			FarEdge:  Mandatory,

--- a/cnf-certification-test/identifiers/remediation.go
+++ b/cnf-certification-test/identifiers/remediation.go
@@ -160,7 +160,7 @@ const (
 
 	DpdkCPUPinningExecProbeRemediation = "If the CNF is doing CPU pinning and running a DPDK process do not use exec probes (executing a command within the container) as it may pile up and block the node eventually."
 
-	StorageRequiredPods = "If pod is StatefulSet, make sure servicename is not local-storage (persistent volumes should not be on local storage)."
+	CheckStorageProvisionerRemediation = `Use a non-local storage (e.g. no kubernetes.io/no-provisioner and no  topolvm.io provisioners) in multinode clusters. Local storage are recommended for single node clusters only, but a single local provisioner should be installed.`
 
 	ExclusiveCPUPoolRemediation = `Ensure that if one container in a Pod selects an exclusive CPU pool the rest also select this type of CPU pool`
 

--- a/cnf-certification-test/identifiers/remediation.go
+++ b/cnf-certification-test/identifiers/remediation.go
@@ -160,7 +160,7 @@ const (
 
 	DpdkCPUPinningExecProbeRemediation = "If the CNF is doing CPU pinning and running a DPDK process do not use exec probes (executing a command within the container) as it may pile up and block the node eventually."
 
-	CheckStorageProvisionerRemediation = `Use a non-local storage (e.g. no kubernetes.io/no-provisioner and no  topolvm.io provisioners) in multinode clusters. Local storage are recommended for single node clusters only, but a single local provisioner should be installed.`
+	CheckStorageProvisionerRemediation = `Use a non-local storage (e.g. no kubernetes.io/no-provisioner and no topolvm.io provisioners) in multinode clusters. Local storage are recommended for single node clusters only, but a single local provisioner should be installed.`
 
 	ExclusiveCPUPoolRemediation = `Ensure that if one container in a Pod selects an exclusive CPU pool the rest also select this type of CPU pool`
 

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -724,7 +724,7 @@ func testStorageProvisioner(env *provider.TestEnvironment) {
 				if Pvc[i].Name == put.Spec.Volumes[pvIndex].PersistentVolumeClaim.ClaimName && Pvc[i].Namespace == put.Namespace {
 					for j := range StorageClasses {
 						if Pvc[i].Spec.StorageClassName != nil && StorageClasses[j].Name == *Pvc[i].Spec.StorageClassName {
-							tnf.ClaimFilePrintf("%s pvc_name: %s, storageclass_name : %s, provisioner_name: %s", put.String(), put.Spec.Volumes[pvIndex].PersistentVolumeClaim.ClaimName,
+							tnf.ClaimFilePrintf("%s pvc_name: %s, storageclass_name: %s, provisioner_name: %s", put.String(), put.Spec.Volumes[pvIndex].PersistentVolumeClaim.ClaimName,
 								StorageClasses[j].Name, StorageClasses[j].Provisioner)
 
 							if env.IsSNO() {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -517,6 +517,10 @@ func (env *TestEnvironment) GetMasterCount() int {
 	return masterCount
 }
 
+func (env *TestEnvironment) IsSNO() bool {
+	return len(env.Nodes) == 1
+}
+
 func getMachineConfig(mcName string, machineConfigs map[string]MachineConfig) (MachineConfig, error) {
 	client := clientsholder.GetClientsHolder()
 


### PR DESCRIPTION
Refactored local storage test to support single node clusters. Local storage is not recommended for multinode cluster. Local storage is recommended for single node clusters, but only one local storage provisioner should be used: either lvms or kubernetes' noprovisionner  
Not backward compatible because of renamed test case: 
- renamed lifecycle-storage-required-pods  to lifecycle-storage-provisioner

related to https://github.com/test-network-function/cnf-certification-test-partner/pull/361