### PR TITLE
Fixed function AreCPUResourcesWholeUnits().

### DIFF
--- a/pkg/provider/isolation.go
+++ b/pkg/provider/isolation.go
@@ -58,21 +58,20 @@ func AreCPUResourcesWholeUnits(p *Pod) bool {
 	// Pods may contain more than one container.  All containers must conform to the CPU isolation requirements.
 	for _, cut := range p.Containers {
 		// Resources must be specified
-		if len(cut.Resources.Requests) == 0 || len(cut.Resources.Limits) == 0 {
+		cpuRequestsMillis := cut.Resources.Requests.Cpu().MilliValue()
+		cpuLimitsMillis := cut.Resources.Limits.Cpu().MilliValue()
+
+		if cpuRequestsMillis == 0 || cpuLimitsMillis == 0 {
 			logrus.Debugf("%s has been found with undefined requests or limits.", cut.String())
 			return false
 		}
 
-		// Gather the values
-		cpuRequests := cut.Resources.Requests.Cpu().MilliValue()
-		cpuLimits := cut.Resources.Limits.Cpu().MilliValue()
-
-		if !isInteger(cpuRequests) {
-			logrus.Debugf("%s has CPU requests %d (milli) that has to be a whole unit.", cut.String(), cpuRequests)
+		if !isInteger(cpuRequestsMillis) {
+			logrus.Debugf("%s has CPU requests %d (milli) that has to be a whole unit.", cut.String(), cpuRequestsMillis)
 			return false
 		}
-		if !isInteger(cpuLimits) {
-			logrus.Debugf("%s has CPU limits %d (milli) that has to be a whole unit.", cut.String(), cpuLimits)
+		if !isInteger(cpuLimitsMillis) {
+			logrus.Debugf("%s has CPU limits %d (milli) that has to be a whole unit.", cut.String(), cpuLimitsMillis)
 			return false
 		}
 	}

--- a/pkg/provider/isolation_test.go
+++ b/pkg/provider/isolation_test.go
@@ -218,6 +218,39 @@ func TestCPUIsolation(t *testing.T) {
 			runtimeClassNameResult:   true,
 			loadBalancingResult:      false,
 		},
+		{ // Test Case #6 - Mem reqs/limit set, but no Cpu limits/reqs set.
+			testPod: &Pod{
+				Containers: []*Container{
+					{
+						Container: &corev1.Container{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"memory": resource.MustParse(validMemLimit),
+								},
+								Limits: corev1.ResourceList{
+									"memory": resource.MustParse(validMemLimit),
+								},
+							},
+						},
+					},
+				},
+				Pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						RuntimeClassName: &testClassName,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"cpu-load-balancing.crio.io": "disable",
+							"irq-load-balancing.crio.io": "disable",
+						},
+					},
+				},
+			},
+			resourcesIdenticalResult: true,
+			wholeUnitsResult:         false,
+			runtimeClassNameResult:   true,
+			loadBalancingResult:      true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
The bug happens when deploying pods with containers that don't have any cpu req/limit defined in its spec but they do have any other resource (like mem) set.

cut.Resources.Requests and cut.Resources.Limits are maps, whose keys are the different resources (mem, cpu, hugepages) that were explicitly set in the container spec.

Requests.Cpu() returns a defaulted (zeroed) Quantity for the cpu resource if that resource type doesn't exist in the requests map, which will happen if cpu reqs/limits are not explicitly set in the pod spec.