### PR TITLE
linters: add some missing linters to the Makefile

### DIFF
--- a/.checkmake
+++ b/.checkmake
@@ -1,0 +1,2 @@
+[maxbodylength]
+disabled = true

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -62,8 +62,9 @@ jobs:
         run: make install-lint
 
       - name: Install checkmake
-        run: curl --location --output $CM_BIN --silent $CM_URL_LINUX
-      - run: chmod +x $CM_BIN
+        run: |
+          curl --location --output $CM_BIN --silent $CM_URL_LINUX
+          chmod +x $CM_BIN
 
       - name: Checkmake
         run: checkmake --config=.checkmake Makefile
@@ -76,7 +77,7 @@ jobs:
 
       - name: Shfmt
         uses: mfinelli/setup-shfmt@v3
-      - run: shfmt -d *.sh script
+        run: shfmt -d *.sh script
 
       - name: markdownlint
         uses: nosborn/github-action-markdown-cli@v3.3.0

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   lint:
-    name: Run Linter and Vet
+    name: Run Linters and Vet
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -75,68 +75,40 @@ jobs:
       - run: chmod +x $CM_BIN
         if: runner.os == 'Linux'
 
-      - name: Install hadolint (Linux)
-        run: |
-          curl \
-            --location \
-            --output /usr/local/bin/hadolint \
-            https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
-          chmod +x /usr/local/bin/hadolint
-        if: runner.os == 'Linux'
+      - name: Checkmake
+        run: checkmake --config=.checkmake Makefile
 
-      - name: Install hadolint (MacOS)
-        run: |
-          brew install hadolint
-        if: runner.os == 'macOS'
-
-      - name: Install shfmt (Linux)
-        run: make install-shfmt
-        if: runner.os == 'Linux'
-
-      - name: Install shfmt (MacOS)
-        run: brew install shfmt
-        if: runner.os == 'macOS'
-
-      - name: make lint
-        run: make lint
-
-      - name: make vet
-        run: make vet
-  action-linters:
-    name: Checkmake, hadolint, markdownlint, shellcheck, shfmt, typos, yamllint
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - run: |
-          curl --location --output $CM_BIN --silent $CM_URL_LINUX
-          chmod +x $CM_BIN
-          $CM_BIN Makefile
-      - uses: hadolint/hadolint-action@v3.1.0
+      - name: Hadolint
+        uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: Dockerfile
           recursive: true
-      - uses: nosborn/github-action-markdown-cli@v3.3.0
+
+      - name: Shfmt
+        uses: mfinelli/setup-shfmt@v3
+      - run: shfmt -d *.sh script
+
+      - name: markdownlint
+        uses: nosborn/github-action-markdown-cli@v3.3.0
         with:
           files: .
-          ignore_files: cmd/tnf/generate/catalog/{INTRO,TEST_CASE_CATALOG}.md
-      - uses: ludeeus/action-shellcheck@master
-      - uses: mfinelli/setup-shfmt@v3
-      - run: shfmt -d *.sh script
-      - uses: crate-ci/typos@master
-      - uses: ibiqlik/action-yamllint@v3
+
+      - name: ShellCheck
+        uses: ludeeus/action-shellcheck@master
+
+      - name: Typos
+        uses: crate-ci/typos@master
+ 
+      - name: Yamllint
+        uses: ibiqlik/action-yamllint@v3
         with:
-          config_data: |
-            extends: default
-            rules:
-              line-length:
-                max: 180
-                level: warning
-              trailing-spaces:
-                level: warning
-              brackets:
-                level: warning
-              empty-lines:
-                level: warning
+          config_file: .yamllint.yml
+
+      - name: Golangci-lint
+        run: golangci-lint run --timeout 10m0s
+
+      - name: make vet
+        run: make vet
   unit-tests:
     name: Run Unit Tests
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -66,6 +66,9 @@ jobs:
           curl --location --output $CM_BIN --silent $CM_URL_LINUX
           chmod +x $CM_BIN
 
+      - name: Install Shfmt
+        uses: mfinelli/setup-shfmt@v3
+
       - name: Checkmake
         run: checkmake --config=.checkmake Makefile
 
@@ -76,7 +79,6 @@ jobs:
           recursive: true
 
       - name: Shfmt
-        uses: mfinelli/setup-shfmt@v3
         run: shfmt -d *.sh script
 
       - name: markdownlint

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -33,10 +33,7 @@ env:
 jobs:
   lint:
     name: Run Linters and Vet
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-22.04, macos-latest]
+    runs-on: ubuntu-latest
     env:
       SHELL: /bin/bash
 
@@ -64,16 +61,9 @@ jobs:
       - name: Install golangci-lint
         run: make install-lint
 
-      - name: Install checkmake (Linux)
+      - name: Install checkmake
         run: curl --location --output $CM_BIN --silent $CM_URL_LINUX
-        if: runner.os == 'Linux'
-
-      - name: Install checkmake (MacOS)
-        run: brew install checkmake
-        if: runner.os == 'macOS'
-
       - run: chmod +x $CM_BIN
-        if: runner.os == 'Linux'
 
       - name: Checkmake
         run: checkmake --config=.checkmake Makefile

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,12 @@
+extends: default
+rules:
+  line-length:
+    max: 180
+    level: warning
+  trailing-spaces:
+    level: warning
+  brackets:
+    level: warning
+  empty-lines:
+    level: warning
+no_warnings: true

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitPreviousRelease=${GIT_PREVIOUS_RELEASE}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.ClaimFormatVersion=${CLAIM_FORMAT_VERSION}
 PARSER_RELEASE=$(shell jq .parserTag version.json)
+BASH_SCRIPTS=$(shell find -name "*.sh" -not -path "./.git/*")
 
 all: build
 
@@ -77,10 +78,14 @@ clean:
 
 # Runs configured linters
 lint:
-	checkmake Makefile
+	checkmake --config=.checkmake Makefile
 	golangci-lint run --timeout 10m0s
 	hadolint Dockerfile
 	shfmt -d *.sh script
+	typos
+	markdownlint '**/*.md'
+	yamllint --no-warnings .
+	shellcheck --format=gcc ${BASH_SCRIPTS}
 
 # Builds and runs unit tests
 test: coverage-qe


### PR DESCRIPTION
Also, updates the GitHub workflow for linters in order to use GitHub Actions when possible and unify all of them in one job.

To install locally the missing linters check [markdownlint](https://github.com/igorshubovych/markdownlint-cli), [typos](https://github.com/crate-ci/typos), [ShellCheck](https://github.com/koalaman/shellcheck#from-your-terminal) and [Yamllint](https://github.com/adrienverge/yamllint).