### PR TITLE
ginkgo_removal branch: enable github checks on new PRs.

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, ginkgo_removal]
   workflow_dispatch:
 env:
   REGISTRY: quay.io


### PR DESCRIPTION
Only the test cases of the observability test suite have been ported to the new ginkgoless mini-framework (checksdb).
The gradetool's [config](https://github.com/test-network-function/cnf-certification-test/blob/ginkgo_removal/generated_policy.json) file was updated accordingly.