### PR TITLE
Remove gotools; adjust expected/actual

### DIFF
--- a/cmd/tnf/claim/compare/compare_test.go
+++ b/cmd/tnf/claim/compare/compare_test.go
@@ -87,7 +87,7 @@ func Test_claimCompareFilesfunc(t *testing.T) {
 			}
 
 			if err != nil {
-				assert.Equal(t, err.Error(), tc.expectedError)
+				assert.Equal(t, tc.expectedError, err.Error())
 			} else {
 				// Read the output from the pipe.
 				out, _ := io.ReadAll(r)

--- a/cmd/tnf/claim/compare/testcases/testcases_test.go
+++ b/cmd/tnf/claim/compare/testcases/testcases_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/cnf-certification-test/cmd/tnf/pkg/claim"
-	"gotest.tools/v3/assert"
 )
 
 func TestGetTestCasesResultsMap(t *testing.T) {
@@ -84,7 +84,7 @@ func TestGetTestCasesResultsMap(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			resultsMap := getTestCasesResultsMap(tc.results)
-			assert.Equal(t, true, reflect.DeepEqual(tc.expectedTestCasesResultsMap, resultsMap))
+			assert.True(t, reflect.DeepEqual(tc.expectedTestCasesResultsMap, resultsMap))
 		})
 	}
 }
@@ -143,7 +143,7 @@ func TestGetMergedTestCasesNames(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			tcMergedNamesList := getMergedTestCasesNames(tc.claim1Results, tc.claim2Results)
-			assert.Equal(t, true, reflect.DeepEqual(tc.expectedMergedTcNames, tcMergedNamesList))
+			assert.True(t, reflect.DeepEqual(tc.expectedMergedTcNames, tcMergedNamesList))
 		})
 	}
 }
@@ -308,7 +308,7 @@ func TestGetDiffReport(t *testing.T) {
 
 			// Check test case results differences
 			t.Logf("diffs: %+v", diffReport.TestCases)
-			assert.Equal(t, true, reflect.DeepEqual(tc.expectedDiffReport.TestCases, diffReport.TestCases))
+			assert.True(t, reflect.DeepEqual(tc.expectedDiffReport.TestCases, diffReport.TestCases))
 
 			// Check count
 			assert.Equal(t, tc.expectedDiffReport.DifferentTestCasesResults, diffReport.DifferentTestCasesResults)

--- a/cmd/tnf/claim/show/failures/failures_test.go
+++ b/cmd/tnf/claim/show/failures/failures_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/cnf-certification-test/cmd/tnf/pkg/claim"
-	"gotest.tools/v3/assert"
 )
 
 func TestParseTargetTestSuitesFlag(t *testing.T) {
@@ -50,7 +50,7 @@ func TestParseTargetTestSuitesFlag(t *testing.T) {
 	for _, tc := range testCases {
 		testSuitesFlag = tc.flag
 		parsedTestSuites := parseTargetTestSuitesFlag()
-		assert.DeepEqual(t, tc.expectedTestSuites, parsedTestSuites)
+		assert.Equal(t, tc.expectedTestSuites, parsedTestSuites)
 	}
 }
 
@@ -265,7 +265,7 @@ func TestGetNonCompliantObjectsFromFailureReason(t *testing.T) {
 			assert.Equal(t, tc.expectedError, err.Error())
 		}
 
-		assert.DeepEqual(t, tc.expectedNonCompliantObjects, nonCompliantObjects)
+		assert.Equal(t, tc.expectedNonCompliantObjects, nonCompliantObjects)
 	}
 }
 
@@ -376,7 +376,7 @@ func TestGetFailedTestCasesByTestSuite(t *testing.T) {
 
 	for _, tc := range testCases {
 		claimScheme, err := claim.Parse(tc.claimFilePath)
-		assert.NilError(t, err)
+		assert.Nil(t, err)
 
 		// Order test case results by test suite, using a helper map.
 		resultsByTestSuite := map[string][]*claim.TestCaseResult{}
@@ -393,6 +393,6 @@ func TestGetFailedTestCasesByTestSuite(t *testing.T) {
 			map[string]bool{tc.targetTestSuite: true},
 		)
 		fmt.Printf("%#v\n\n", testSuites)
-		assert.DeepEqual(t, tc.expectedFailedTestSuites, testSuites)
+		assert.Equal(t, tc.expectedFailedTestSuites, testSuites)
 	}
 }

--- a/cmd/tnf/pkg/claim/claim_test.go
+++ b/cmd/tnf/pkg/claim/claim_test.go
@@ -3,7 +3,7 @@ package claim
 import (
 	"testing"
 
-	"gotest.tools/v3/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsClaimFormatVersionSupported(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -219,7 +219,6 @@ require (
 	github.com/test-network-function/oct v0.0.4
 	github.com/test-network-function/privileged-daemonset v1.0.15
 	gopkg.in/yaml.v3 v3.0.1
-	gotest.tools/v3 v3.5.1
 	k8s.io/kubectl v0.28.4
 )
 

--- a/pkg/junit/convert_test.go
+++ b/pkg/junit/convert_test.go
@@ -38,7 +38,7 @@ func TestExtractTestSuiteResults(t *testing.T) {
 	results, err := junit.ExtractTestSuiteResults(claim, testKey)
 	assert.Nil(t, err)
 	// positive test
-	assert.Equal(t, true, results["[It] operator Runs test on operators operator-install-status-CSV_INSTALLED"].Passed)
+	assert.True(t, results["[It] operator Runs test on operators operator-install-status-CSV_INSTALLED"].Passed)
 	// negative test
-	assert.Equal(t, false, results["[It] platform-alteration platform-alteration-boot-params"].Passed)
+	assert.False(t, results["[It] platform-alteration platform-alteration-boot-params"].Passed)
 }

--- a/pkg/scheduling/scheduling_test.go
+++ b/pkg/scheduling/scheduling_test.go
@@ -470,9 +470,9 @@ func TestExistsSchedulingPolicyAndPriority(t *testing.T) {
 
 	for _, tc := range testCases {
 		policy, priority, err := parseSchedulingPolicyAndPriority(tc.outputString)
-		assert.Equal(t, policy, tc.expectedPolicy)
-		assert.Equal(t, priority, tc.expectedPriority)
-		assert.Equal(t, err, tc.expectedError)
+		assert.Equal(t, tc.expectedPolicy, policy)
+		assert.Equal(t, tc.expectedPriority, priority)
+		assert.Equal(t, tc.expectedError, err)
 	}
 }
 


### PR DESCRIPTION
Remove `"gotest.tools/v3/assert"` from the go.mod as we are using `"github.com/stretchr/testify/assert"` everywhere else.

Adjust some expected vs actual parameters.