### PR TITLE
Re-enable QE PR checks

### DIFF
--- a/.github/workflows/qe-hosted.yml
+++ b/.github/workflows/qe-hosted.yml
@@ -1,8 +1,8 @@
 name: QE Testing (Ubuntu-hosted)
 
 on:
-  # pull_request:
-  #   branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
   # Schedule a daily cron at midnight UTC
   schedule:
@@ -26,6 +26,7 @@ jobs:
       TEST_TNF_IMAGE_NAME: quay.io/testnetworkfunction/cnf-certification-test
       TEST_TNF_IMAGE_TAG: localtest
       DOCKER_CONFIG_DIR: '/home/runner/.docker/'
+      SKIP_PRELOAD_IMAGES: true
 
     steps:
       - name: Free Disk Space (Ubuntu)


### PR DESCRIPTION
Similar to: https://github.com/test-network-function/cnfcert-tests-verification/pull/607

Just as a note, the PR checks for the performance suite will fail due to an error introduced in this PR: https://github.com/test-network-function/cnf-certification-test/pull/1631 