### PR TITLE
Transition manageability suite to ginkgoless

### DIFF
--- a/generated_policy.json
+++ b/generated_policy.json
@@ -2,6 +2,16 @@
   "grades": {
     "requiredPassingTests": [
       {
+        "id": "manageability-container-port-name-format",
+        "suite": "manageability",
+        "tags": "extended"
+      },
+      {
+        "id": "manageability-containers-image-tag",
+        "suite": "manageability",
+        "tags": "extended"
+      },
+      {
         "id": "observability-container-logging",
         "suite": "observability",
         "tags": "telco"

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/pkg/loghelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/versions"
 
+	_ "github.com/test-network-function/cnf-certification-test/cnf-certification-test/manageability"
 	_ "github.com/test-network-function/cnf-certification-test/cnf-certification-test/observability"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/webserver"
 


### PR DESCRIPTION
Building upon the work done by @greyerof, this PR will transition the `manageability` suite to what we're calling "ginkgoless".