### PR TITLE
Transition certification suite to ginkgoless.

### DIFF
--- a/generated_policy.json
+++ b/generated_policy.json
@@ -2,6 +2,11 @@
   "grades": {
     "requiredPassingTests": [
       {
+        "id": "affiliated-certification-operator-is-certified",
+        "suite": "affiliated-certification",
+        "tags": "common"
+      },
+      {
         "id": "manageability-container-port-name-format",
         "suite": "manageability",
         "tags": "extended"
@@ -36,11 +41,11 @@
         "suite": "performance",
         "tags": "faredge"
       },
-      {
+            {
         "id": "performance-max-resources-exec-probes",
         "suite": "performance",
         "tags": "faredge"
-      }
+            }
     ],
     "gradeName": "good"
   }

--- a/generated_policy.json
+++ b/generated_policy.json
@@ -41,11 +41,11 @@
         "suite": "performance",
         "tags": "faredge"
       },
-            {
+      {
         "id": "performance-max-resources-exec-probes",
         "suite": "performance",
         "tags": "faredge"
-            }
+      }
     ],
     "gradeName": "good"
   }

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/pkg/loghelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/versions"
 
+	_ "github.com/test-network-function/cnf-certification-test/cnf-certification-test/certification"
 	_ "github.com/test-network-function/cnf-certification-test/cnf-certification-test/manageability"
 	_ "github.com/test-network-function/cnf-certification-test/cnf-certification-test/observability"
 	_ "github.com/test-network-function/cnf-certification-test/cnf-certification-test/performance"

--- a/pkg/tnf/status.go
+++ b/pkg/tnf/status.go
@@ -9,7 +9,7 @@ import (
 // ClaimFilePrintf prints to stdout.
 // ToDo: Remove?
 func ClaimFilePrintf(format string, args ...interface{}) {
-	Logf(logrus.TraceLevel, format, args)
+	Logf(logrus.TraceLevel, format, args...)
 }
 
 // Logf prints to stdout.


### PR DESCRIPTION
Non-backward compatibility: the tc/check
"affiliated-certification-helm-version" will be skipped if no helm
chart releases were discovered. Also, in case we discovered some chart
releases and helm is v3, every chart release will be added as a compliant
report object.

~PR #1620 needs to be merged first, as this code uses the helper function
"testhelper.GetNoContainersUnderTestSkipFn()" created by that PR.~

Also, added the expansion of the "args..." in the ClaimFilePrintf call
to Logf.