### PR TITLE
Allow cluster role bindings for pods ultimately owned by a cluster wide operator

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -612,8 +612,7 @@ func IsCSVAndClusterWide(aNamespace, name string, env *provider.TestEnvironment)
 // return true if CSV install mode contains multi namespaces or all namespaces
 func IsInstallModeMultiNamespace(installModes []v1alpha1.InstallMode) bool {
 	for i := 0; i < len(installModes); i++ {
-		if installModes[i].Type == v1alpha1.InstallModeTypeAllNamespaces ||
-			installModes[i].Type == v1alpha1.InstallModeTypeMultiNamespace {
+		if installModes[i].Type == v1alpha1.InstallModeTypeAllNamespaces {
 			return true
 		}
 	}

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -43,6 +43,7 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextv1fake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sFakeClient "k8s.io/client-go/kubernetes/fake"
 	networkingv1 "k8s.io/client-go/kubernetes/typed/networking/v1"
 	"k8s.io/client-go/rest"
@@ -63,6 +64,7 @@ type ClientsHolder struct {
 	MachineCfg           ocpMachine.Interface
 	KubeConfig           []byte
 	ready                bool
+	GroupResources       []*metav1.APIResourceList
 }
 
 var clientsHolder = ClientsHolder{}
@@ -292,6 +294,11 @@ func newClientsHolder(filenames ...string) (*ClientsHolder, error) { //nolint:fu
 	if err != nil {
 		return nil, fmt.Errorf("cannot instantiate discoveryClient: %s", err)
 	}
+	clientsHolder.GroupResources, err = discoveryClient.ServerPreferredResources()
+	if err != nil {
+		logrus.Errorf("Could not get list of resources in cluster")
+	}
+
 	resolver := scale.NewDiscoveryScaleKindResolver(discoveryClient)
 	gr, err := restmapper.GetAPIGroupResources(clientsHolder.K8sClient.Discovery())
 	if err != nil {

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (
@@ -403,4 +404,72 @@ func (p *Pod) IsRunAsUserID(uid int64) bool {
 		return false
 	}
 	return *p.Pod.Spec.SecurityContext.RunAsUser == uid
+}
+
+// Get the list of top owners of pods
+func (p *Pod) GetTopOwner() (topOwners map[string]TopOwner, err error) {
+	topOwners = make(map[string]TopOwner)
+	err = followOwnerReferences(topOwners, p.Namespace, p.OwnerReferences)
+	if err != nil {
+		return topOwners, fmt.Errorf("could not get top owners, err=%s", err)
+	}
+	return topOwners, nil
+}
+
+// Structure to describe a top owner of a pod
+type TopOwner struct {
+	Kind      string
+	Name      string
+	Namespace string
+}
+
+// Recursively follow the ownership tree to find the top owners
+func followOwnerReferences(topOwners map[string]TopOwner, namespace string, ownerRefs []metav1.OwnerReference) (err error) {
+	clients := clientsholder.GetClientsHolder()
+	for _, ownerRef := range ownerRefs {
+		fmt.Printf("-> Owner: %s/%s\n", ownerRef.Kind, ownerRef.Name)
+		// Get group resource version
+		gvr := getResourceSchema(ownerRef.APIVersion, ownerRef.Kind)
+		// Get the owner resources
+		resource, err := clients.DynamicClient.Resource(gvr).Namespace(namespace).Get(context.Background(), ownerRef.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("could not get object indicated by owner references")
+		}
+		// Get owner references of the unstructured object
+		ownerReferences := resource.GetOwnerReferences()
+		if err != nil {
+			return fmt.Errorf("error getting owner references. err= %s", err)
+		}
+		// if no owner references, we have reached the top record it
+		if len(ownerReferences) == 0 {
+			logrus.Info("reached the top of this branch")
+			topOwners[ownerRef.Name] = TopOwner{Kind: ownerRef.Kind, Name: ownerRef.Name, Namespace: namespace}
+		}
+		// if not continue following other branches
+		err = followOwnerReferences(topOwners, namespace, ownerReferences)
+		if err != nil {
+			return fmt.Errorf("error following owners")
+		}
+	}
+	return nil
+}
+
+// Get the Group Version Resource based on APIVersion and kind
+func getResourceSchema(apiVersion, kind string) (gvr schema.GroupVersionResource) {
+	const groupVersionComponentsNumber = 2
+	clients := clientsholder.GetClientsHolder()
+	for _, gr := range clients.GroupResources {
+		for i := 0; i < len(gr.APIResources); i++ {
+			if gr.APIResources[i].Kind == kind && gr.GroupVersion == apiVersion {
+				groupSplit := strings.Split(gr.GroupVersion, "/")
+				if len(groupSplit) == groupVersionComponentsNumber {
+					gvr.Group = groupSplit[0]
+					gvr.Version = groupSplit[1]
+					gvr.Resource = gr.APIResources[i].Name
+				}
+				return gvr
+			}
+		}
+	}
+	return gvr
 }

--- a/pkg/provider/pods_test.go
+++ b/pkg/provider/pods_test.go
@@ -17,19 +17,22 @@
 package provider
 
 import (
+	"errors"
+	"reflect"
 	"testing"
 
-	"errors"
-
-	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/runtime"
-
+	olmv1Alpha "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
+	v1app "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	v1 "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sDynamicFake "k8s.io/client-go/dynamic/fake"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestPod_CheckResourceOnly2MiHugePages(t *testing.T) {
@@ -513,5 +516,82 @@ func TestIsRunAsUserID(t *testing.T) {
 
 	for _, tc := range testCases {
 		assert.Equal(t, tc.expectedOutput, tc.testPod.IsRunAsUserID(tc.testUID))
+	}
+}
+
+func Test_followOwnerReferences(t *testing.T) {
+	type args struct {
+		topOwners map[string]TopOwner
+		namespace string
+		ownerRefs []metav1.OwnerReference
+	}
+
+	csv1 := &olmv1Alpha.ClusterServiceVersion{
+		TypeMeta: metav1.TypeMeta{Kind: "ClusterServiceVersion", APIVersion: "operators.coreos.com/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "csv1",
+			Namespace:       "ns1",
+			OwnerReferences: []metav1.OwnerReference{},
+		},
+	}
+	dep1 := &v1app.Deployment{
+		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "dep1",
+			Namespace:       "ns1",
+			OwnerReferences: []metav1.OwnerReference{{APIVersion: "operators.coreos.com/v1alpha1", Kind: "ClusterServiceVersion", Name: "csv1"}},
+		},
+	}
+	rep1 := &v1app.ReplicaSet{
+		TypeMeta: metav1.TypeMeta{Kind: "ReplicaSet", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "rep1",
+			Namespace:       "ns1",
+			OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "dep1"}},
+		},
+	}
+
+	resourceList := []*metav1.APIResourceList{
+		{GroupVersion: "operators.coreos.com/v1alpha1", APIResources: []metav1.APIResource{{Name: "clusterserviceversions", Kind: "ClusterServiceVersion"}}},
+		{GroupVersion: "apps/v1", APIResources: []metav1.APIResource{{Name: "deployments", Kind: "Deployment"}}},
+		{GroupVersion: "apps/v1", APIResources: []metav1.APIResource{{Name: "replicasets", Kind: "ReplicaSet"}}},
+		{GroupVersion: "apps/v1", APIResources: []metav1.APIResource{{Name: "pods", Kind: "Pod"}}},
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "test1",
+			args: args{topOwners: map[string]TopOwner{"csv1": {Namespace: "ns1", Kind: "ClusterServiceVersion", Name: "csv1"}},
+				namespace: "ns1",
+				ownerRefs: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "rep1"}},
+			},
+		},
+	}
+
+	// Spoof the get and update functions
+	client := k8sDynamicFake.NewSimpleDynamicClient(runtime.NewScheme(), rep1, dep1, csv1)
+	client.Fake.AddReactor("get", "ClusterServiceVersion", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, csv1, nil
+	})
+	client.Fake.AddReactor("get", "Deployment", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, dep1, nil
+	})
+	client.Fake.AddReactor("get", "ReplicaSet", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, rep1, nil
+	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotResults := map[string]TopOwner{}
+			if err := followOwnerReferences(resourceList, client, gotResults, tt.args.namespace, tt.args.ownerRefs); (err != nil) != tt.wantErr {
+				t.Errorf("followOwnerReferences() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(gotResults, tt.args.topOwners) {
+				t.Errorf("followOwnerReferences() = %v, want %v", gotResults, tt.args.topOwners)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Pods' Owner references are traversed using unstructured generic objects until the top owner are reached and then recorded. If the top owner includes a CSV that is "cluster wide", we allow cluster role bindings to be used by the pods. 
A CSV is clusterwide if:
- the IsClusterWide variable in out operator object is set (checks the target namespaces) 
- the CSV installMethods are either multi-namespace or all-namespace