### PR TITLE
Disable collector sanity check temporarily

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -372,17 +372,8 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.21.2
-      # Prepare collector to be used when running smoke tests
-      - name: Check out `Collector`
-        uses: actions/checkout@v4
-        with:
-          repository: test-network-function/collector
-          path: collector
 
-      - name: Deploy collector and mysql
-        uses: ./collector/.github/actions/prepare-collector-for-use
-        with:
-          working_directory: collector
+
 
       # Perform smoke tests using a TNF container.
       - name: Check out code into the Go module directory
@@ -422,17 +413,22 @@ jobs:
       - name: 'Test: Run Smoke Tests in a TNF container'
         run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} TNF_ENABLE_DATA_COLLECTION=true ./run-tnf-container.sh ${{ env.TESTING_CMD_PARAMS }} -l "${SMOKE_TESTS_GINKGO_LABELS_FILTER}"
 
-      # Perform tests on collector
+      # Prepare collector to be used when running smoke tests
       - name: Check out `Collector`
         uses: actions/checkout@v4
         with:
           repository: test-network-function/collector
           path: collector
 
-      - name: Run sanity check on collector
-        uses: ./collector/.github/actions/run-sanity-check
+      - name: Deploy collector and mysql
+        uses: ./collector/.github/actions/prepare-collector-for-use
         with:
           working_directory: collector
+
+      # - name: Run sanity check on collector
+      #   uses: ./collector/.github/actions/run-sanity-check
+      #   with:
+      #     working_directory: collector
 
       - name: Upload container test results as an artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Related to: #1540 

This seems to be causing issues.  Commenting out the sanity check until it's fixed.  I also reorganized the calls to the checkout of the collector repo.