### PR TITLE
Disable DEBUG_TNF flag in QE runs

### DIFF
--- a/.github/workflows/qe-hosted.yml
+++ b/.github/workflows/qe-hosted.yml
@@ -21,7 +21,6 @@ jobs:
         suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
     env:
       SHELL: /bin/bash
-      DEBUG_TNF: true # More verbose output from the TNF
       KUBECONFIG: '/home/runner/.kube/config'
       PFLT_DOCKERCONFIG: '/home/runner/.docker/config'
       TEST_TNF_IMAGE_NAME: quay.io/testnetworkfunction/cnf-certification-test

--- a/.github/workflows/qe.yaml
+++ b/.github/workflows/qe.yaml
@@ -21,7 +21,6 @@ jobs:
         suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
     env:
       SHELL: /bin/bash
-      DEBUG_TNF: true # More verbose output from the TNF
       KUBECONFIG: '/home/tnf/.kube/config'
       PFLT_DOCKERCONFIG: '/home/tnf/.docker/config'
       TEST_TNF_IMAGE_NAME: quay.io/testnetworkfunction/cnf-certification-test


### PR DESCRIPTION
Not needed as we do not dump the log files anyways.