### PR TITLE
Fix for the webserver kubeconfig file handling.

### DIFF
--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -157,6 +157,15 @@ func GetClientsHolder(filenames ...string) *ClientsHolder {
 	return clientsHolder
 }
 
+func GetNewClientsHolder(kubeconfigFile string) *ClientsHolder {
+	_, err := newClientsHolder(kubeconfigFile)
+	if err != nil {
+		logrus.Panic("Failed to create k8s clients holder: ", err)
+	}
+
+	return &clientsHolder
+}
+
 func createByteArrayKubeConfig(kubeConfig *clientcmdapi.Config) ([]byte, error) {
 	yamlBytes, err := clientcmd.Write(*kubeConfig)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -155,14 +155,13 @@ func main() {
 	}
 
 	// Set clientsholder singleton with the filenames from the env vars.
-	_ = clientsholder.GetClientsHolder(getK8sClientsConfigFileNames()...)
-
 	log.Infof("Output folder for the claim file: %s", *claimPath)
 	if *serverModeFlag {
 		log.Info("Running CNF Certification Suite in web server mode.")
 		webserver.StartServer(*claimPath)
 	} else {
 		log.Info("Running CNF Certification Suite in stand-alone mode.")
+		_ = clientsholder.GetClientsHolder(getK8sClientsConfigFileNames()...)
 		certsuite.Run(*labelsFlag, *claimPath, timeout)
 	}
 }


### PR DESCRIPTION
The kubeconfig sent via web form is now copied to a temporary file.

Also, I created a new function in the clientsholder package to recreate the oc clients for each webserver run, using the kubceonfig file sent via web form.