### PR TITLE
Transition preflight suite to ginkgoless.

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,7 +134,9 @@ func main() {
 	log.Infof("Claim Format Version: %s", versions.ClaimFormatVersion)
 	log.Infof("Labels filter       : %v", *labelsFlag)
 
-	certsuite.LoadChecksDB()
+	_ = clientsholder.GetClientsHolder(getK8sClientsConfigFileNames()...)
+
+	certsuite.LoadChecksDB(*labelsFlag)
 
 	if *listFlag {
 		// ToDo: List all the available checks, filtered with --labels.
@@ -161,7 +163,6 @@ func main() {
 		webserver.StartServer(*claimPath)
 	} else {
 		log.Info("Running CNF Certification Suite in stand-alone mode.")
-		_ = clientsholder.GetClientsHolder(getK8sClientsConfigFileNames()...)
 		certsuite.Run(*labelsFlag, *claimPath, timeout)
 	}
 }

--- a/pkg/certsuite/certsuite.go
+++ b/pkg/certsuite/certsuite.go
@@ -13,6 +13,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/networking"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/observability"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/performance"
+	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/preflight"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/results"
 	"github.com/test-network-function/cnf-certification-test/pkg/checksdb"
 	"github.com/test-network-function/cnf-certification-test/pkg/claimhelper"
@@ -21,7 +22,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
 )
 
-func LoadChecksDB() {
+func LoadChecksDB(labelsExpr string) {
 	accesscontrol.LoadChecks()
 	certification.LoadChecks()
 	lifecycle.LoadChecks()
@@ -29,6 +30,11 @@ func LoadChecksDB() {
 	networking.LoadChecks()
 	observability.LoadChecks()
 	performance.LoadChecks()
+
+	if preflight.ShouldRun(labelsExpr) {
+		logrus.Infof("Loading preflight's lib checks.")
+		preflight.LoadChecks()
+	}
 }
 
 func Run(labelsFilter, outputFolder string, timeout time.Duration) {


### PR DESCRIPTION
The conditions to avoid pre-running the preflight lib's checks have been moved to a helper public function ShouldRun() that is called from certsuite.LoadChecksDB().