### PR TITLE
Transition lifecycle suite to ginkgoless

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 
 	_ "github.com/test-network-function/cnf-certification-test/cnf-certification-test/accesscontrol"
 	_ "github.com/test-network-function/cnf-certification-test/cnf-certification-test/certification"
+	_ "github.com/test-network-function/cnf-certification-test/cnf-certification-test/lifecycle"
 	_ "github.com/test-network-function/cnf-certification-test/cnf-certification-test/manageability"
 	_ "github.com/test-network-function/cnf-certification-test/cnf-certification-test/networking"
 	_ "github.com/test-network-function/cnf-certification-test/cnf-certification-test/observability"

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -441,20 +441,70 @@ func GetNoRolesSkipFn(env *provider.TestEnvironment) func() (bool, string) {
 	}
 }
 
-func GetDaemonSetFailedToSpawnSkipFn(env *provider.TestEnvironment) func() (bool, string) {
+func GetSharedProcessNamespacePodsSkipFn(env *provider.TestEnvironment) func() (bool, string) {
 	return func() (bool, string) {
-		if env.DaemonsetFailedToSpawn {
-			return true, "DaemonSet failed to spawn."
+		if len(env.GetShareProcessNamespacePods()) == 0 {
+			return true, "Shared process namespace pods found."
 		}
 
 		return false, ""
 	}
 }
 
-func GetSharedProcessNamespacePodsSkipFn(env *provider.TestEnvironment) func() (bool, string) {
+func GetNotIntrusiveSkipFn(env *provider.TestEnvironment) func() (bool, string) {
 	return func() (bool, string) {
-		if len(env.GetShareProcessNamespacePods()) == 0 {
-			return true, "Shared process namespace pods found."
+		if !env.IsIntrusive() {
+			return true, "not intrusive test"
+		}
+
+		return false, ""
+	}
+}
+
+func GetNoPersistentVolumesSkipFn(env *provider.TestEnvironment) func() (bool, string) {
+	return func() (bool, string) {
+		if len(env.PersistentVolumes) == 0 {
+			return true, "no persistent volumes to check found"
+		}
+
+		return false, ""
+	}
+}
+
+func GetNotEnoughWorkersSkipFn(env *provider.TestEnvironment, minWorkerNodes int) func() (bool, string) {
+	return func() (bool, string) {
+		if env.GetWorkerCount() < minWorkerNodes {
+			return true, "not enough nodes to check found"
+		}
+
+		return false, ""
+	}
+}
+
+func GetPodsWithoutAffinityRequiredLabelSkipFn(env *provider.TestEnvironment) func() (bool, string) {
+	return func() (bool, string) {
+		if len(env.GetPodsWithoutAffinityRequiredLabel()) == 0 {
+			return true, "no pods with required affinity label found"
+		}
+
+		return false, ""
+	}
+}
+
+func GetNoGuaranteedPodsWithExclusiveCPUsSkipFn(env *provider.TestEnvironment) func() (bool, string) {
+	return func() (bool, string) {
+		if len(env.GetGuaranteedPodsWithExclusiveCPUs()) == 0 {
+			return true, "no pods with exclusive CPUs found"
+		}
+
+		return false, ""
+	}
+}
+
+func GetNoAffinityRequiredPodsSkipFn(env *provider.TestEnvironment) func() (bool, string) {
+	return func() (bool, string) {
+		if len(env.GetAffinityRequiredPods()) == 0 {
+			return true, "no pods with required affinity found"
 		}
 
 		return false, ""


### PR DESCRIPTION
Similar to: #1616 

The biggest changes here that are out of the ordinary are to the pod-recreation test which was still using direct `ginkgo.Fail` calls.