### PR TITLE
performance: avoid failing test case if a process cannot be found

### DIFF
--- a/cnf-certification-test/performance/suite.go
+++ b/cnf-certification-test/performance/suite.go
@@ -237,21 +237,21 @@ func getExecProbesCmds(c *provider.Container) map[string]bool {
 	cmds := map[string]bool{}
 
 	if c.LivenessProbe != nil && c.LivenessProbe.Exec != nil {
-		for _, cmd := range c.LivenessProbe.Exec.Command {
-			cmds[cmd] = true
-		}
+		cmd := strings.Join(c.LivenessProbe.Exec.Command, "")
+		cmd = strings.Join(strings.Fields(cmd), "")
+		cmds[cmd] = true
 	}
 
 	if c.ReadinessProbe != nil && c.ReadinessProbe.Exec != nil {
-		for _, cmd := range c.ReadinessProbe.Exec.Command {
-			cmds[cmd] = true
-		}
+		cmd := strings.Join(c.ReadinessProbe.Exec.Command, "")
+		cmd = strings.Join(strings.Fields(cmd), "")
+		cmds[cmd] = true
 	}
 
 	if c.StartupProbe != nil && c.StartupProbe.Exec.Command != nil {
-		for _, cmd := range c.StartupProbe.Exec.Command {
-			cmds[cmd] = true
-		}
+		cmd := strings.Join(c.StartupProbe.Exec.Command, "")
+		cmd = strings.Join(strings.Fields(cmd), "")
+		cmds[cmd] = true
 	}
 
 	return cmds
@@ -278,7 +278,7 @@ func testRtAppsNoExecProbes(env *provider.TestEnvironment, cuts []*provider.Cont
 		execProbesCmds := getExecProbesCmds(cut)
 		allProcessesCompliant := true
 		for _, p := range processes {
-			if execProbesCmds[p.Args] {
+			if execProbesCmds[strings.Join(strings.Fields(p.Args), "")] {
 				compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container process belongs to an exec probe (skipping verification)", true).
 					AddField(testhelper.ProcessID, strconv.Itoa(p.Pid)).
 					AddField(testhelper.ProcessCommandLine, p.Args))

--- a/cnf-certification-test/performance/suite.go
+++ b/cnf-certification-test/performance/suite.go
@@ -19,6 +19,7 @@ package performance
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/sirupsen/logrus"
@@ -232,29 +233,49 @@ func testSchedulingPolicyInCPUPool(env *provider.TestEnvironment,
 	testhelper.AddTestResultReason(compliantContainersPids, nonCompliantContainersPids, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
+const noProcessFoundErrMsg = "No such process"
+
 func testRtAppsNoExecProbes(env *provider.TestEnvironment, cuts []*provider.Container) {
 	var compliantObjects []*testhelper.ReportObject
 	var nonCompliantObjects []*testhelper.ReportObject
 	for _, cut := range cuts {
+		if !cut.HasExecProbes() {
+			compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container does not define exec probes", true))
+			continue
+		}
+
 		processes, err := crclient.GetContainerProcesses(cut, env)
 		if err != nil {
 			tnf.ClaimFilePrintf("Could not determine the processes pids for container %s, err: %v", cut, err)
 			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Could not determine the processes pids for container", false))
 			break
 		}
+
+		allProcessesCompliant := true
 		for _, p := range processes {
 			schedPolicy, _, err := scheduling.GetProcessCPUScheduling(p.Pid, cut)
 			if err != nil {
+				// If the process does not exist anymore it means that it has finished since the time the process list
+				// was retrieved. In this case, just ignore the error and continue processing the rest of the processes.
+				if strings.Contains(err.Error(), noProcessFoundErrMsg) {
+					continue
+				}
 				tnf.ClaimFilePrintf("Could not determine the scheduling policy for container %s (pid=%v), err: %v", cut, p.Pid, err)
 				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Could not determine the scheduling policy for container", false).
 					AddField(testhelper.ProcessID, strconv.Itoa(p.Pid)))
-				break
+				allProcessesCompliant = false
+				continue
 			}
-			if scheduling.PolicyIsRT(schedPolicy) && cut.HasExecProbes() {
+			if scheduling.PolicyIsRT(schedPolicy) {
 				tnf.ClaimFilePrintf("Pod %s/Container %s defines exec probes while having a RT scheduling policy for pid %d", cut.Podname, cut, p.Pid)
 				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container defines exec probes while having a RT scheduling policy", false).
 					AddField(testhelper.ProcessID, strconv.Itoa(p.Pid)))
+				allProcessesCompliant = false
 			}
+		}
+
+		if allProcessesCompliant {
+			compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container defines exec probes but does not have a RT scheduling policy", true))
 		}
 	}
 	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)

--- a/pkg/scheduling/scheduling.go
+++ b/pkg/scheduling/scheduling.go
@@ -132,7 +132,8 @@ func GetProcessCPUScheduling(pid int, testContainer *provider.Container) (schedu
 
 	stdout, stderr, err := ch.ExecCommandContainer(ctx, command)
 	if err != nil || stderr != "" {
-		return schedulePolicy, InvalidPriority, fmt.Errorf("command %q failed to run in debug pod %s (node %s): %v", command, ctx.GetPodName(), testContainer.NodeName, err)
+		return schedulePolicy, InvalidPriority, fmt.Errorf("command %q failed to run in debug pod %s (node %s): %v (stderr: %v)",
+			command, ctx.GetPodName(), testContainer.NodeName, err, stderr)
 	}
 
 	schedulePolicy, schedulePriority, err = parseSchedulingPolicyAndPriority(stdout)


### PR DESCRIPTION
It applies to `rt-apps-no-exec-probes`.

The reason a process cannot be found after it has been properly retrieved previously could be that the process has finished. So, in this case it seems more adequate to just ignore it than to produce an error. If the error is of another kind, the container is added to the non compliant list but the processing for that container continues instead of breaking, to have more info on the processes.

The commit also changes the verification order in that test case, making the faster check of exec probes at the beginning, skipping the slower part in which the processes are list.

Finally, the compliant containers are added to its list with the reason for compliance.