### PR TITLE
Setup QE OCP 4.14 runner

### DIFF
--- a/.github/workflows/qe-ocp-413-intrusive.yaml
+++ b/.github/workflows/qe-ocp-413-intrusive.yaml
@@ -1,0 +1,78 @@
+name: QE OCP 4.13 Intrusive Testing
+
+on:
+  # pull_request:
+  #   branches: [ main ]
+  workflow_dispatch:
+  # Schedule a daily cron at midnight UTC
+  schedule:
+    - cron: '0 0 * * *'
+env:
+  QE_REPO: test-network-function/cnfcert-tests-verification
+
+jobs:
+  qe-ocp-413-intrusive-testing:
+    runs-on: qe-ocp
+    strategy:
+      fail-fast: false
+      matrix: 
+        # Add more suites if more intrusive tests are added to the QE repo
+        suite: [lifecycle]
+    env:
+      SHELL: /bin/bash
+      KUBECONFIG: '/home/labuser/.kube/config'
+      PFLT_DOCKERCONFIG: '/home/labuser/.docker/config'
+      TEST_TNF_IMAGE_NAME: quay.io/testnetworkfunction/cnf-certification-test
+      TEST_TNF_IMAGE_TAG: localtest
+      DOCKER_CONFIG_DIR: '/home/labuser/.docker'
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Run initial setup
+        uses: ./.github/actions/setup
+
+      - name: Preemptively prune docker resources
+        run: docker system prune -f --volumes
+
+      - name: Build the test image
+        run: make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
+
+      - name: Show pods
+        run: oc get pods -A
+
+      - name: Clone the QE repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.QE_REPO }}
+          path: cnfcert-tests-verification
+
+      - name: Preemptively potential QE namespaces
+        run: ./scripts/delete-namespaces.sh
+        working-directory: cnfcert-tests-verification
+
+      - name: Preemptively delete report and config folders
+        shell: bash
+        run: |
+          sudo rm -rf /tmp/tnf_config/
+          sudo rm -rf /tmp/tnf_report/
+
+      # Setup is complete.  Time to run the QE tests.
+      - name: Run the tests
+        run: FEATURES=${{matrix.suite}} TNF_REPO_PATH=${GITHUB_WORKSPACE} TNF_IMAGE=${{env.TEST_TNF_IMAGE_NAME}} TNF_IMAGE_TAG=${{env.TEST_TNF_IMAGE_TAG}} DISABLE_INTRUSIVE_TESTS=false ENABLE_PARALLEL=false ENABLE_FLAKY_RETRY=true make test-features
+        working-directory: cnfcert-tests-verification
+
+      - name: (if on main and upstream) Send chat msg to dev team if failed to run QE tests
+        if: ${{ failure() && github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          JOB_RUN_ID: ${{ github.run_id }}
+          JOB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GITHUB_REPO: https://github.com/test-network-function/cnf-certification-test
+        run: |
+          curl -X POST --data "{
+              \"text\": \"🚨⚠️  Failed to run intrusive OCP 4.13 QE tests from commit \<$GITHUB_REPO/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<$GITHUB_REPO/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"
+          }" -H 'Content-type: application/json; charset=UTF-8' ${{ secrets.QE_NIGHTLY_WEBHOOK }}

--- a/.github/workflows/qe-ocp-413.yaml
+++ b/.github/workflows/qe-ocp-413.yaml
@@ -1,4 +1,4 @@
-name: QE OCP Intrusive Testing
+name: QE OCP 4.13 Testing
 
 on:
   # pull_request:
@@ -11,13 +11,12 @@ env:
   QE_REPO: test-network-function/cnfcert-tests-verification
 
 jobs:
-  qe-ocp-intrusive-testing:
+  qe-ocp-413-testing:
     runs-on: qe-ocp
     strategy:
       fail-fast: false
       matrix: 
-        # Add more suites if more intrusive tests are added to the QE repo
-        suite: [lifecycle]
+        suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/labuser/.kube/config'
@@ -62,7 +61,7 @@ jobs:
 
       # Setup is complete.  Time to run the QE tests.
       - name: Run the tests
-        run: FEATURES=${{matrix.suite}} TNF_REPO_PATH=${GITHUB_WORKSPACE} TNF_IMAGE=${{env.TEST_TNF_IMAGE_NAME}} TNF_IMAGE_TAG=${{env.TEST_TNF_IMAGE_TAG}} DISABLE_INTRUSIVE_TESTS=false ENABLE_PARALLEL=false ENABLE_FLAKY_RETRY=true make test-features
+        run: FEATURES=${{matrix.suite}} TNF_REPO_PATH=${GITHUB_WORKSPACE} TNF_IMAGE=${{env.TEST_TNF_IMAGE_NAME}} TNF_IMAGE_TAG=${{env.TEST_TNF_IMAGE_TAG}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=true ENABLE_FLAKY_RETRY=true make test-features
         working-directory: cnfcert-tests-verification
 
       - name: (if on main and upstream) Send chat msg to dev team if failed to run QE tests
@@ -74,5 +73,5 @@ jobs:
           GITHUB_REPO: https://github.com/test-network-function/cnf-certification-test
         run: |
           curl -X POST --data "{
-              \"text\": \"🚨⚠️  Failed to run intrusive OCP QE tests from commit \<$GITHUB_REPO/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<$GITHUB_REPO/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"
+              \"text\": \"🚨⚠️  Failed to run non-intrusive OCP 4.13 QE tests from commit \<$GITHUB_REPO/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<$GITHUB_REPO/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"
           }" -H 'Content-type: application/json; charset=UTF-8' ${{ secrets.QE_NIGHTLY_WEBHOOK }}

--- a/.github/workflows/qe-ocp-414-intrusive.yaml
+++ b/.github/workflows/qe-ocp-414-intrusive.yaml
@@ -1,4 +1,4 @@
-name: QE OCP Testing
+name: QE OCP 4.14 Intrusive Testing
 
 on:
   # pull_request:
@@ -11,19 +11,20 @@ env:
   QE_REPO: test-network-function/cnfcert-tests-verification
 
 jobs:
-  qe-ocp-testing:
-    runs-on: qe-ocp
+  qe-ocp-414-intrusive-testing:
+    runs-on: qe-ocp-414
     strategy:
       fail-fast: false
       matrix: 
-        suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
+        # Add more suites if more intrusive tests are added to the QE repo
+        suite: [lifecycle]
     env:
       SHELL: /bin/bash
-      KUBECONFIG: '/home/labuser/.kube/config'
-      PFLT_DOCKERCONFIG: '/home/labuser/.docker/config'
+      KUBECONFIG: '/home/labuser2/.kube/config'
+      PFLT_DOCKERCONFIG: '/home/labuser2/.docker/config'
       TEST_TNF_IMAGE_NAME: quay.io/testnetworkfunction/cnf-certification-test
       TEST_TNF_IMAGE_TAG: localtest
-      DOCKER_CONFIG_DIR: '/home/labuser/.docker'
+      DOCKER_CONFIG_DIR: '/home/labuser2/.docker'
 
     steps:
       - name: Check out code
@@ -61,7 +62,7 @@ jobs:
 
       # Setup is complete.  Time to run the QE tests.
       - name: Run the tests
-        run: FEATURES=${{matrix.suite}} TNF_REPO_PATH=${GITHUB_WORKSPACE} TNF_IMAGE=${{env.TEST_TNF_IMAGE_NAME}} TNF_IMAGE_TAG=${{env.TEST_TNF_IMAGE_TAG}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=true ENABLE_FLAKY_RETRY=true make test-features
+        run: FEATURES=${{matrix.suite}} TNF_REPO_PATH=${GITHUB_WORKSPACE} TNF_IMAGE=${{env.TEST_TNF_IMAGE_NAME}} TNF_IMAGE_TAG=${{env.TEST_TNF_IMAGE_TAG}} DISABLE_INTRUSIVE_TESTS=false ENABLE_PARALLEL=false ENABLE_FLAKY_RETRY=true make test-features
         working-directory: cnfcert-tests-verification
 
       - name: (if on main and upstream) Send chat msg to dev team if failed to run QE tests
@@ -73,5 +74,5 @@ jobs:
           GITHUB_REPO: https://github.com/test-network-function/cnf-certification-test
         run: |
           curl -X POST --data "{
-              \"text\": \"🚨⚠️  Failed to run non-intrusive OCP QE tests from commit \<$GITHUB_REPO/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<$GITHUB_REPO/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"
+              \"text\": \"🚨⚠️  Failed to run intrusive OCP 4.14 QE tests from commit \<$GITHUB_REPO/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<$GITHUB_REPO/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"
           }" -H 'Content-type: application/json; charset=UTF-8' ${{ secrets.QE_NIGHTLY_WEBHOOK }}

--- a/.github/workflows/qe-ocp-414.yaml
+++ b/.github/workflows/qe-ocp-414.yaml
@@ -1,0 +1,77 @@
+name: QE OCP 4.14 Testing
+
+on:
+  # pull_request:
+  #   branches: [ main ]
+  workflow_dispatch:
+  # Schedule a daily cron at midnight UTC
+  schedule:
+    - cron: '0 0 * * *'
+env:
+  QE_REPO: test-network-function/cnfcert-tests-verification
+
+jobs:
+  qe-ocp-414-testing:
+    runs-on: qe-ocp-414
+    strategy:
+      fail-fast: false
+      matrix: 
+        suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
+    env:
+      SHELL: /bin/bash
+      KUBECONFIG: '/home/labuser2/.kube/config'
+      PFLT_DOCKERCONFIG: '/home/labuser2/.docker/config'
+      TEST_TNF_IMAGE_NAME: quay.io/testnetworkfunction/cnf-certification-test
+      TEST_TNF_IMAGE_TAG: localtest
+      DOCKER_CONFIG_DIR: '/home/labuser2/.docker'
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Run initial setup
+        uses: ./.github/actions/setup
+
+      - name: Preemptively prune docker resources
+        run: docker system prune -f --volumes
+
+      - name: Build the test image
+        run: make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
+
+      - name: Show pods
+        run: oc get pods -A
+
+      - name: Clone the QE repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.QE_REPO }}
+          path: cnfcert-tests-verification
+
+      - name: Preemptively potential QE namespaces
+        run: ./scripts/delete-namespaces.sh
+        working-directory: cnfcert-tests-verification
+
+      - name: Preemptively delete report and config folders
+        shell: bash
+        run: |
+          sudo rm -rf /tmp/tnf_config/
+          sudo rm -rf /tmp/tnf_report/
+
+      # Setup is complete.  Time to run the QE tests.
+      - name: Run the tests
+        run: FEATURES=${{matrix.suite}} TNF_REPO_PATH=${GITHUB_WORKSPACE} TNF_IMAGE=${{env.TEST_TNF_IMAGE_NAME}} TNF_IMAGE_TAG=${{env.TEST_TNF_IMAGE_TAG}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=true ENABLE_FLAKY_RETRY=true make test-features
+        working-directory: cnfcert-tests-verification
+
+      - name: (if on main and upstream) Send chat msg to dev team if failed to run QE tests
+        if: ${{ failure() && github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          JOB_RUN_ID: ${{ github.run_id }}
+          JOB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GITHUB_REPO: https://github.com/test-network-function/cnf-certification-test
+        run: |
+          curl -X POST --data "{
+              \"text\": \"🚨⚠️  Failed to run non-intrusive OCP 4.14 QE tests from commit \<$GITHUB_REPO/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<$GITHUB_REPO/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"
+          }" -H 'Content-type: application/json; charset=UTF-8' ${{ secrets.QE_NIGHTLY_WEBHOOK }}


### PR DESCRIPTION
We are going to start testing OCP 4.14 QE as part of our nightlies.  Notable changes:
- Changed `qe-ocp.yaml` --> `qe-ocp-413.yaml`.
- Changed `qe-ocp-intrusive.yaml` --> `qe-ocp-413-intrusive.yaml`.
- Added `qe-ocp-414.yaml` --> `qe-ocp-414.yaml`.
- Added `qe-ocp-414-intrusive.yaml` --> `qe-ocp-414-intrusive.yaml`.

With future releases of OCP, we'll test the two releases in General Availability.  The 4.13 runner will be deprecated and 4.15 will be added.