### PR TITLE
Transition performance suite to ginkgoless.

### DIFF
--- a/generated_policy.json
+++ b/generated_policy.json
@@ -20,6 +20,16 @@
         "id": "observability-termination-policy",
         "suite": "observability",
         "tags": "telco"
+      },
+      {
+        "id": "performance-exclusive-cpu-pool",
+        "suite": "performance",
+        "tags": "faredge"
+      },
+      {
+        "id": "performance-max-resources-exec-probes",
+        "suite": "performance",
+        "tags": "faredge"
       }
     ],
     "gradeName": "good"

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/pkg/versions"
 
 	_ "github.com/test-network-function/cnf-certification-test/cnf-certification-test/observability"
+	_ "github.com/test-network-function/cnf-certification-test/cnf-certification-test/performance"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/webserver"
 
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -326,6 +326,26 @@ func ResultToString(result int) (str string) {
 	return ""
 }
 
+func GetNoContainersUnderTestSkipFn(env *provider.TestEnvironment) func() (bool, string) {
+	return func() (bool, string) {
+		if len(env.Containers) == 0 {
+			return true, "There are no containers to check. Please check under test labels."
+		}
+
+		return false, ""
+	}
+}
+
+func GetNoPodsUnderTestSkipFn(env *provider.TestEnvironment) func() (bool, string) {
+	return func() (bool, string) {
+		if len(env.Pods) == 0 {
+			return true, "There are no pods to check. Please check under test labels."
+		}
+
+		return false, ""
+	}
+}
+
 func SkipIfEmptyAny(skip func(string, ...int), object ...[2]interface{}) {
 	for _, o := range object {
 		s := reflect.ValueOf(o[0])


### PR DESCRIPTION
Also, added a couple of generic helper functions that create skip functions to be used in the check.WithSkipCheckFn() call.
- testhelper.GetNoContainersUnderTestSkipFn(env)
- testhelper.GetNoPodsUnderTestSkipFn(env)

Both return a closure function over the env pointer, and the signature of that function is the expected by the checksdb's runner:
  func() (skip bool, string)