### PR TITLE
Allow more than one skip functions per check.

### DIFF
--- a/cnf-certification-test/observability/suite.go
+++ b/cnf-certification-test/observability/suite.go
@@ -27,7 +27,6 @@ import (
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/identifiers"
 	pdbv1 "github.com/test-network-function/cnf-certification-test/cnf-certification-test/observability/pdb"
 
-	// "github.com/test-network-function/cnf-certification-test/cnf-certification-test/results"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/pkg/checksdb"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
@@ -44,32 +43,6 @@ var (
 		env = provider.GetTestEnvironment()
 		return nil
 	}
-
-	skipIfNoContainersFn = func() (bool, string) {
-		if len(env.Containers) == 0 {
-			logrus.Warnf("No containers to check...")
-			return true, "There are no containers to check. Please check under test labels."
-		}
-
-		return false, ""
-	}
-
-	skipIfNoCrdsFn = func() (bool, string) {
-		if len(env.Crds) == 0 {
-			logrus.Warn("No CRDs to check.")
-			return true, "There are no CRDs to check."
-		}
-
-		return false, ""
-	}
-
-	skipIfNoDeploymentsNorStatefulSets = func() (bool, string) {
-		if len(env.Deployments) == 0 && len(env.StatefulSets) == 0 {
-			logrus.Warn("No deployments nor statefulsets to check.")
-			return true, "There are no deployments nor statefulsets to check."
-		}
-		return false, ""
-	}
 )
 
 func init() {
@@ -80,7 +53,7 @@ func init() {
 
 	testID, tags := identifiers.GetGinkgoTestIDAndLabels(identifiers.TestLoggingIdentifier)
 	check := checksdb.NewCheck(testID, tags).
-		WithSkipCheckFn(skipIfNoContainersFn).
+		WithSkipCheckFn(testhelper.GetNoContainersUnderTestSkipFn(&env)).
 		WithCheckFn(func(c *checksdb.Check) error {
 			testContainersLogging(c, &env)
 			return nil
@@ -90,7 +63,7 @@ func init() {
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestCrdsStatusSubresourceIdentifier)
 	check = checksdb.NewCheck(testID, tags).
-		WithSkipCheckFn(skipIfNoCrdsFn).
+		WithSkipCheckFn(testhelper.GetNoCrdsUnderTestSkipFn(&env)).
 		WithCheckFn(func(c *checksdb.Check) error {
 			testCrds(c, &env)
 			return nil
@@ -100,7 +73,7 @@ func init() {
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestTerminationMessagePolicyIdentifier)
 	check = checksdb.NewCheck(testID, tags).
-		WithSkipCheckFn(skipIfNoContainersFn).
+		WithSkipCheckFn(testhelper.GetNoContainersUnderTestSkipFn(&env)).
 		WithCheckFn(func(c *checksdb.Check) error {
 			testTerminationMessagePolicy(c, &env)
 			return nil
@@ -110,7 +83,8 @@ func init() {
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestPodDisruptionBudgetIdentifier)
 	check = checksdb.NewCheck(testID, tags).
-		WithSkipCheckFn(skipIfNoDeploymentsNorStatefulSets).
+		WithSkipCheckFn(testhelper.GetNoDeploymentsUnderTestSkipFn(&env), testhelper.GetNoStatefulSetsUnderTestSkipFn(&env)).
+		WithSkipModeAll().
 		WithCheckFn(func(c *checksdb.Check) error {
 			testPodDisruptionBudgets(c, &env)
 			return nil

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -329,7 +329,7 @@ func ResultToString(result int) (str string) {
 func GetNoContainersUnderTestSkipFn(env *provider.TestEnvironment) func() (bool, string) {
 	return func() (bool, string) {
 		if len(env.Containers) == 0 {
-			return true, "There are no containers to check. Please check under test labels."
+			return true, "no containers to check found"
 		}
 
 		return false, ""
@@ -339,7 +339,37 @@ func GetNoContainersUnderTestSkipFn(env *provider.TestEnvironment) func() (bool,
 func GetNoPodsUnderTestSkipFn(env *provider.TestEnvironment) func() (bool, string) {
 	return func() (bool, string) {
 		if len(env.Pods) == 0 {
-			return true, "There are no pods to check. Please check under test labels."
+			return true, "no pods to check found"
+		}
+
+		return false, ""
+	}
+}
+
+func GetNoDeploymentsUnderTestSkipFn(env *provider.TestEnvironment) func() (bool, string) {
+	return func() (bool, string) {
+		if len(env.Deployments) == 0 {
+			return true, "no deployments to check found"
+		}
+
+		return false, ""
+	}
+}
+
+func GetNoStatefulSetsUnderTestSkipFn(env *provider.TestEnvironment) func() (bool, string) {
+	return func() (bool, string) {
+		if len(env.StatefulSets) == 0 {
+			return true, "no statefulSets to check found"
+		}
+
+		return false, ""
+	}
+}
+
+func GetNoCrdsUnderTestSkipFn(env *provider.TestEnvironment) func() (bool, string) {
+	return func() (bool, string) {
+		if len(env.Crds) == 0 {
+			return true, "no CRDs to check found"
 		}
 
 		return false, ""


### PR DESCRIPTION
The `check.WithSkipFn(skipFunc)` has been replaced by a variadic func version to allow more than one skip functions to be called: `check.WithSkipFn(skipFunc1, skipFunc2...)`

By default, the check will be skipped if any skip function returns true when they're called (which happens before running the CheckFn).

If we need to skip the check in case all the skip functions return true, the check.WithSkipModeAll() needs to be used.

Examples:
1. Skip check if no deployments ***or*** no statefulsets were found (`testhelper.SkipIfEmptyAny()`):
```
check := checksdb.NewCheck(id, labels).
  WithSkipCheckFn(testhelper.GetNoDeploymentsUnderTestSkipFn(&env), testhelper.GetNoStatefulSetsUnderTestSkipFn(&env)).
  WithCheckFn(func() error {
    ..
  })
```
2. We want to skip the check if no deployments ***and*** no statefulsets were found (`testhelper.SkipIfEmptyAll()`):
```
check := checksdb.NewCheck(id, labels).
  WithSkipCheckFn(testhelper.GetNoDeploymentsUnderTestSkipFn(&env), testhelper.GetNoStatefulSetsUnderTestSkipFn(&env)).
  WithSkipCheckModeAll().
  WithCheckFn(func() error {
    ..
  })
```
The skip functions are appended to a slice in the same order as they're passed to the check.WithSkipCheckFn() calls, and it can be called more than once. E.g.: in the previous examples, this call:
```
  ...
  WithSkipCheckFn(testhelper.GetNoDeploymentsUnderTestSkipFn(&env), testhelper.GetNoStatefulSetsUnderTestSkipFn(&env)).
  ...
```
is equal to:
```
  ...
  WithSkipCheckFn(testhelper.GetNoDeploymentsUnderTestSkipFn(&env)).
  WithSkipCheckFn(testhelper.GetNoStatefulSetsUnderTestSkipFn(&env)).
  ...
```
Extra changes:
- Added recovery mechanism from panic when running the skip functions, similar to the beforeX/afterX ones.
- Added helper skip func creators in the testhelper package for no CRDs, no statefulSets and no deployments found.
- Adapted the observability ts.