### PR TITLE
Allow Role bindings across namespaces

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -524,7 +524,8 @@ func testPodRoleBindings(env *provider.TestEnvironment) {
 								"The role bindings used by this pod do not live in one of the CNF namespaces", false).
 								AddField(testhelper.RoleBindingName, env.RoleBindings[rbIndex].Name).
 								AddField(testhelper.RoleBindingNamespace, env.RoleBindings[rbIndex].Namespace).
-								AddField(testhelper.ServiceAccountName, put.Spec.ServiceAccountName))
+								AddField(testhelper.ServiceAccountName, put.Spec.ServiceAccountName).
+								SetType(testhelper.PodRoleBinding))
 						found = true
 						podIsCompliant = false
 						break

--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -474,7 +474,9 @@ func testPodServiceAccount(env *provider.TestEnvironment) {
 	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)
 }
 
-// testPodRoleBindings verifies that the pod utilizes a valid role binding that does not cross namespaces
+// testPodRoleBindings verifies that the pod utilizes a valid role binding that does not cross non-CNF namespaces
+//
+//nolint:funlen
 func testPodRoleBindings(env *provider.TestEnvironment) {
 	ginkgo.By("Should not have RoleBinding in other namespaces")
 	var compliantObjects []*testhelper.ReportObject
@@ -502,15 +504,24 @@ func testPodRoleBindings(env *provider.TestEnvironment) {
 				// We must check if the pod's service account is in the role binding's subjects.
 				found := false
 				for _, subject := range env.RoleBindings[rbIndex].Subjects {
-					// If the subject is a service account and the service account is in the same namespace as the pod, then we have a failure
-					//nolint:gocritic
-					if subject.Kind == rbacv1.ServiceAccountKind && subject.Namespace == put.Namespace && subject.Name == put.Spec.ServiceAccountName {
-						tnf.Logf(logrus.WarnLevel, "Pod: %s/%s has the following role bindings that do not live in the same namespace: %s", put.Namespace, put.Name, env.RoleBindings[rbIndex].Name)
+					// If the subject is a service account and the service account is in the same namespace as one of the CNF's namespaces, then continue, this is allowed
+					if subject.Kind == rbacv1.ServiceAccountKind &&
+						subject.Namespace == put.Namespace &&
+						subject.Name == put.Spec.ServiceAccountName &&
+						stringhelper.StringInSlice(env.Namespaces, env.RoleBindings[rbIndex].Namespace, false) {
+						continue
+					}
+
+					// Finally, if the subject is a service account and the service account is in the same namespace as the pod, then we have a failure
+					if subject.Kind == rbacv1.ServiceAccountKind &&
+						subject.Namespace == put.Namespace &&
+						subject.Name == put.Spec.ServiceAccountName {
+						tnf.Logf(logrus.WarnLevel, "Pod: %s has the following role bindings that do not live in one of the CNF namespaces: %s", put, env.RoleBindings[rbIndex].Name)
 
 						// Add the pod to the non-compliant list
 						nonCompliantObjects = append(nonCompliantObjects,
 							testhelper.NewPodReportObject(put.Namespace, put.Name,
-								"The role bindings used by this pod do not live in the same namespace", false).
+								"The role bindings used by this pod do not live in one of the CNF namespaces", false).
 								AddField(testhelper.RoleBindingName, env.RoleBindings[rbIndex].Name).
 								AddField(testhelper.RoleBindingNamespace, env.RoleBindings[rbIndex].Namespace).
 								AddField(testhelper.ServiceAccountName, put.Spec.ServiceAccountName))
@@ -528,7 +539,7 @@ func testPodRoleBindings(env *provider.TestEnvironment) {
 		// Add pod to the compliant object list
 		if podIsCompliant {
 			compliantObjects = append(compliantObjects,
-				testhelper.NewPodReportObject(put.Namespace, put.Name, "All the role bindings used by this pod (applied by the service accounts) live in the same namespace", true))
+				testhelper.NewPodReportObject(put.Namespace, put.Name, "All the role bindings used by this pod (applied by the service accounts) live in one of the CNF namespaces", true))
 		}
 	}
 	testhelper.AddTestResultReason(compliantObjects, nonCompliantObjects, tnf.ClaimFilePrintf, ginkgo.Fail)

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -200,6 +200,7 @@ const (
 	ImageRepo                    = "Image Repo"
 	ImageTag                     = "Image Tag"
 	ImageRegistry                = "Image Registry"
+	PodRoleBinding               = "Pods with RoleBindings details"
 )
 
 func (obj *ReportObject) SetContainerProcessValues(aPolicy, aPriority, aCommandLine string) *ReportObject {


### PR DESCRIPTION
Allows a CNF to declare roles across the different namespaces that it uses. Each rolebinding can only allow roles in their own namespace to remote service accounts. This avoids duplicating the same role in multiple namespaces.
See: https://octopus.com/blog/k8s-rbac-roles-and-bindings