### PR TITLE
Cherry pick 1-to-1 result struct change

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -14,7 +14,7 @@ env:
   OCT_IMAGE_NAME: testnetworkfunction/oct
   OCT_IMAGE_TAG: latest
   GRADETOOL_IMAGE_NAME: testnetworkfunction/gradetool
-  GRADETOOL_IMAGE_TAG: latest
+  GRADETOOL_IMAGE_TAG: test1
   TNF_CONTAINER_CLIENT: docker
   TNF_NON_INTRUSIVE_ONLY: false
   TNF_ALLOW_PREFLIGHT_INSECURE: false

--- a/.github/workflows/qe-hosted.yml
+++ b/.github/workflows/qe-hosted.yml
@@ -49,11 +49,6 @@ jobs:
       - name: Run initial setup
         uses: ./.github/actions/setup
 
-      - name: Extract dependent Pull Requests
-        uses: depends-on/depends-on-action@main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -94,6 +89,11 @@ jobs:
         with:
           repository: ${{ env.QE_REPO }}
           path: cnfcert-tests-verification
+
+      - name: Extract dependent Pull Requests
+        uses: depends-on/depends-on-action@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run the tests
         uses: nick-fields/retry@v2

--- a/cmd/tnf/claim/compare/testcases/testcases.go
+++ b/cmd/tnf/claim/compare/testcases/testcases.go
@@ -34,11 +34,9 @@ type DiffReport struct {
 func getTestCasesResultsMap(testSuiteResults claim.TestSuiteResults) map[string]string {
 	testCaseResults := map[string]string{}
 
-	for _, results := range testSuiteResults {
-		for i := range results {
-			testCase := results[i]
-			testCaseResults[testCase.TestID.ID] = testCase.State
-		}
+	//nolint:gocritic
+	for _, testCase := range testSuiteResults {
+		testCaseResults[testCase.TestID.ID] = testCase.State
 	}
 
 	return testCaseResults

--- a/cmd/tnf/claim/compare/testcases/testcases_test.go
+++ b/cmd/tnf/claim/compare/testcases/testcases_test.go
@@ -27,13 +27,11 @@ func TestGetTestCasesResultsMap(t *testing.T) {
 		{
 			description: "one test case in the access-control ts",
 			results: claim.TestSuiteResults{
-				"access-control": []claim.TestCaseResult{
-					{
-						TestID: claim.TestCaseID{
-							ID: "access-control-ssh-daemons",
-						},
-						State: "skipped",
+				"access-control": claim.TestCaseResult{
+					TestID: claim.TestCaseID{
+						ID: "access-control-ssh-daemons",
 					},
+					State: "skipped",
 				},
 			},
 			expectedTestCasesResultsMap: map[string]string{
@@ -43,33 +41,29 @@ func TestGetTestCasesResultsMap(t *testing.T) {
 		{
 			description: "two test suites with two test cases each",
 			results: claim.TestSuiteResults{
-				"access-control": []claim.TestCaseResult{
-					{
-						TestID: claim.TestCaseID{
-							ID: "access-control-ssh-daemons",
-						},
-						State: "skipped",
+				"access-control-ssh-daemons": claim.TestCaseResult{
+					TestID: claim.TestCaseID{
+						ID: "access-control-ssh-daemons",
 					},
-					{
-						TestID: claim.TestCaseID{
-							ID: "access-control-sys-admin-capability-check",
-						},
-						State: "passed",
-					},
+					State: "skipped",
 				},
-				"lifecycle": []claim.TestCaseResult{
-					{
-						TestID: claim.TestCaseID{
-							ID: "lifecycle-pod-scheduling",
-						},
-						State: "skipped",
+				"access-control-sys-admin-capability-check": claim.TestCaseResult{
+					TestID: claim.TestCaseID{
+						ID: "access-control-sys-admin-capability-check",
 					},
-					{
-						TestID: claim.TestCaseID{
-							ID: "lifecycle-pod-high-availability",
-						},
-						State: "failed",
+					State: "passed",
+				},
+				"lifecycle-pod-scheduling": claim.TestCaseResult{
+					TestID: claim.TestCaseID{
+						ID: "lifecycle-pod-scheduling",
 					},
+					State: "skipped",
+				},
+				"lifecycle-pod-high-availability": claim.TestCaseResult{
+					TestID: claim.TestCaseID{
+						ID: "lifecycle-pod-high-availability",
+					},
+					State: "failed",
 				},
 			},
 			expectedTestCasesResultsMap: map[string]string{
@@ -210,9 +204,9 @@ func TestGetDiffReport(t *testing.T) {
 	}{
 		{
 			description: "results1 empty, results2 with one tc result",
-			results1:    map[string][]claim.TestCaseResult{},
-			results2: map[string][]claim.TestCaseResult{
-				"access-control": {{TestID: claim.TestCaseID{ID: "access-control-ssh-daemons"}, State: "passed"}},
+			results1:    map[string]claim.TestCaseResult{},
+			results2: map[string]claim.TestCaseResult{
+				"access-control": {TestID: claim.TestCaseID{ID: "access-control-ssh-daemons"}, State: "passed"},
 			},
 			expectedDiffReport: DiffReport{
 				Claim1ResultsSummary: TcResultsSummary{},
@@ -229,11 +223,11 @@ func TestGetDiffReport(t *testing.T) {
 		},
 		{
 			description: "results1 and results2 have the same passing tc",
-			results1: map[string][]claim.TestCaseResult{
-				"access-control": {{TestID: claim.TestCaseID{ID: "access-control-ssh-daemons"}, State: "passed"}},
+			results1: map[string]claim.TestCaseResult{
+				"access-control": {TestID: claim.TestCaseID{ID: "access-control-ssh-daemons"}, State: "passed"},
 			},
-			results2: map[string][]claim.TestCaseResult{
-				"access-control": {{TestID: claim.TestCaseID{ID: "access-control-ssh-daemons"}, State: "passed"}},
+			results2: map[string]claim.TestCaseResult{
+				"access-control": {TestID: claim.TestCaseID{ID: "access-control-ssh-daemons"}, State: "passed"},
 			},
 			expectedDiffReport: DiffReport{
 				Claim1ResultsSummary:      TcResultsSummary{Passed: 1},
@@ -244,11 +238,11 @@ func TestGetDiffReport(t *testing.T) {
 		},
 		{
 			description: "results1 and results2 have same tc with different result",
-			results1: map[string][]claim.TestCaseResult{
-				"access-control": {{TestID: claim.TestCaseID{ID: "access-control-ssh-daemons"}, State: "passed"}},
+			results1: map[string]claim.TestCaseResult{
+				"access-control": {TestID: claim.TestCaseID{ID: "access-control-ssh-daemons"}, State: "passed"},
 			},
-			results2: map[string][]claim.TestCaseResult{
-				"access-control": {{TestID: claim.TestCaseID{ID: "access-control-ssh-daemons"}, State: "failed"}},
+			results2: map[string]claim.TestCaseResult{
+				"access-control": {TestID: claim.TestCaseID{ID: "access-control-ssh-daemons"}, State: "failed"},
 			},
 			expectedDiffReport: DiffReport{
 				Claim1ResultsSummary:      TcResultsSummary{Passed: 1},
@@ -259,13 +253,13 @@ func TestGetDiffReport(t *testing.T) {
 		},
 		{
 			description: "results1 and results2 have the same two tcs from different test suites, both with different results",
-			results1: map[string][]claim.TestCaseResult{
-				"access-control": {{TestID: claim.TestCaseID{ID: "access-control-ssh-daemons"}, State: "passed"}},
-				"lifecycle":      {{TestID: claim.TestCaseID{ID: "lifecycle-pod-scheduling"}, State: "failed"}},
+			results1: map[string]claim.TestCaseResult{
+				"access-control": {TestID: claim.TestCaseID{ID: "access-control-ssh-daemons"}, State: "passed"},
+				"lifecycle":      {TestID: claim.TestCaseID{ID: "lifecycle-pod-scheduling"}, State: "failed"},
 			},
-			results2: map[string][]claim.TestCaseResult{
-				"access-control": {{TestID: claim.TestCaseID{ID: "access-control-ssh-daemons"}, State: "failed"}},
-				"lifecycle":      {{TestID: claim.TestCaseID{ID: "lifecycle-pod-scheduling"}, State: "passed"}},
+			results2: map[string]claim.TestCaseResult{
+				"access-control": {TestID: claim.TestCaseID{ID: "access-control-ssh-daemons"}, State: "failed"},
+				"lifecycle":      {TestID: claim.TestCaseID{ID: "lifecycle-pod-scheduling"}, State: "passed"},
 			},
 			expectedDiffReport: DiffReport{
 				Claim1ResultsSummary: TcResultsSummary{Passed: 1, Failed: 1},
@@ -279,13 +273,13 @@ func TestGetDiffReport(t *testing.T) {
 		},
 		{
 			description: "one same test case result and another different",
-			results1: map[string][]claim.TestCaseResult{
-				"access-control": {{TestID: claim.TestCaseID{ID: "access-control-ssh-daemons"}, State: "passed"}},
-				"lifecycle":      {{TestID: claim.TestCaseID{ID: "lifecycle-pod-scheduling"}, State: "failed"}},
+			results1: map[string]claim.TestCaseResult{
+				"access-control": {TestID: claim.TestCaseID{ID: "access-control-ssh-daemons"}, State: "passed"},
+				"lifecycle":      {TestID: claim.TestCaseID{ID: "lifecycle-pod-scheduling"}, State: "failed"},
 			},
-			results2: map[string][]claim.TestCaseResult{
-				"access-control": {{TestID: claim.TestCaseID{ID: "access-control-ssh-daemons"}, State: "passed"}},
-				"lifecycle":      {{TestID: claim.TestCaseID{ID: "lifecycle-pod-scheduling"}, State: "skipped"}},
+			results2: map[string]claim.TestCaseResult{
+				"access-control": {TestID: claim.TestCaseID{ID: "access-control-ssh-daemons"}, State: "passed"},
+				"lifecycle":      {TestID: claim.TestCaseID{ID: "lifecycle-pod-scheduling"}, State: "skipped"},
 			},
 			expectedDiffReport: DiffReport{
 				Claim1ResultsSummary: TcResultsSummary{Passed: 1, Failed: 1},

--- a/cmd/tnf/claim/compare/testdata/claim_access_control.json
+++ b/cmd/tnf/claim/compare/testdata/claim_access_control.json
@@ -9239,8 +9239,7 @@
       "testsExtraInfo": ""
     },
     "results": {
-      "access-control-bpf-capability-check": [
-        {
+      "access-control-bpf-capability-check": {
           "capturedTestOutput": "Non compliant [BPF container: xdp-c pod: xdp ns: tnf \u0026Capabilities{Add:[BPF PERFMON NET_ADMIN],Drop:[],}] capability detected in container %!s(MISSING). All container caps: %!s(MISSING)\n{\"CompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"test-0\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"test-1\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"test-765d6b8dcf-gbvsd\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"test-765d6b8dcf-s768n\",\"test\"]}],\"NonCompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\",\"SCC Capability\"],\"ObjectFieldsValues\":[\"Non compliant capability detected in container\",\"tnf\",\"xdp\",\"xdp-c\",\"BPF\"]}]}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Telco",
@@ -9266,10 +9265,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-cluster-role-bindings": [
-        {
+        },
+      "access-control-cluster-role-bindings": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is not using a cluster role binding\",\"tnf\",\"test-0\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is not using a cluster role binding\",\"tnf\",\"test-1\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is not using a cluster role binding\",\"tnf\",\"test-765d6b8dcf-gbvsd\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is not using a cluster role binding\",\"tnf\",\"test-765d6b8dcf-s768n\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is not using a cluster role binding\",\"tnf\",\"xdp\"]}],\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-security-rbac",
@@ -9295,10 +9292,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-container-host-port": [
-        {
+        },
+      "access-control-container-host-port": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Host port is not configured\",\"tnf\",\"test-0\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Host port is not configured\",\"tnf\",\"test-1\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Host port is not configured\",\"tnf\",\"test-765d6b8dcf-gbvsd\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Host port is not configured\",\"tnf\",\"test-765d6b8dcf-s768n\",\"test\"]}],\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-avoid-accessing-resource-on-host",
@@ -9324,10 +9319,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-crd-roles": [
-        {
+        },
+      "access-control-crd-roles": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-custom-role-to-access-application-crds",
@@ -9353,10 +9346,8 @@
             "suite": "access-control",
             "tags": "extended"
           }
-        }
-      ],
-      "access-control-ipc-lock-capability-check": [
-        {
+        },
+      "access-control-ipc-lock-capability-check": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"test-0\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"test-1\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"test-765d6b8dcf-gbvsd\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"test-765d6b8dcf-s768n\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"xdp\",\"xdp-c\"]}],\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-ipc_lock",
@@ -9382,10 +9373,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-namespace": [
-        {
+        },
+      "access-control-namespace": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Namespace\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\"],\"ObjectFieldsValues\":[\"Namespace has valid prefix\",\"tnf\"]},{\"ObjectType\":\"Namespace\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\"],\"ObjectFieldsValues\":[\"Namespace has valid prefix\",\"tnf\"]},{\"ObjectType\":\"Namespace\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\"],\"ObjectFieldsValues\":[\"Namespace has valid prefix\",\"tnf\"]},{\"ObjectType\":\"Namespace\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\"],\"ObjectFieldsValues\":[\"Namespace has valid prefix\",\"tnf\"]},{\"ObjectType\":\"Namespace\",\"ObjectFieldsKeys\":[\"Reason For Compliance\"],\"ObjectFieldsValues\":[\"CRs are in the configured namespaces\"]}],\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-requirements-cnf-reqs",
@@ -9411,10 +9400,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-namespace-resource-quota": [
-        {
+        },
+      "access-control-namespace-resource-quota": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is running in a namespace that has a ResourceQuota applied\",\"tnf\",\"test-0\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is running in a namespace that has a ResourceQuota applied\",\"tnf\",\"test-1\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is running in a namespace that has a ResourceQuota applied\",\"tnf\",\"test-765d6b8dcf-gbvsd\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is running in a namespace that has a ResourceQuota applied\",\"tnf\",\"test-765d6b8dcf-s768n\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is running in a namespace that has a ResourceQuota applied\",\"tnf\",\"xdp\"]}],\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-memory-allocation",
@@ -9440,10 +9427,8 @@
             "suite": "access-control",
             "tags": "extended"
           }
-        }
-      ],
-      "access-control-net-admin-capability-check": [
-        {
+        },
+      "access-control-net-admin-capability-check": {
           "capturedTestOutput": "Non compliant [NET_ADMIN container: test pod: test-765d6b8dcf-gbvsd ns: tnf \u0026Capabilities{Add:[NET_ADMIN],Drop:[],}] capability detected in container %!s(MISSING). All container caps: %!s(MISSING)\nNon compliant [NET_ADMIN container: test pod: test-765d6b8dcf-s768n ns: tnf \u0026Capabilities{Add:[NET_ADMIN],Drop:[],}] capability detected in container %!s(MISSING). All container caps: %!s(MISSING)\nNon compliant [NET_ADMIN container: xdp-c pod: xdp ns: tnf \u0026Capabilities{Add:[BPF PERFMON NET_ADMIN],Drop:[],}] capability detected in container %!s(MISSING). All container caps: %!s(MISSING)\n{\"CompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"test-0\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"test-1\",\"test\"]}],\"NonCompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\",\"SCC Capability\"],\"ObjectFieldsValues\":[\"Non compliant capability detected in container\",\"tnf\",\"test-765d6b8dcf-gbvsd\",\"test\",\"NET_ADMIN\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\",\"SCC Capability\"],\"ObjectFieldsValues\":[\"Non compliant capability detected in container\",\"tnf\",\"test-765d6b8dcf-s768n\",\"test\",\"NET_ADMIN\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\",\"SCC Capability\"],\"ObjectFieldsValues\":[\"Non compliant capability detected in container\",\"tnf\",\"xdp\",\"xdp-c\",\"NET_ADMIN\"]}]}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-net_admin",
@@ -9469,10 +9454,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-net-raw-capability-check": [
-        {
+        },
+      "access-control-net-raw-capability-check": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"test-0\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"test-1\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"test-765d6b8dcf-gbvsd\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"test-765d6b8dcf-s768n\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"xdp\",\"xdp-c\"]}],\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-user-plane-cnfs",
@@ -9498,10 +9481,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-no-1337-uid": [
-        {
+        },
+      "access-control-no-1337-uid": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is not using securityContext RunAsUser 1337\",\"tnf\",\"test-0\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is not using securityContext RunAsUser 1337\",\"tnf\",\"test-1\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is not using securityContext RunAsUser 1337\",\"tnf\",\"test-765d6b8dcf-gbvsd\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is not using securityContext RunAsUser 1337\",\"tnf\",\"test-765d6b8dcf-s768n\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is not using securityContext RunAsUser 1337\",\"tnf\",\"xdp\"]}],\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Extended",
@@ -9527,10 +9508,8 @@
             "suite": "access-control",
             "tags": "extended"
           }
-        }
-      ],
-      "access-control-one-process-per-container": [
-        {
+        },
+      "access-control-one-process-per-container": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container has only one process running\",\"tnf\",\"test-0\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container has only one process running\",\"tnf\",\"test-1\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container has only one process running\",\"tnf\",\"test-765d6b8dcf-gbvsd\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container has only one process running\",\"tnf\",\"test-765d6b8dcf-s768n\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container has only one process running\",\"tnf\",\"xdp\",\"xdp-c\"]}],\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-one-process-per-container",
@@ -9556,10 +9535,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-pod-automount-service-account-token": [
-        {
+        },
+      "access-control-pod-automount-service-account-token": {
           "capturedTestOutput": "Pod [xdp] has been found with default service account name.\n",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-automount-services-for-pods",
@@ -9585,10 +9562,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-pod-host-ipc": [
-        {
+        },
+      "access-control-pod-host-ipc": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"HostIpc is not set to true\",\"tnf\",\"test-0\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"HostIpc is not set to true\",\"tnf\",\"test-1\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"HostIpc is not set to true\",\"tnf\",\"test-765d6b8dcf-gbvsd\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"HostIpc is not set to true\",\"tnf\",\"test-765d6b8dcf-s768n\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"HostIpc is not set to true\",\"tnf\",\"xdp\"]}],\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-security",
@@ -9614,10 +9589,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-pod-host-network": [
-        {
+        },
+      "access-control-pod-host-network": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Host network is not set to true\",\"tnf\",\"test-0\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Host network is not set to true\",\"tnf\",\"test-1\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Host network is not set to true\",\"tnf\",\"test-765d6b8dcf-gbvsd\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Host network is not set to true\",\"tnf\",\"test-765d6b8dcf-s768n\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Host network is not set to true\",\"tnf\",\"xdp\"]}],\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-avoid-the-host-network-namespace",
@@ -9643,10 +9616,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-pod-host-path": [
-        {
+        },
+      "access-control-pod-host-path": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Hostpath path is not set\",\"tnf\",\"xdp\"]}],\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-security",
@@ -9672,10 +9643,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-pod-host-pid": [
-        {
+        },
+      "access-control-pod-host-pid": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"HostPid is not set to true\",\"tnf\",\"test-0\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"HostPid is not set to true\",\"tnf\",\"test-1\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"HostPid is not set to true\",\"tnf\",\"test-765d6b8dcf-gbvsd\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"HostPid is not set to true\",\"tnf\",\"test-765d6b8dcf-s768n\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"HostPid is not set to true\",\"tnf\",\"xdp\"]}],\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-security",
@@ -9701,10 +9670,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-pod-role-bindings": [
-        {
+        },
+      "access-control-pod-role-bindings": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"All the role bindings used by this pod (applied by the service accounts) live in the same namespace\",\"tnf\",\"test-0\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"All the role bindings used by this pod (applied by the service accounts) live in the same namespace\",\"tnf\",\"test-1\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"All the role bindings used by this pod (applied by the service accounts) live in the same namespace\",\"tnf\",\"test-765d6b8dcf-gbvsd\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"All the role bindings used by this pod (applied by the service accounts) live in the same namespace\",\"tnf\",\"test-765d6b8dcf-s768n\"]}],\"NonCompliantObjectsOut\":[{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"The serviceAccountName is either empty or default\",\"tnf\",\"xdp\"]}]}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-security-rbac",
@@ -9730,10 +9697,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-pod-service-account": [
-        {
+        },
+      "access-control-pod-service-account": {
           "capturedTestOutput": "Pod [xdp tnf] (ns: %!s(MISSING)) does not have a valid service account name.\n{\"CompliantObjectsOut\":[{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod has a service account name\",\"tnf\",\"test-0\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod has a service account name\",\"tnf\",\"test-1\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod has a service account name\",\"tnf\",\"test-765d6b8dcf-gbvsd\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod has a service account name\",\"tnf\",\"test-765d6b8dcf-s768n\"]}],\"NonCompliantObjectsOut\":[{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod does not have a valid service account name\",\"tnf\",\"xdp\"]}]}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-scc-permissions-for-an-application",
@@ -9759,10 +9724,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-projected-volume-service-account-token": [
-        {
+        },
+      "access-control-projected-volume-service-account-token": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"the pod is not using a projected volume for service account access\",\"tnf\",\"test-0\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"the pod is not using a projected volume for service account access\",\"tnf\",\"test-1\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"the pod is not using a projected volume for service account access\",\"tnf\",\"test-765d6b8dcf-gbvsd\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"the pod is not using a projected volume for service account access\",\"tnf\",\"test-765d6b8dcf-s768n\"]}],\"NonCompliantObjectsOut\":[{\"ObjectType\":\"ProjectedVolume\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\",\"Projected Volume Name\",\"Projected Volume SA Token\",\"Projected Volume SA Token\",\"Projected Volume SA Token\",\"Projected Volume SA Token\"],\"ObjectFieldsValues\":[\"the projected volume Service account token field is not nil\",\"tnf\",\"xdp\",\"kube-api-access-t8lpx\",\"\\u0026ServiceAccountTokenProjection{Audience:,ExpirationSeconds:*3607,Path:token,}\",\"nil\",\"nil\",\"nil\"]}]}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-automount-services-for-pods",
@@ -9788,10 +9751,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-requests-and-limits": [
-        {
+        },
+      "access-control-requests-and-limits": {
           "capturedTestOutput": "Container has been found missing resource limits: [container: xdp-c pod: xdp ns: tnf]\nContainer has been found missing resource requests: [container: xdp-c pod: xdp ns: tnf]\n{\"CompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container has resource requests and limits\",\"tnf\",\"test-0\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container has resource requests and limits\",\"tnf\",\"test-1\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container has resource requests and limits\",\"tnf\",\"test-765d6b8dcf-gbvsd\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container has resource requests and limits\",\"tnf\",\"test-765d6b8dcf-s768n\",\"test\"]}],\"NonCompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container is missing resource requests or limits\",\"tnf\",\"xdp\",\"xdp-c\"]}]}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-requests/limits",
@@ -9817,10 +9778,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-security-context": [
-        {
+        },
+      "access-control-security-context": {
           "capturedTestOutput": "containerSCC [container: test pod: test-0 ns: tnf {false false false false false true false true false true true true CategoryID1(limited access granted automatically) true true}] is %!v(MISSING)\nTesting if pod belongs to category [CategoryID1(limited access granted automatically)]\nAllVolumeAllowed = [true] - OK\nRunAsUserPresent = [true] - OK\nRunAsNonRoot = [true false] but expected  %!s(MISSING) - NOK\nFsGroupPresent  = [true] - OK\nDropCapabilities list - OK\n%!(EXTRA []interface {}=[])HostDirVolumePluginPresent = [false] - OK\nHostIPC = [false] - OK\nHostNetwork = [false] - OK\nHostPID = [false] - OK\nHostPorts = [false] - OK\nHostNetwork = [false] - OK\nPrivilegedContainer = [false] - OK\nReadOnlyRootFilesystem = [false] - OK\nSeLinuxContextPresent  is not nil - OK\n%!(EXTRA []interface {}=[])CapabilitiesCategory  list is as expected [CategoryID1(limited access granted automatically)] - OK\nTesting if pod belongs to category [CategoryID1NoUID0(automatically granted, basic rights with mesh networks)]\nAllVolumeAllowed = [true] - OK\nRunAsUserPresent = [true] - OK\nRunAsNonRoot = [true] - OK\nFsGroupPresent  = [true] - OK\nDropCapabilities list - OK\n%!(EXTRA []interface {}=[])HostDirVolumePluginPresent = [false] - OK\nHostIPC = [false] - OK\nHostNetwork = [false] - OK\nHostPID = [false] - OK\nHostPorts = [false] - OK\nHostNetwork = [false] - OK\nPrivilegedContainer = [false] - OK\nReadOnlyRootFilesystem = [false] - OK\nSeLinuxContextPresent  is not nil - OK\n%!(EXTRA []interface {}=[])CapabilitiesCategory  list is as expected [CategoryID1(limited access granted automatically)] - OK\nTesting if pod belongs to category1NoUID0 \n%!(EXTRA []interface {}=[])containerSCC [container: test pod: test-1 ns: tnf {false false false false false true false true false true true true CategoryID1(limited access granted automatically) true true}] is %!v(MISSING)\nTesting if pod belongs to category [CategoryID1(limited access granted automatically)]\nAllVolumeAllowed = [true] - OK\nRunAsUserPresent = [true] - OK\nRunAsNonRoot = [true false] but expected  %!s(MISSING) - NOK\nFsGroupPresent  = [true] - OK\nDropCapabilities list - OK\n%!(EXTRA []interface {}=[])HostDirVolumePluginPresent = [false] - OK\nHostIPC = [false] - OK\nHostNetwork = [false] - OK\nHostPID = [false] - OK\nHostPorts = [false] - OK\nHostNetwork = [false] - OK\nPrivilegedContainer = [false] - OK\nReadOnlyRootFilesystem = [false] - OK\nSeLinuxContextPresent  is not nil - OK\n%!(EXTRA []interface {}=[])CapabilitiesCategory  list is as expected [CategoryID1(limited access granted automatically)] - OK\nTesting if pod belongs to category [CategoryID1NoUID0(automatically granted, basic rights with mesh networks)]\nAllVolumeAllowed = [true] - OK\nRunAsUserPresent = [true] - OK\nRunAsNonRoot = [true] - OK\nFsGroupPresent  = [true] - OK\nDropCapabilities list - OK\n%!(EXTRA []interface {}=[])HostDirVolumePluginPresent = [false] - OK\nHostIPC = [false] - OK\nHostNetwork = [false] - OK\nHostPID = [false] - OK\nHostPorts = [false] - OK\nHostNetwork = [false] - OK\nPrivilegedContainer = [false] - OK\nReadOnlyRootFilesystem = [false] - OK\nSeLinuxContextPresent  is not nil - OK\n%!(EXTRA []interface {}=[])CapabilitiesCategory  list is as expected [CategoryID1(limited access granted automatically)] - OK\nTesting if pod belongs to category1NoUID0 \n%!(EXTRA []interface {}=[])containerSCC [container: test pod: test-765d6b8dcf-gbvsd ns: tnf {false false false false false false false false false false false true CategoryID2(advanced networking (vlan tag, dscp, priority)) false true}] is %!v(MISSING)\nTesting if pod belongs to category [CategoryID1(limited access granted automatically)]\nAllVolumeAllowed = [true] - OK\nRunAsUserPresent = [false true] but expected  %!s(MISSING) - NOK\nRunAsNonRoot = [false] - OK\nFsGroupPresent  = [false true] but expected  %!s(MISSING) - NOK\nRequiredDropCapabilitiesPresent = [false true] but expected  %!s(MISSING) - NOK\nits didnt have all the required (MKNOD, SETUID, SETGID, KILL)/(ALL) drop value \n%!(EXTRA []interface {}=[])HostDirVolumePluginPresent = [false] - OK\nHostIPC = [false] - OK\nHostNetwork = [false] - OK\nHostPID = [false] - OK\nHostPorts = [false] - OK\nHostNetwork = [false] - OK\nPrivilegedContainer = [false] - OK\nReadOnlyRootFilesystem = [false] - OK\nSeLinuxContextPresent  is not nil - OK\n%!(EXTRA []interface {}=[])CapabilitiesCategory = [CategoryID2(advanced networking (vlan tag, dscp, priority)) CategoryID1(limited access granted automatically)] but expected  %!s(MISSING) - NOK\nTesting if pod belongs to category [CategoryID1NoUID0(automatically granted, basic rights with mesh networks)]\nAllVolumeAllowed = [true] - OK\nRunAsUserPresent = [false true] but expected  %!s(MISSING) - NOK\nRunAsNonRoot = [false] - OK\nFsGroupPresent  = [false true] but expected  %!s(MISSING) - NOK\nRequiredDropCapabilitiesPresent = [false true] but expected  %!s(MISSING) - NOK\nits didnt have all the required (MKNOD, SETUID, SETGID, KILL)/(ALL) drop value \n%!(EXTRA []interface {}=[])HostDirVolumePluginPresent = [false] - OK\nHostIPC = [false] - OK\nHostNetwork = [false] - OK\nHostPID = [false] - OK\nHostPorts = [false] - OK\nHostNetwork = [false] - OK\nPrivilegedContainer = [false] - OK\nReadOnlyRootFilesystem = [false] - OK\nSeLinuxContextPresent  is not nil - OK\n%!(EXTRA []interface {}=[])CapabilitiesCategory = [CategoryID2(advanced networking (vlan tag, dscp, priority)) CategoryID1(limited access granted automatically)] but expected  %!s(MISSING) - NOK\nTesting if pod belongs to category [CategoryID2(advanced networking (vlan tag, dscp, priority))]\nAllVolumeAllowed = [true] - OK\nRunAsUserPresent = [false true] but expected  %!s(MISSING) - NOK\nRunAsNonRoot = [false] - OK\nFsGroupPresent  = [false true] but expected  %!s(MISSING) - NOK\nRequiredDropCapabilitiesPresent = [false true] but expected  %!s(MISSING) - NOK\nits didnt have all the required (MKNOD, SETUID, SETGID, KILL)/(ALL) drop value \n%!(EXTRA []interface {}=[])HostDirVolumePluginPresent = [false] - OK\nHostIPC = [false] - OK\nHostNetwork = [false] - OK\nHostPID = [false] - OK\nHostPorts = [false] - OK\nHostNetwork = [false] - OK\nPrivilegedContainer = [false] - OK\nReadOnlyRootFilesystem = [false] - OK\nSeLinuxContextPresent  is not nil - OK\n%!(EXTRA []interface {}=[])CapabilitiesCategory  list is as expected [CategoryID2(advanced networking (vlan tag, dscp, priority))] - OK\nTesting if pod belongs to category [CategoryID3(SRIOV and DPDK)]\nAllVolumeAllowed = [true] - OK\nRunAsUserPresent = [false true] but expected  %!s(MISSING) - NOK\nRunAsNonRoot = [false] - OK\nFsGroupPresent  = [false true] but expected  %!s(MISSING) - NOK\nRequiredDropCapabilitiesPresent = [false true] but expected  %!s(MISSING) - NOK\nits didnt have all the required (MKNOD, SETUID, SETGID, KILL)/(ALL) drop value \n%!(EXTRA []interface {}=[])HostDirVolumePluginPresent = [false] - OK\nHostIPC = [false] - OK\nHostNetwork = [false] - OK\nHostPID = [false] - OK\nHostPorts = [false] - OK\nHostNetwork = [false] - OK\nPrivilegedContainer = [false] - OK\nReadOnlyRootFilesystem = [false] - OK\nSeLinuxContextPresent  is not nil - OK\n%!(EXTRA []interface {}=[])CapabilitiesCategory = [CategoryID2(advanced networking (vlan tag, dscp, priority)) CategoryID3(SRIOV and DPDK)] but expected  %!s(MISSING) - NOK\ncontainerSCC [container: test pod: test-765d6b8dcf-s768n ns: tnf {false false false false false false false false false false false true CategoryID2(advanced networking (vlan tag, dscp, priority)) false true}] is %!v(MISSING)\nTesting if pod belongs to category [CategoryID1(limited access granted automatically)]\nAllVolumeAllowed = [true] - OK\nRunAsUserPresent = [false true] but expected  %!s(MISSING) - NOK\nRunAsNonRoot = [false] - OK\nFsGroupPresent  = [false true] but expected  %!s(MISSING) - NOK\nRequiredDropCapabilitiesPresent = [false true] but expected  %!s(MISSING) - NOK\nits didnt have all the required (MKNOD, SETUID, SETGID, KILL)/(ALL) drop value \n%!(EXTRA []interface {}=[])HostDirVolumePluginPresent = [false] - OK\nHostIPC = [false] - OK\nHostNetwork = [false] - OK\nHostPID = [false] - OK\nHostPorts = [false] - OK\nHostNetwork = [false] - OK\nPrivilegedContainer = [false] - OK\nReadOnlyRootFilesystem = [false] - OK\nSeLinuxContextPresent  is not nil - OK\n%!(EXTRA []interface {}=[])CapabilitiesCategory = [CategoryID2(advanced networking (vlan tag, dscp, priority)) CategoryID1(limited access granted automatically)] but expected  %!s(MISSING) - NOK\nTesting if pod belongs to category [CategoryID1NoUID0(automatically granted, basic rights with mesh networks)]\nAllVolumeAllowed = [true] - OK\nRunAsUserPresent = [false true] but expected  %!s(MISSING) - NOK\nRunAsNonRoot = [false] - OK\nFsGroupPresent  = [false true] but expected  %!s(MISSING) - NOK\nRequiredDropCapabilitiesPresent = [false true] but expected  %!s(MISSING) - NOK\nits didnt have all the required (MKNOD, SETUID, SETGID, KILL)/(ALL) drop value \n%!(EXTRA []interface {}=[])HostDirVolumePluginPresent = [false] - OK\nHostIPC = [false] - OK\nHostNetwork = [false] - OK\nHostPID = [false] - OK\nHostPorts = [false] - OK\nHostNetwork = [false] - OK\nPrivilegedContainer = [false] - OK\nReadOnlyRootFilesystem = [false] - OK\nSeLinuxContextPresent  is not nil - OK\n%!(EXTRA []interface {}=[])CapabilitiesCategory = [CategoryID2(advanced networking (vlan tag, dscp, priority)) CategoryID1(limited access granted automatically)] but expected  %!s(MISSING) - NOK\nTesting if pod belongs to category [CategoryID2(advanced networking (vlan tag, dscp, priority))]\nAllVolumeAllowed = [true] - OK\nRunAsUserPresent = [false true] but expected  %!s(MISSING) - NOK\nRunAsNonRoot = [false] - OK\nFsGroupPresent  = [false true] but expected  %!s(MISSING) - NOK\nRequiredDropCapabilitiesPresent = [false true] but expected  %!s(MISSING) - NOK\nits didnt have all the required (MKNOD, SETUID, SETGID, KILL)/(ALL) drop value \n%!(EXTRA []interface {}=[])HostDirVolumePluginPresent = [false] - OK\nHostIPC = [false] - OK\nHostNetwork = [false] - OK\nHostPID = [false] - OK\nHostPorts = [false] - OK\nHostNetwork = [false] - OK\nPrivilegedContainer = [false] - OK\nReadOnlyRootFilesystem = [false] - OK\nSeLinuxContextPresent  is not nil - OK\n%!(EXTRA []interface {}=[])CapabilitiesCategory  list is as expected [CategoryID2(advanced networking (vlan tag, dscp, priority))] - OK\nTesting if pod belongs to category [CategoryID3(SRIOV and DPDK)]\nAllVolumeAllowed = [true] - OK\nRunAsUserPresent = [false true] but expected  %!s(MISSING) - NOK\nRunAsNonRoot = [false] - OK\nFsGroupPresent  = [false true] but expected  %!s(MISSING) - NOK\nRequiredDropCapabilitiesPresent = [false true] but expected  %!s(MISSING) - NOK\nits didnt have all the required (MKNOD, SETUID, SETGID, KILL)/(ALL) drop value \n%!(EXTRA []interface {}=[])HostDirVolumePluginPresent = [false] - OK\nHostIPC = [false] - OK\nHostNetwork = [false] - OK\nHostPID = [false] - OK\nHostPorts = [false] - OK\nHostNetwork = [false] - OK\nPrivilegedContainer = [false] - OK\nReadOnlyRootFilesystem = [false] - OK\nSeLinuxContextPresent  is not nil - OK\n%!(EXTRA []interface {}=[])CapabilitiesCategory = [CategoryID2(advanced networking (vlan tag, dscp, priority)) CategoryID3(SRIOV and DPDK)] but expected  %!s(MISSING) - NOK\ncontainerSCC [container: xdp-c pod: xdp ns: tnf {false false false false false false false false false false false false CategoryID4(anything not matching lower category) false true}] is %!v(MISSING)\nTesting if pod belongs to category [CategoryID1(limited access granted automatically)]\nAllVolumeAllowed = [true] - OK\nRunAsUserPresent = [false true] but expected  %!s(MISSING) - NOK\nRunAsNonRoot = [false] - OK\nFsGroupPresent  = [false true] but expected  %!s(MISSING) - NOK\nRequiredDropCapabilitiesPresent = [false true] but expected  %!s(MISSING) - NOK\nits didnt have all the required (MKNOD, SETUID, SETGID, KILL)/(ALL) drop value \n%!(EXTRA []interface {}=[])HostDirVolumePluginPresent = [false] - OK\nHostIPC = [false] - OK\nHostNetwork = [false] - OK\nHostPID = [false] - OK\nHostPorts = [false] - OK\nHostNetwork = [false] - OK\nPrivilegedContainer = [false] - OK\nReadOnlyRootFilesystem = [false] - OK\nSeLinuxContextPresent  = [false true] but expected  %!s(MISSING) expected to be non nil - NOK\nCapabilitiesCategory = [CategoryID4(anything not matching lower category) CategoryID1(limited access granted automatically)] but expected  %!s(MISSING) - NOK\nTesting if pod belongs to category [CategoryID1NoUID0(automatically granted, basic rights with mesh networks)]\nAllVolumeAllowed = [true] - OK\nRunAsUserPresent = [false true] but expected  %!s(MISSING) - NOK\nRunAsNonRoot = [false] - OK\nFsGroupPresent  = [false true] but expected  %!s(MISSING) - NOK\nRequiredDropCapabilitiesPresent = [false true] but expected  %!s(MISSING) - NOK\nits didnt have all the required (MKNOD, SETUID, SETGID, KILL)/(ALL) drop value \n%!(EXTRA []interface {}=[])HostDirVolumePluginPresent = [false] - OK\nHostIPC = [false] - OK\nHostNetwork = [false] - OK\nHostPID = [false] - OK\nHostPorts = [false] - OK\nHostNetwork = [false] - OK\nPrivilegedContainer = [false] - OK\nReadOnlyRootFilesystem = [false] - OK\nSeLinuxContextPresent  = [false true] but expected  %!s(MISSING) expected to be non nil - NOK\nCapabilitiesCategory = [CategoryID4(anything not matching lower category) CategoryID1(limited access granted automatically)] but expected  %!s(MISSING) - NOK\nTesting if pod belongs to category [CategoryID2(advanced networking (vlan tag, dscp, priority))]\nAllVolumeAllowed = [true] - OK\nRunAsUserPresent = [false true] but expected  %!s(MISSING) - NOK\nRunAsNonRoot = [false] - OK\nFsGroupPresent  = [false true] but expected  %!s(MISSING) - NOK\nRequiredDropCapabilitiesPresent = [false true] but expected  %!s(MISSING) - NOK\nits didnt have all the required (MKNOD, SETUID, SETGID, KILL)/(ALL) drop value \n%!(EXTRA []interface {}=[])HostDirVolumePluginPresent = [false] - OK\nHostIPC = [false] - OK\nHostNetwork = [false] - OK\nHostPID = [false] - OK\nHostPorts = [false] - OK\nHostNetwork = [false] - OK\nPrivilegedContainer = [false] - OK\nReadOnlyRootFilesystem = [false] - OK\nSeLinuxContextPresent  = [false true] but expected  %!s(MISSING) expected to be non nil - NOK\nCapabilitiesCategory = [CategoryID4(anything not matching lower category) CategoryID2(advanced networking (vlan tag, dscp, priority))] but expected  %!s(MISSING) - NOK\nTesting if pod belongs to category [CategoryID3(SRIOV and DPDK)]\nAllVolumeAllowed = [true] - OK\nRunAsUserPresent = [false true] but expected  %!s(MISSING) - NOK\nRunAsNonRoot = [false] - OK\nFsGroupPresent  = [false true] but expected  %!s(MISSING) - NOK\nRequiredDropCapabilitiesPresent = [false true] but expected  %!s(MISSING) - NOK\nits didnt have all the required (MKNOD, SETUID, SETGID, KILL)/(ALL) drop value \n%!(EXTRA []interface {}=[])HostDirVolumePluginPresent = [false] - OK\nHostIPC = [false] - OK\nHostNetwork = [false] - OK\nHostPID = [false] - OK\nHostPorts = [false] - OK\nHostNetwork = [false] - OK\nPrivilegedContainer = [false] - OK\nReadOnlyRootFilesystem = [false] - OK\nSeLinuxContextPresent  = [false true] but expected  %!s(MISSING) expected to be non nil - NOK\nCapabilitiesCategory = [CategoryID4(anything not matching lower category) CategoryID3(SRIOV and DPDK)] but expected  %!s(MISSING) - NOK\n{\"CompliantObjectsOut\":[{\"ObjectType\":\"ContainerCategory\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\",\"Category\"],\"ObjectFieldsValues\":[\"container category is category 1 or category NoUID0\",\"tnf\",\"test-0\",\"test\",\"CategoryID1NoUID0(automatically granted, basic rights with mesh networks)\"]},{\"ObjectType\":\"ContainerCategory\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\",\"Category\"],\"ObjectFieldsValues\":[\"container category is category 1 or category NoUID0\",\"tnf\",\"test-1\",\"test\",\"CategoryID1NoUID0(automatically granted, basic rights with mesh networks)\"]},{\"ObjectType\":\"Cnf\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Category\"],\"ObjectFieldsValues\":[\"Overall CNF category\",\"CategoryID4(anything not matching lower category)\"]}],\"NonCompliantObjectsOut\":[{\"ObjectType\":\"ContainerCategory\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\",\"Category\"],\"ObjectFieldsValues\":[\"container category is NOT category 1 or category NoUID0\",\"tnf\",\"test-765d6b8dcf-gbvsd\",\"test\",\"CategoryID4(anything not matching lower category)\"]},{\"ObjectType\":\"ContainerCategory\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\",\"Category\"],\"ObjectFieldsValues\":[\"container category is NOT category 1 or category NoUID0\",\"tnf\",\"test-765d6b8dcf-s768n\",\"test\",\"CategoryID4(anything not matching lower category)\"]},{\"ObjectType\":\"ContainerCategory\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\",\"Category\"],\"ObjectFieldsValues\":[\"container category is NOT category 1 or category NoUID0\",\"tnf\",\"xdp\",\"xdp-c\",\"CategoryID4(anything not matching lower category)\"]}]}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-security",
@@ -9846,10 +9805,8 @@
             "suite": "access-control",
             "tags": "extended"
           }
-        }
-      ],
-      "access-control-security-context-non-root-user-check": [
-        {
+        },
+      "access-control-security-context-non-root-user-check": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Root User not detected (RunAsUser uid=0)\",\"tnf\",\"test-0\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Root User not detected (RunAsUser uid=0)\",\"tnf\",\"test-0\",\"test\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Root User not detected (RunAsUser uid=0)\",\"tnf\",\"test-1\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Root User not detected (RunAsUser uid=0)\",\"tnf\",\"test-1\",\"test\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Root User not detected (RunAsUser uid=0)\",\"tnf\",\"test-765d6b8dcf-gbvsd\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Root User not detected (RunAsUser uid=0)\",\"tnf\",\"test-765d6b8dcf-s768n\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Root User not detected (RunAsUser uid=0)\",\"tnf\",\"xdp\"]}],\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-security",
@@ -9875,10 +9832,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-security-context-privilege-escalation": [
-        {
+        },
+      "access-control-security-context-privilege-escalation": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"AllowPrivilegeEscalation is set to false\",\"tnf\",\"test-0\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"AllowPrivilegeEscalation is set to false\",\"tnf\",\"test-1\",\"test\"]}],\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-security",
@@ -9904,10 +9859,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-service-type": [
-        {
+        },
+      "access-control-service-type": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":null,\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-avoid-the-host-network-namespace",
@@ -9933,10 +9886,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-ssh-daemons": [
-        {
+        },
+      "access-control-ssh-daemons": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is not running an SSH daemon\",\"tnf\",\"test-0\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is not running an SSH daemon\",\"tnf\",\"test-1\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is not running an SSH daemon\",\"tnf\",\"test-765d6b8dcf-gbvsd\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is not running an SSH daemon\",\"tnf\",\"test-765d6b8dcf-s768n\"]},{\"ObjectType\":\"Pod\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\"],\"ObjectFieldsValues\":[\"Pod is not running an SSH daemon\",\"tnf\",\"xdp\"]}],\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-pod-interaction/configuration",
@@ -9962,10 +9913,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-sys-admin-capability-check": [
-        {
+        },
+      "access-control-sys-admin-capability-check": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"test-0\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"test-1\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"test-765d6b8dcf-gbvsd\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"test-765d6b8dcf-s768n\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"No forbidden capabilities detected in container\",\"tnf\",\"xdp\",\"xdp-c\"]}],\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-avoid-sys_admin",
@@ -9991,10 +9940,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-sys-nice-realtime-capability": [
-        {
+        },
+      "access-control-sys-nice-realtime-capability": {
           "capturedTestOutput": "[container: test pod: test-0 ns: tnf] has been found running on a realtime kernel enabled node without SYS_NICE capability.\n[container: test pod: test-1 ns: tnf] has been found running on a realtime kernel enabled node without SYS_NICE capability.\n[container: test pod: test-765d6b8dcf-gbvsd ns: tnf] has been found running on a realtime kernel enabled node without SYS_NICE capability.\n[container: test pod: test-765d6b8dcf-s768n ns: tnf] has been found running on a realtime kernel enabled node without SYS_NICE capability.\n[container: xdp-c pod: xdp ns: tnf] has been found running on a realtime kernel enabled node without SYS_NICE capability.\n{\"CompliantObjectsOut\":null,\"NonCompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container is running on a realtime kernel enabled node without SYS_NICE capability\",\"tnf\",\"test-0\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container is running on a realtime kernel enabled node without SYS_NICE capability\",\"tnf\",\"test-1\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container is running on a realtime kernel enabled node without SYS_NICE capability\",\"tnf\",\"test-765d6b8dcf-gbvsd\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container is running on a realtime kernel enabled node without SYS_NICE capability\",\"tnf\",\"test-765d6b8dcf-s768n\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container is running on a realtime kernel enabled node without SYS_NICE capability\",\"tnf\",\"xdp\",\"xdp-c\"]}]}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-sys_nice",
@@ -10020,10 +9967,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-sys-ptrace-capability": [
-        {
+        },
+      "access-control-sys-ptrace-capability": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-sys_ptrace",
@@ -10049,10 +9994,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "affiliated-certification-container-is-certified": [
-        {
+        },
+      "affiliated-certification-container-is-certified": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://redhat-connect.gitbook.io/partner-guide-for-red-hat-openshift-and-container/certify-your-application/overview",
@@ -10078,10 +10021,8 @@
             "suite": "affiliated-certification",
             "tags": "common"
           }
-        }
-      ],
-      "affiliated-certification-container-is-certified-digest": [
-        {
+        },
+      "affiliated-certification-container-is-certified-digest": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://redhat-connect.gitbook.io/partner-guide-for-red-hat-openshift-and-container/certify-your-application/overview",
@@ -10107,10 +10048,8 @@
             "suite": "affiliated-certification",
             "tags": "common"
           }
-        }
-      ],
-      "affiliated-certification-helm-version": [
-        {
+        },
+      "affiliated-certification-helm-version": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-helm",
@@ -10136,10 +10075,8 @@
             "suite": "affiliated-certification",
             "tags": "common"
           }
-        }
-      ],
-      "affiliated-certification-helmchart-is-certified": [
-        {
+        },
+      "affiliated-certification-helmchart-is-certified": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://redhat-connect.gitbook.io/partner-guide-for-red-hat-openshift-and-container/certify-your-application/overview",
@@ -10165,10 +10102,8 @@
             "suite": "affiliated-certification",
             "tags": "common"
           }
-        }
-      ],
-      "affiliated-certification-operator-is-certified": [
-        {
+        },
+      "affiliated-certification-operator-is-certified": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-operator-requirements",
@@ -10194,10 +10129,8 @@
             "suite": "affiliated-certification",
             "tags": "common"
           }
-        }
-      ],
-      "lifecycle-affinity-required-pods": [
-        {
+        },
+      "lifecycle-affinity-required-pods": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10223,10 +10156,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-container-shutdown": [
-        {
+        },
+      "lifecycle-container-shutdown": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cloud-native-design-best-practices",
@@ -10252,10 +10183,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-container-startup": [
-        {
+        },
+      "lifecycle-container-startup": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cloud-native-design-best-practices",
@@ -10281,10 +10210,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-cpu-isolation": [
-        {
+        },
+      "lifecycle-cpu-isolation": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cpu-isolation",
@@ -10310,10 +10237,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-crd-scaling": [
-        {
+        },
+      "lifecycle-crd-scaling": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10339,10 +10264,8 @@
             "suite": "lifecycle",
             "tags": "common"
           }
-        }
-      ],
-      "lifecycle-deployment-scaling": [
-        {
+        },
+      "lifecycle-deployment-scaling": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10368,10 +10291,8 @@
             "suite": "lifecycle",
             "tags": "common"
           }
-        }
-      ],
-      "lifecycle-image-pull-policy": [
-        {
+        },
+      "lifecycle-image-pull-policy": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-use-imagepullpolicy-if-not-present",
@@ -10397,10 +10318,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-liveness-probe": [
-        {
+        },
+      "lifecycle-liveness-probe": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10426,10 +10345,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-persistent-volume-reclaim-policy": [
-        {
+        },
+      "lifecycle-persistent-volume-reclaim-policy": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-csi",
@@ -10455,10 +10372,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-pod-high-availability": [
-        {
+        },
+      "lifecycle-pod-high-availability": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10484,10 +10399,8 @@
             "suite": "lifecycle",
             "tags": "common"
           }
-        }
-      ],
-      "lifecycle-pod-owner-type": [
-        {
+        },
+      "lifecycle-pod-owner-type": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-no-naked-pods",
@@ -10513,10 +10426,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-pod-recreation": [
-        {
+        },
+      "lifecycle-pod-recreation": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-upgrade-expectations",
@@ -10542,10 +10453,8 @@
             "suite": "lifecycle",
             "tags": "common"
           }
-        }
-      ],
-      "lifecycle-pod-scheduling": [
-        {
+        },
+      "lifecycle-pod-scheduling": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10571,10 +10480,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-pod-toleration-bypass": [
-        {
+        },
+      "lifecycle-pod-toleration-bypass": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-taints-and-tolerations",
@@ -10600,10 +10507,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-readiness-probe": [
-        {
+        },
+      "lifecycle-readiness-probe": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10629,10 +10534,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-startup-probe": [
-        {
+        },
+      "lifecycle-startup-probe": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-pod-exit-status",
@@ -10658,10 +10561,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-statefulset-scaling": [
-        {
+        },
+      "lifecycle-statefulset-scaling": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10687,10 +10588,8 @@
             "suite": "lifecycle",
             "tags": "common"
           }
-        }
-      ],
-      "lifecycle-storage-required-pods": [
-        {
+        },
+      "lifecycle-storage-required-pods": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-local-storage",
@@ -10716,10 +10615,8 @@
             "suite": "lifecycle",
             "tags": "common"
           }
-        }
-      ],
-      "manageability-container-port-name-format": [
-        {
+        },
+      "manageability-container-port-name-format": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-requirements-cnf-reqs",
@@ -10745,10 +10642,8 @@
             "suite": "manageability",
             "tags": "extended"
           }
-        }
-      ],
-      "manageability-containers-image-tag": [
-        {
+        },
+      "manageability-containers-image-tag": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-image-tagging",
@@ -10774,10 +10669,8 @@
             "suite": "manageability",
             "tags": "extended"
           }
-        }
-      ],
-      "networking-dpdk-cpu-pinning-exec-probe": [
-        {
+        },
+      "networking-dpdk-cpu-pinning-exec-probe": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cpu-manager-pinning",
@@ -10803,10 +10696,8 @@
             "suite": "networking",
             "tags": "telco"
           }
-        }
-      ],
-      "networking-dual-stack-service": [
-        {
+        },
+      "networking-dual-stack-service": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-ipv4-\u0026-ipv6",
@@ -10832,10 +10723,8 @@
             "suite": "networking",
             "tags": "extended"
           }
-        }
-      ],
-      "networking-icmpv4-connectivity": [
-        {
+        },
+      "networking-icmpv4-connectivity": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-ipv4-\u0026-ipv6",
@@ -10861,10 +10750,8 @@
             "suite": "networking",
             "tags": "common"
           }
-        }
-      ],
-      "networking-icmpv4-connectivity-multus": [
-        {
+        },
+      "networking-icmpv4-connectivity-multus": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10890,10 +10777,8 @@
             "suite": "networking",
             "tags": "telco"
           }
-        }
-      ],
-      "networking-icmpv6-connectivity": [
-        {
+        },
+      "networking-icmpv6-connectivity": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-ipv4-\u0026-ipv6",
@@ -10919,10 +10804,8 @@
             "suite": "networking",
             "tags": "common"
           }
-        }
-      ],
-      "networking-icmpv6-connectivity-multus": [
-        {
+        },
+      "networking-icmpv6-connectivity-multus": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10948,10 +10831,8 @@
             "suite": "networking",
             "tags": "telco"
           }
-        }
-      ],
-      "networking-network-policy-deny-all": [
-        {
+        },
+      "networking-network-policy-deny-all": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-vrfs-aka-routing-instances",
@@ -10977,10 +10858,8 @@
             "suite": "networking",
             "tags": "common"
           }
-        }
-      ],
-      "networking-ocp-reserved-ports-usage": [
-        {
+        },
+      "networking-ocp-reserved-ports-usage": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-ports-reserved-by-openshift",
@@ -11006,10 +10885,8 @@
             "suite": "networking",
             "tags": "common"
           }
-        }
-      ],
-      "networking-reserved-partner-ports": [
-        {
+        },
+      "networking-reserved-partner-ports": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Extended",
@@ -11035,10 +10912,8 @@
             "suite": "networking",
             "tags": "extended"
           }
-        }
-      ],
-      "networking-restart-on-reboot-sriov-pod": [
-        {
+        },
+      "networking-restart-on-reboot-sriov-pod": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Far Edge",
@@ -11064,10 +10939,8 @@
             "suite": "networking",
             "tags": "faredge"
           }
-        }
-      ],
-      "networking-undeclared-container-ports-usage": [
-        {
+        },
+      "networking-undeclared-container-ports-usage": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-requirements-cnf-reqs",
@@ -11093,10 +10966,8 @@
             "suite": "networking",
             "tags": "extended"
           }
-        }
-      ],
-      "observability-container-logging": [
-        {
+        },
+      "observability-container-logging": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-logging",
@@ -11122,10 +10993,8 @@
             "suite": "observability",
             "tags": "telco"
           }
-        }
-      ],
-      "observability-crd-status": [
-        {
+        },
+      "observability-crd-status": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-operator-requirements",
@@ -11151,10 +11020,8 @@
             "suite": "observability",
             "tags": "common"
           }
-        }
-      ],
-      "observability-pod-disruption-budget": [
-        {
+        },
+      "observability-pod-disruption-budget": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-upgrade-expectations",
@@ -11180,10 +11047,8 @@
             "suite": "observability",
             "tags": "common"
           }
-        }
-      ],
-      "observability-termination-policy": [
-        {
+        },
+      "observability-termination-policy": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-pod-exit-status",
@@ -11209,10 +11074,8 @@
             "suite": "observability",
             "tags": "telco"
           }
-        }
-      ],
-      "operator-install-source": [
-        {
+        },
+      "operator-install-source": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-operator-requirements",
@@ -11238,10 +11101,8 @@
             "suite": "operator",
             "tags": "common"
           }
-        }
-      ],
-      "operator-install-status-no-privileges": [
-        {
+        },
+      "operator-install-status-no-privileges": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-operator-requirements",
@@ -11267,10 +11128,8 @@
             "suite": "operator",
             "tags": "common"
           }
-        }
-      ],
-      "operator-install-status-succeeded": [
-        {
+        },
+      "operator-install-status-succeeded": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-operator-requirements",
@@ -11296,10 +11155,8 @@
             "suite": "operator",
             "tags": "common"
           }
-        }
-      ],
-      "performance-exclusive-cpu-pool": [
-        {
+        },
+      "performance-exclusive-cpu-pool": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Far Edge",
@@ -11325,10 +11182,8 @@
             "suite": "performance",
             "tags": "faredge"
           }
-        }
-      ],
-      "performance-exclusive-cpu-pool-rt-scheduling-policy": [
-        {
+        },
+      "performance-exclusive-cpu-pool-rt-scheduling-policy": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Far Edge",
@@ -11354,10 +11209,8 @@
             "suite": "performance",
             "tags": "faredge"
           }
-        }
-      ],
-      "performance-isolated-cpu-pool-rt-scheduling-policy": [
-        {
+        },
+      "performance-isolated-cpu-pool-rt-scheduling-policy": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Far Edge",
@@ -11383,10 +11236,8 @@
             "suite": "performance",
             "tags": "faredge"
           }
-        }
-      ],
-      "performance-max-resources-exec-probes": [
-        {
+        },
+      "performance-max-resources-exec-probes": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Far Edge",
@@ -11412,10 +11263,8 @@
             "suite": "performance",
             "tags": "faredge"
           }
-        }
-      ],
-      "performance-rt-apps-no-exec-probes": [
-        {
+        },
+      "performance-rt-apps-no-exec-probes": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Far Edge",
@@ -11441,10 +11290,8 @@
             "suite": "performance",
             "tags": "faredge"
           }
-        }
-      ],
-      "performance-shared-cpu-pool-non-rt-scheduling-policy": [
-        {
+        },
+      "performance-shared-cpu-pool-non-rt-scheduling-policy": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Far Edge",
@@ -11470,10 +11317,8 @@
             "suite": "performance",
             "tags": "faredge"
           }
-        }
-      ],
-      "platform-alteration-base-image": [
-        {
+        },
+      "platform-alteration-base-image": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-image-standards",
@@ -11499,10 +11344,8 @@
             "suite": "platform-alteration",
             "tags": "common"
           }
-        }
-      ],
-      "platform-alteration-boot-params": [
-        {
+        },
+      "platform-alteration-boot-params": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-host-os",
@@ -11528,10 +11371,8 @@
             "suite": "platform-alteration",
             "tags": "common"
           }
-        }
-      ],
-      "platform-alteration-hugepages-1g-only": [
-        {
+        },
+      "platform-alteration-hugepages-1g-only": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Far Edge",
@@ -11557,10 +11398,8 @@
             "suite": "platform-alteration",
             "tags": "faredge"
           }
-        }
-      ],
-      "platform-alteration-hugepages-2m-only": [
-        {
+        },
+      "platform-alteration-hugepages-2m-only": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-huge-pages",
@@ -11586,10 +11425,8 @@
             "suite": "platform-alteration",
             "tags": "extended"
           }
-        }
-      ],
-      "platform-alteration-hugepages-config": [
-        {
+        },
+      "platform-alteration-hugepages-config": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-huge-pages",
@@ -11615,10 +11452,8 @@
             "suite": "platform-alteration",
             "tags": "common"
           }
-        }
-      ],
-      "platform-alteration-hyperthread-enable": [
-        {
+        },
+      "platform-alteration-hyperthread-enable": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Extended",
@@ -11644,10 +11479,8 @@
             "suite": "platform-alteration",
             "tags": "extended"
           }
-        }
-      ],
-      "platform-alteration-is-selinux-enforcing": [
-        {
+        },
+      "platform-alteration-is-selinux-enforcing": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-pod-security",
@@ -11673,10 +11506,8 @@
             "suite": "platform-alteration",
             "tags": "common"
           }
-        }
-      ],
-      "platform-alteration-isredhat-release": [
-        {
+        },
+      "platform-alteration-isredhat-release": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-base-images",
@@ -11702,10 +11533,8 @@
             "suite": "platform-alteration",
             "tags": "common"
           }
-        }
-      ],
-      "platform-alteration-ocp-lifecycle": [
-        {
+        },
+      "platform-alteration-ocp-lifecycle": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-k8s",
@@ -11731,10 +11560,8 @@
             "suite": "platform-alteration",
             "tags": "common"
           }
-        }
-      ],
-      "platform-alteration-ocp-node-os-lifecycle": [
-        {
+        },
+      "platform-alteration-ocp-node-os-lifecycle": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-host-os",
@@ -11760,10 +11587,8 @@
             "suite": "platform-alteration",
             "tags": "common"
           }
-        }
-      ],
-      "platform-alteration-service-mesh-usage": [
-        {
+        },
+      "platform-alteration-service-mesh-usage": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Extended",
@@ -11789,10 +11614,8 @@
             "suite": "platform-alteration",
             "tags": "extended"
           }
-        }
-      ],
-      "platform-alteration-sysctl-config": [
-        {
+        },
+      "platform-alteration-sysctl-config": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-security",
@@ -11818,10 +11641,8 @@
             "suite": "platform-alteration",
             "tags": "common"
           }
-        }
-      ],
-      "platform-alteration-tainted-node-kernel": [
-        {
+        },
+      "platform-alteration-tainted-node-kernel": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -11848,7 +11669,6 @@
             "tags": "common"
           }
         }
-      ]
     },
     "versions": {
       "claimFormat": "v0.1.0",

--- a/cmd/tnf/claim/compare/testdata/claim_observability.json
+++ b/cmd/tnf/claim/compare/testdata/claim_observability.json
@@ -9265,8 +9265,7 @@
       "testsExtraInfo": ""
     },
     "results": {
-      "access-control-bpf-capability-check": [
-        {
+      "access-control-bpf-capability-check": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Telco",
@@ -9292,10 +9291,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-cluster-role-bindings": [
-        {
+        },
+      "access-control-cluster-role-bindings": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-security-rbac",
@@ -9321,10 +9318,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-container-host-port": [
-        {
+        },
+      "access-control-container-host-port": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-avoid-accessing-resource-on-host",
@@ -9350,10 +9345,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-crd-roles": [
-        {
+        },
+      "access-control-crd-roles": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-custom-role-to-access-application-crds",
@@ -9379,10 +9372,8 @@
             "suite": "access-control",
             "tags": "extended"
           }
-        }
-      ],
-      "access-control-ipc-lock-capability-check": [
-        {
+        },
+      "access-control-ipc-lock-capability-check": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-ipc_lock",
@@ -9408,10 +9399,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-namespace": [
-        {
+        },
+      "access-control-namespace": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-requirements-cnf-reqs",
@@ -9437,10 +9426,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-namespace-resource-quota": [
-        {
+        },
+      "access-control-namespace-resource-quota": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-memory-allocation",
@@ -9466,10 +9453,8 @@
             "suite": "access-control",
             "tags": "extended"
           }
-        }
-      ],
-      "access-control-net-admin-capability-check": [
-        {
+        },
+      "access-control-net-admin-capability-check": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-net_admin",
@@ -9495,10 +9480,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-net-raw-capability-check": [
-        {
+        },
+      "access-control-net-raw-capability-check": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-user-plane-cnfs",
@@ -9524,10 +9507,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-no-1337-uid": [
-        {
+        },
+      "access-control-no-1337-uid": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Extended",
@@ -9553,10 +9534,8 @@
             "suite": "access-control",
             "tags": "extended"
           }
-        }
-      ],
-      "access-control-one-process-per-container": [
-        {
+        },
+      "access-control-one-process-per-container": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-one-process-per-container",
@@ -9582,10 +9561,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-pod-automount-service-account-token": [
-        {
+        },
+      "access-control-pod-automount-service-account-token": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-automount-services-for-pods",
@@ -9611,10 +9588,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-pod-host-ipc": [
-        {
+        },
+      "access-control-pod-host-ipc": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-security",
@@ -9640,10 +9615,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-pod-host-network": [
-        {
+        },
+      "access-control-pod-host-network": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-avoid-the-host-network-namespace",
@@ -9669,10 +9642,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-pod-host-path": [
-        {
+        },
+      "access-control-pod-host-path": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-security",
@@ -9698,10 +9669,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-pod-host-pid": [
-        {
+        },
+      "access-control-pod-host-pid": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-security",
@@ -9727,10 +9696,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-pod-role-bindings": [
-        {
+        },
+      "access-control-pod-role-bindings": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-security-rbac",
@@ -9756,10 +9723,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-pod-service-account": [
-        {
+        },
+      "access-control-pod-service-account": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-scc-permissions-for-an-application",
@@ -9785,10 +9750,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-projected-volume-service-account-token": [
-        {
+        },
+      "access-control-projected-volume-service-account-token": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-automount-services-for-pods",
@@ -9814,10 +9777,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-requests-and-limits": [
-        {
+        },
+      "access-control-requests-and-limits": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-requests/limits",
@@ -9843,10 +9804,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-security-context": [
-        {
+        },
+      "access-control-security-context": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-security",
@@ -9872,10 +9831,8 @@
             "suite": "access-control",
             "tags": "extended"
           }
-        }
-      ],
-      "access-control-security-context-non-root-user-check": [
-        {
+        },
+      "access-control-security-context-non-root-user-check": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-security",
@@ -9901,10 +9858,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-security-context-privilege-escalation": [
-        {
+        },
+      "access-control-security-context-privilege-escalation": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-security",
@@ -9930,10 +9885,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-service-type": [
-        {
+        },
+      "access-control-service-type": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-avoid-the-host-network-namespace",
@@ -9959,10 +9912,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-ssh-daemons": [
-        {
+        },
+      "access-control-ssh-daemons": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-pod-interaction/configuration",
@@ -9988,10 +9939,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-sys-admin-capability-check": [
-        {
+        },
+      "access-control-sys-admin-capability-check": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-avoid-sys_admin",
@@ -10017,10 +9966,8 @@
             "suite": "access-control",
             "tags": "common"
           }
-        }
-      ],
-      "access-control-sys-nice-realtime-capability": [
-        {
+        },
+      "access-control-sys-nice-realtime-capability": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-sys_nice",
@@ -10046,10 +9993,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "access-control-sys-ptrace-capability": [
-        {
+        },
+      "access-control-sys-ptrace-capability": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-sys_ptrace",
@@ -10075,10 +10020,8 @@
             "suite": "access-control",
             "tags": "telco"
           }
-        }
-      ],
-      "affiliated-certification-container-is-certified": [
-        {
+        },
+      "affiliated-certification-container-is-certified": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://redhat-connect.gitbook.io/partner-guide-for-red-hat-openshift-and-container/certify-your-application/overview",
@@ -10104,10 +10047,8 @@
             "suite": "affiliated-certification",
             "tags": "common"
           }
-        }
-      ],
-      "affiliated-certification-container-is-certified-digest": [
-        {
+        },
+      "affiliated-certification-container-is-certified-digest": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://redhat-connect.gitbook.io/partner-guide-for-red-hat-openshift-and-container/certify-your-application/overview",
@@ -10133,10 +10074,8 @@
             "suite": "affiliated-certification",
             "tags": "common"
           }
-        }
-      ],
-      "affiliated-certification-helm-version": [
-        {
+        },
+      "affiliated-certification-helm-version": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-helm",
@@ -10162,10 +10101,8 @@
             "suite": "affiliated-certification",
             "tags": "common"
           }
-        }
-      ],
-      "affiliated-certification-helmchart-is-certified": [
-        {
+        },
+      "affiliated-certification-helmchart-is-certified": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://redhat-connect.gitbook.io/partner-guide-for-red-hat-openshift-and-container/certify-your-application/overview",
@@ -10191,10 +10128,8 @@
             "suite": "affiliated-certification",
             "tags": "common"
           }
-        }
-      ],
-      "affiliated-certification-operator-is-certified": [
-        {
+        },
+      "affiliated-certification-operator-is-certified": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-operator-requirements",
@@ -10220,10 +10155,8 @@
             "suite": "affiliated-certification",
             "tags": "common"
           }
-        }
-      ],
-      "lifecycle-affinity-required-pods": [
-        {
+        },
+      "lifecycle-affinity-required-pods": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10249,10 +10182,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-container-shutdown": [
-        {
+        },
+      "lifecycle-container-shutdown": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cloud-native-design-best-practices",
@@ -10278,10 +10209,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-container-startup": [
-        {
+        },
+      "lifecycle-container-startup": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cloud-native-design-best-practices",
@@ -10307,10 +10236,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-cpu-isolation": [
-        {
+        },
+      "lifecycle-cpu-isolation": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cpu-isolation",
@@ -10336,10 +10263,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-crd-scaling": [
-        {
+        },
+      "lifecycle-crd-scaling": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10365,10 +10290,8 @@
             "suite": "lifecycle",
             "tags": "common"
           }
-        }
-      ],
-      "lifecycle-deployment-scaling": [
-        {
+        },
+      "lifecycle-deployment-scaling": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10394,10 +10317,8 @@
             "suite": "lifecycle",
             "tags": "common"
           }
-        }
-      ],
-      "lifecycle-image-pull-policy": [
-        {
+        },
+      "lifecycle-image-pull-policy": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-use-imagepullpolicy-if-not-present",
@@ -10423,10 +10344,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-liveness-probe": [
-        {
+        },
+      "lifecycle-liveness-probe": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10452,10 +10371,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-persistent-volume-reclaim-policy": [
-        {
+        },
+      "lifecycle-persistent-volume-reclaim-policy": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-csi",
@@ -10481,10 +10398,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-pod-high-availability": [
-        {
+        },
+      "lifecycle-pod-high-availability": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10510,10 +10425,8 @@
             "suite": "lifecycle",
             "tags": "common"
           }
-        }
-      ],
-      "lifecycle-pod-owner-type": [
-        {
+        },
+      "lifecycle-pod-owner-type": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-no-naked-pods",
@@ -10539,10 +10452,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-pod-recreation": [
-        {
+        },
+      "lifecycle-pod-recreation": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-upgrade-expectations",
@@ -10568,10 +10479,8 @@
             "suite": "lifecycle",
             "tags": "common"
           }
-        }
-      ],
-      "lifecycle-pod-scheduling": [
-        {
+        },
+      "lifecycle-pod-scheduling": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10597,10 +10506,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-pod-toleration-bypass": [
-        {
+        },
+      "lifecycle-pod-toleration-bypass": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-taints-and-tolerations",
@@ -10626,10 +10533,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-readiness-probe": [
-        {
+        },
+      "lifecycle-readiness-probe": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10655,10 +10560,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-startup-probe": [
-        {
+        },
+      "lifecycle-startup-probe": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-pod-exit-status",
@@ -10684,10 +10587,8 @@
             "suite": "lifecycle",
             "tags": "telco"
           }
-        }
-      ],
-      "lifecycle-statefulset-scaling": [
-        {
+        },
+      "lifecycle-statefulset-scaling": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10713,10 +10614,8 @@
             "suite": "lifecycle",
             "tags": "common"
           }
-        }
-      ],
-      "lifecycle-storage-required-pods": [
-        {
+        },
+      "lifecycle-storage-required-pods": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-local-storage",
@@ -10742,10 +10641,8 @@
             "suite": "lifecycle",
             "tags": "common"
           }
-        }
-      ],
-      "manageability-container-port-name-format": [
-        {
+        },
+      "manageability-container-port-name-format": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-requirements-cnf-reqs",
@@ -10771,10 +10668,8 @@
             "suite": "manageability",
             "tags": "extended"
           }
-        }
-      ],
-      "manageability-containers-image-tag": [
-        {
+        },
+      "manageability-containers-image-tag": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-image-tagging",
@@ -10800,10 +10695,8 @@
             "suite": "manageability",
             "tags": "extended"
           }
-        }
-      ],
-      "networking-dpdk-cpu-pinning-exec-probe": [
-        {
+        },
+      "networking-dpdk-cpu-pinning-exec-probe": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cpu-manager-pinning",
@@ -10829,10 +10722,8 @@
             "suite": "networking",
             "tags": "telco"
           }
-        }
-      ],
-      "networking-dual-stack-service": [
-        {
+        },
+      "networking-dual-stack-service": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-ipv4-\u0026-ipv6",
@@ -10858,10 +10749,8 @@
             "suite": "networking",
             "tags": "extended"
           }
-        }
-      ],
-      "networking-icmpv4-connectivity": [
-        {
+        },
+      "networking-icmpv4-connectivity": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-ipv4-\u0026-ipv6",
@@ -10887,10 +10776,8 @@
             "suite": "networking",
             "tags": "common"
           }
-        }
-      ],
-      "networking-icmpv4-connectivity-multus": [
-        {
+        },
+      "networking-icmpv4-connectivity-multus": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10916,10 +10803,8 @@
             "suite": "networking",
             "tags": "telco"
           }
-        }
-      ],
-      "networking-icmpv6-connectivity": [
-        {
+        },
+      "networking-icmpv6-connectivity": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-ipv4-\u0026-ipv6",
@@ -10945,10 +10830,8 @@
             "suite": "networking",
             "tags": "common"
           }
-        }
-      ],
-      "networking-icmpv6-connectivity-multus": [
-        {
+        },
+      "networking-icmpv6-connectivity-multus": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -10974,10 +10857,8 @@
             "suite": "networking",
             "tags": "telco"
           }
-        }
-      ],
-      "networking-network-policy-deny-all": [
-        {
+        },
+      "networking-network-policy-deny-all": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-vrfs-aka-routing-instances",
@@ -11003,10 +10884,8 @@
             "suite": "networking",
             "tags": "common"
           }
-        }
-      ],
-      "networking-ocp-reserved-ports-usage": [
-        {
+        },
+      "networking-ocp-reserved-ports-usage": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-ports-reserved-by-openshift",
@@ -11032,10 +10911,8 @@
             "suite": "networking",
             "tags": "common"
           }
-        }
-      ],
-      "networking-reserved-partner-ports": [
-        {
+        },
+      "networking-reserved-partner-ports": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Extended",
@@ -11061,10 +10938,8 @@
             "suite": "networking",
             "tags": "extended"
           }
-        }
-      ],
-      "networking-restart-on-reboot-sriov-pod": [
-        {
+        },
+      "networking-restart-on-reboot-sriov-pod": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Far Edge",
@@ -11090,10 +10965,8 @@
             "suite": "networking",
             "tags": "faredge"
           }
-        }
-      ],
-      "networking-undeclared-container-ports-usage": [
-        {
+        },
+      "networking-undeclared-container-ports-usage": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-requirements-cnf-reqs",
@@ -11119,9 +10992,8 @@
             "suite": "networking",
             "tags": "extended"
           }
-        }
-      ],
-      "observability-container-logging": [
+        },
+      "observability-container-logging": 
         {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Found log line to stderr/stdout\",\"tnf\",\"test-0\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Found log line to stderr/stdout\",\"tnf\",\"test-1\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Found log line to stderr/stdout\",\"tnf\",\"test-765d6b8dcf-gbvsd\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Found log line to stderr/stdout\",\"tnf\",\"test-765d6b8dcf-s768n\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Found log line to stderr/stdout\",\"tnf\",\"xdp\",\"xdp-c\"]}],\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
@@ -11148,10 +11020,8 @@
             "suite": "observability",
             "tags": "telco"
           }
-        }
-      ],
-      "observability-crd-status": [
-        {
+        },
+      "observability-crd-status": {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Custom Resource Definition\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Custom Resource Definition Name\",\"Custom Resource Definition Version\"],\"ObjectFieldsValues\":[\"Crd has a status sub resource set\",\"crdexamples.test-network-function.com\",\"v1\"]}],\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-operator-requirements",
@@ -11177,9 +11047,8 @@
             "suite": "observability",
             "tags": "common"
           }
-        }
-      ],
-      "observability-pod-disruption-budget": [
+        },
+      "observability-pod-disruption-budget":
         {
           "capturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"StatefulSet\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"StatefulSet\",\"Pod Disruption Budget Reference\"],\"ObjectFieldsValues\":[\"StatefulSet: references PodDisruptionBudget\",\"test\",\"test-pdb-max\"]}],\"NonCompliantObjectsOut\":null}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
@@ -11206,9 +11075,8 @@
             "suite": "observability",
             "tags": "common"
           }
-        }
-      ],
-      "observability-termination-policy": [
+        },
+      "observability-termination-policy":
         {
           "capturedTestOutput": "FAILURE: [container: xdp-c pod: xdp ns: tnf] does not have a TerminationMessagePolicy: FallbackToLogsOnError\n{\"CompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"TerminationMessagePolicy is FallbackToLogsOnError\",\"tnf\",\"test-0\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"TerminationMessagePolicy is FallbackToLogsOnError\",\"tnf\",\"test-1\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"TerminationMessagePolicy is FallbackToLogsOnError\",\"tnf\",\"test-765d6b8dcf-gbvsd\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"TerminationMessagePolicy is FallbackToLogsOnError\",\"tnf\",\"test-765d6b8dcf-s768n\",\"test\"]}],\"NonCompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"TerminationMessagePolicy is not FallbackToLogsOnError\",\"tnf\",\"xdp\",\"xdp-c\"]}]}\n%!(EXTRA []interface {}=[])",
           "catalogInfo": {
@@ -11235,10 +11103,8 @@
             "suite": "observability",
             "tags": "telco"
           }
-        }
-      ],
-      "operator-install-source": [
-        {
+        },
+      "operator-install-source": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-operator-requirements",
@@ -11264,10 +11130,8 @@
             "suite": "operator",
             "tags": "common"
           }
-        }
-      ],
-      "operator-install-status-no-privileges": [
-        {
+        },
+      "operator-install-status-no-privileges": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-operator-requirements",
@@ -11293,10 +11157,8 @@
             "suite": "operator",
             "tags": "common"
           }
-        }
-      ],
-      "operator-install-status-succeeded": [
-        {
+        },
+      "operator-install-status-succeeded": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-operator-requirements",
@@ -11322,10 +11184,8 @@
             "suite": "operator",
             "tags": "common"
           }
-        }
-      ],
-      "performance-exclusive-cpu-pool": [
-        {
+        },
+      "performance-exclusive-cpu-pool": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Far Edge",
@@ -11351,10 +11211,8 @@
             "suite": "performance",
             "tags": "faredge"
           }
-        }
-      ],
-      "performance-exclusive-cpu-pool-rt-scheduling-policy": [
-        {
+        },
+      "performance-exclusive-cpu-pool-rt-scheduling-policy": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Far Edge",
@@ -11380,10 +11238,8 @@
             "suite": "performance",
             "tags": "faredge"
           }
-        }
-      ],
-      "performance-isolated-cpu-pool-rt-scheduling-policy": [
-        {
+        },
+      "performance-isolated-cpu-pool-rt-scheduling-policy": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Far Edge",
@@ -11409,10 +11265,8 @@
             "suite": "performance",
             "tags": "faredge"
           }
-        }
-      ],
-      "performance-max-resources-exec-probes": [
-        {
+        },
+      "performance-max-resources-exec-probes": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Far Edge",
@@ -11438,10 +11292,8 @@
             "suite": "performance",
             "tags": "faredge"
           }
-        }
-      ],
-      "performance-rt-apps-no-exec-probes": [
-        {
+        },
+      "performance-rt-apps-no-exec-probes": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Far Edge",
@@ -11467,10 +11319,8 @@
             "suite": "performance",
             "tags": "faredge"
           }
-        }
-      ],
-      "performance-shared-cpu-pool-non-rt-scheduling-policy": [
-        {
+        },
+      "performance-shared-cpu-pool-non-rt-scheduling-policy": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Far Edge",
@@ -11496,10 +11346,8 @@
             "suite": "performance",
             "tags": "faredge"
           }
-        }
-      ],
-      "platform-alteration-base-image": [
-        {
+        },
+      "platform-alteration-base-image": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-image-standards",
@@ -11525,10 +11373,8 @@
             "suite": "platform-alteration",
             "tags": "common"
           }
-        }
-      ],
-      "platform-alteration-boot-params": [
-        {
+        },
+      "platform-alteration-boot-params": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-host-os",
@@ -11554,10 +11400,8 @@
             "suite": "platform-alteration",
             "tags": "common"
           }
-        }
-      ],
-      "platform-alteration-hugepages-1g-only": [
-        {
+        },
+      "platform-alteration-hugepages-1g-only": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Far Edge",
@@ -11583,10 +11427,8 @@
             "suite": "platform-alteration",
             "tags": "faredge"
           }
-        }
-      ],
-      "platform-alteration-hugepages-2m-only": [
-        {
+        },
+      "platform-alteration-hugepages-2m-only": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-huge-pages",
@@ -11612,10 +11454,8 @@
             "suite": "platform-alteration",
             "tags": "extended"
           }
-        }
-      ],
-      "platform-alteration-hugepages-config": [
-        {
+        },
+      "platform-alteration-hugepages-config": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-huge-pages",
@@ -11641,10 +11481,8 @@
             "suite": "platform-alteration",
             "tags": "common"
           }
-        }
-      ],
-      "platform-alteration-hyperthread-enable": [
-        {
+        },
+      "platform-alteration-hyperthread-enable": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Extended",
@@ -11670,10 +11508,8 @@
             "suite": "platform-alteration",
             "tags": "extended"
           }
-        }
-      ],
-      "platform-alteration-is-selinux-enforcing": [
-        {
+        },
+      "platform-alteration-is-selinux-enforcing": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-pod-security",
@@ -11699,10 +11535,8 @@
             "suite": "platform-alteration",
             "tags": "common"
           }
-        }
-      ],
-      "platform-alteration-isredhat-release": [
-        {
+        },
+      "platform-alteration-isredhat-release": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-base-images",
@@ -11728,10 +11562,8 @@
             "suite": "platform-alteration",
             "tags": "common"
           }
-        }
-      ],
-      "platform-alteration-ocp-lifecycle": [
-        {
+        },
+      "platform-alteration-ocp-lifecycle": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-k8s",
@@ -11757,10 +11589,8 @@
             "suite": "platform-alteration",
             "tags": "common"
           }
-        }
-      ],
-      "platform-alteration-ocp-node-os-lifecycle": [
-        {
+        },
+      "platform-alteration-ocp-node-os-lifecycle": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-host-os",
@@ -11786,10 +11616,8 @@
             "suite": "platform-alteration",
             "tags": "common"
           }
-        }
-      ],
-      "platform-alteration-service-mesh-usage": [
-        {
+        },
+      "platform-alteration-service-mesh-usage": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "No Doc Link - Extended",
@@ -11815,10 +11643,8 @@
             "suite": "platform-alteration",
             "tags": "extended"
           }
-        }
-      ],
-      "platform-alteration-sysctl-config": [
-        {
+        },
+      "platform-alteration-sysctl-config": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-cnf-security",
@@ -11844,10 +11670,8 @@
             "suite": "platform-alteration",
             "tags": "common"
           }
-        }
-      ],
-      "platform-alteration-tainted-node-kernel": [
-        {
+        },
+      "platform-alteration-tainted-node-kernel": {
           "capturedTestOutput": "",
           "catalogInfo": {
             "bestPracticeReference": "https://test-network-function.github.io/cnf-best-practices/#cnf-best-practices-high-level-cnf-expectations",
@@ -11874,7 +11698,6 @@
             "tags": "common"
           }
         }
-      ]
     },
     "versions": {
       "claimFormat": "v0.1.0",

--- a/cmd/tnf/claim/show/csv/csv.go
+++ b/cmd/tnf/claim/show/csv/csv.go
@@ -159,16 +159,16 @@ func buildCSV(claimScheme *claim.Schema, cnfType string, catalogMap map[string]c
 		record = append(record,
 			CNFNameFlag,
 			testID,
-			claimScheme.Claim.Results[testID][0].TestID.Suite,
-			claimScheme.Claim.Results[testID][0].CatalogInfo.Description,
-			claimScheme.Claim.Results[testID][0].State,
-			claimScheme.Claim.Results[testID][0].StartTime,
-			claimScheme.Claim.Results[testID][0].EndTime,
-			claimScheme.Claim.Results[testID][0].FailureReason,
-			claimScheme.Claim.Results[testID][0].CapturedTestOutput,
+			claimScheme.Claim.Results[testID].TestID.Suite,
+			claimScheme.Claim.Results[testID].CatalogInfo.Description,
+			claimScheme.Claim.Results[testID].State,
+			claimScheme.Claim.Results[testID].StartTime,
+			claimScheme.Claim.Results[testID].EndTime,
+			claimScheme.Claim.Results[testID].FailureReason,
+			claimScheme.Claim.Results[testID].CapturedTestOutput,
 			catalogMap[testID].Remediation,
 			cnfType, // Append the CNF type
-			claimScheme.Claim.Results[testID][0].CategoryClassification[cnfType],
+			claimScheme.Claim.Results[testID].CategoryClassification[cnfType],
 		)
 
 		resultsCSVRecords = append(resultsCSVRecords, record)

--- a/cmd/tnf/claim/show/failures/failures.go
+++ b/cmd/tnf/claim/show/failures/failures.go
@@ -299,7 +299,7 @@ func showFailures(_ *cobra.Command, _ []string) error {
 	// Order test case results by test suite, using a helper map.
 	resultsByTestSuite := map[string][]*claim.TestCaseResult{}
 	for id := range claimScheme.Claim.Results {
-		tcResult := claimScheme.Claim.Results[id][0]
+		tcResult := claimScheme.Claim.Results[id]
 		resultsByTestSuite[tcResult.TestID.Suite] = append(resultsByTestSuite[tcResult.TestID.Suite], &tcResult)
 	}
 

--- a/cmd/tnf/claim/show/failures/failures_test.go
+++ b/cmd/tnf/claim/show/failures/failures_test.go
@@ -381,7 +381,7 @@ func TestGetFailedTestCasesByTestSuite(t *testing.T) {
 		// Order test case results by test suite, using a helper map.
 		resultsByTestSuite := map[string][]*claim.TestCaseResult{}
 		for id := range claimScheme.Claim.Results {
-			tcResult := claimScheme.Claim.Results[id][0]
+			tcResult := claimScheme.Claim.Results[id]
 			resultsByTestSuite[tcResult.TestID.Suite] = append(
 				resultsByTestSuite[tcResult.TestID.Suite],
 				&tcResult,

--- a/cmd/tnf/claim/show/failures/testdata/claim1.json
+++ b/cmd/tnf/claim/show/failures/testdata/claim1.json
@@ -1,8 +1,7 @@
 {
   "claim": {
     "results": {
-      "access-control-sys-admin-capability-check": [
-        {
+      "access-control-sys-admin-capability-check": {
           "CapturedTestOutput": "Non compliant SYS_ADMIN capability detected in container container: test pod: test-887998557-8gwwm ns: tnf. All container caps: \u0026Capabilities{Add:[SYS_ADMIN NET_ADMIN],Drop:[],}\nNon compliant SYS_ADMIN capability detected in container container: test pod: test-887998557-pr2w5 ns: tnf. All container caps: \u0026Capabilities{Add:[SYS_ADMIN NET_ADMIN],Drop:[],}\n{\"CompliantObjectsOut\":null,\"NonCompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\",\"SCC Capability\"],\"ObjectFieldsValues\":[\"Non compliant capability detected in container\",\"tnf\",\"test-887998557-8gwwm\",\"test\",\"SYS_ADMIN\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\",\"SCC Capability\"],\"ObjectFieldsValues\":[\"Non compliant capability detected in container\",\"tnf\",\"test-887998557-pr2w5\",\"test\",\"SYS_ADMIN\"]}]}\n",
           "duration": 282454,
           "endTime": "2023-07-18 03:37:42.095508375 -0500 CDT m=+23.133713410",
@@ -28,10 +27,8 @@
             "NonTelco": "Optional",
             "Telco": "Mandatory"
           }
-        }
-      ],
-      "access-control-sys-nice-realtime-capability": [
-        {
+        },
+      "access-control-sys-nice-realtime-capability": {
           "CapturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container is not running on a realtime kernel enabled node\",\"tnf\",\"jack-6f88b5bfb4-q5cw6\",\"jack\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container is not running on a realtime kernel enabled node\",\"tnf\",\"jack-6f88b5bfb4-szs8g\",\"jack\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container is not running on a realtime kernel enabled node\",\"tnf\",\"test-0\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container is not running on a realtime kernel enabled node\",\"tnf\",\"test-1\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container is not running on a realtime kernel enabled node\",\"tnf\",\"test-887998557-8gwwm\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container is not running on a realtime kernel enabled node\",\"tnf\",\"test-887998557-pr2w5\",\"test\"]}],\"NonCompliantObjectsOut\":null}\n",
           "duration": 245335,
           "endTime": "2023-07-18 03:37:44.324268378 -0500 CDT m=+25.362473413",
@@ -57,10 +54,8 @@
             "NonTelco": "Optional",
             "Telco": "Mandatory"
           }
-        }
-      ],
-      "platform-alteration-sysctl-config": [
-        {
+        },
+      "platform-alteration-sysctl-config": {
           "CapturedTestOutput": "",
           "duration": 0,
           "endTime": "0001-01-01 00:00:00 +0000 UTC",
@@ -86,10 +81,8 @@
             "NonTelco": "Optional",
             "Telco": "Mandatory"
           }
-        }
-      ],
-      "platform-alteration-tainted-node-kernel": [
-        {
+        },
+      "platform-alteration-tainted-node-kernel": {
           "CapturedTestOutput": "",
           "duration": 0,
           "endTime": "0001-01-01 00:00:00 +0000 UTC",
@@ -116,7 +109,6 @@
             "Telco": "Mandatory"
           }
         }
-      ]
     },
     "versions": {
       "claimFormat": "v0.0.1",

--- a/cmd/tnf/claim/show/failures/testdata/claim2.json
+++ b/cmd/tnf/claim/show/failures/testdata/claim2.json
@@ -1,8 +1,7 @@
 {
   "claim": {
     "results": {
-      "access-control-sys-admin-capability-check": [
-        {
+      "access-control-sys-admin-capability-check": {
           "CapturedTestOutput": "Non compliant SYS_ADMIN capability detected in container container: test pod: test-887998557-8gwwm ns: tnf. All container caps: \u0026Capabilities{Add:[SYS_ADMIN NET_ADMIN],Drop:[],}\nNon compliant SYS_ADMIN capability detected in container container: test pod: test-887998557-pr2w5 ns: tnf. All container caps: \u0026Capabilities{Add:[SYS_ADMIN NET_ADMIN],Drop:[],}\n{\"CompliantObjectsOut\":null,\"NonCompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\",\"SCC Capability\"],\"ObjectFieldsValues\":[\"Non compliant capability detected in container\",\"tnf\",\"test-887998557-8gwwm\",\"test\",\"SYS_ADMIN\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Non Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\",\"SCC Capability\"],\"ObjectFieldsValues\":[\"Non compliant capability detected in container\",\"tnf\",\"test-887998557-pr2w5\",\"test\",\"SYS_ADMIN\"]}]}\n",
           "duration": 282454,
           "endTime": "2023-07-18 03:37:42.095508375 -0500 CDT m=+23.133713410",
@@ -28,10 +27,8 @@
             "NonTelco": "Optional",
             "Telco": "Mandatory"
           }
-        }
-      ],
-      "access-control-sys-nice-realtime-capability": [
-        {
+        },
+      "access-control-sys-nice-realtime-capability": {
           "CapturedTestOutput": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container is not running on a realtime kernel enabled node\",\"tnf\",\"jack-6f88b5bfb4-q5cw6\",\"jack\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container is not running on a realtime kernel enabled node\",\"tnf\",\"jack-6f88b5bfb4-szs8g\",\"jack\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container is not running on a realtime kernel enabled node\",\"tnf\",\"test-0\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container is not running on a realtime kernel enabled node\",\"tnf\",\"test-1\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container is not running on a realtime kernel enabled node\",\"tnf\",\"test-887998557-8gwwm\",\"test\"]},{\"ObjectType\":\"Container\",\"ObjectFieldsKeys\":[\"Reason For Compliance\",\"Namespace\",\"Pod Name\",\"Container Name\"],\"ObjectFieldsValues\":[\"Container is not running on a realtime kernel enabled node\",\"tnf\",\"test-887998557-pr2w5\",\"test\"]}],\"NonCompliantObjectsOut\":null}\n",
           "duration": 245335,
           "endTime": "2023-07-18 03:37:44.324268378 -0500 CDT m=+25.362473413",
@@ -57,10 +54,8 @@
             "NonTelco": "Optional",
             "Telco": "Mandatory"
           }
-        }
-      ],
-      "platform-alteration-sysctl-config": [
-        {
+        },
+      "platform-alteration-sysctl-config": {
           "CapturedTestOutput": "",
           "duration": 0,
           "endTime": "0001-01-01 00:00:00 +0000 UTC",
@@ -86,10 +81,8 @@
             "NonTelco": "Optional",
             "Telco": "Mandatory"
           }
-        }
-      ],
-      "platform-alteration-tainted-node-kernel": [
-        {
+        },
+      "platform-alteration-tainted-node-kernel": {
           "CapturedTestOutput": "",
           "duration": 0,
           "endTime": "0001-01-01 00:00:00 +0000 UTC",
@@ -116,7 +109,6 @@
             "Telco": "Mandatory"
           }
         }
-      ]
     },
     "versions": {
       "claimFormat": "v0.0.1",

--- a/cmd/tnf/pkg/claim/claim.go
+++ b/cmd/tnf/pkg/claim/claim.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	supportedClaimFormatVersion = "v0.1.0"
+	supportedClaimFormatVersion = "v0.2.0"
 )
 
 const (
@@ -54,7 +54,7 @@ type TestCaseResult struct {
 }
 
 // Maps a test suite name to a list of TestCaseResult
-type TestSuiteResults map[string][]TestCaseResult
+type TestSuiteResults map[string]TestCaseResult
 
 type Nodes struct {
 	NodesSummary interface{} `json:"nodeSummary"`

--- a/cmd/tnf/pkg/claim/claim_test.go
+++ b/cmd/tnf/pkg/claim/claim_test.go
@@ -22,14 +22,14 @@ func TestIsClaimFormatVersionSupported(t *testing.T) {
 		},
 		{
 			claimFormatVersion: "v0.0.0",
-			expectedError:      "claim format version v0.0.0 is not supported. Supported version is v0.1.0",
+			expectedError:      "claim format version v0.0.0 is not supported. Supported version is v0.2.0",
 		},
 		{
 			claimFormatVersion: "v0.0.1",
-			expectedError:      "claim format version v0.0.1 is not supported. Supported version is v0.1.0",
+			expectedError:      "claim format version v0.0.1 is not supported. Supported version is v0.2.0",
 		},
 		{
-			claimFormatVersion: "v0.1.0",
+			claimFormatVersion: "v0.2.0",
 			expectedError:      "",
 		},
 	}

--- a/cnf-certification-test/results/results.go
+++ b/cnf-certification-test/results/results.go
@@ -32,7 +32,7 @@ const (
 )
 
 // results is the results map
-var results = map[string][]claim.Result{}
+var results = map[string]claim.Result{}
 
 // RecordResult is a hook provided to save aspects of the ginkgo.GinkgoTestDescription for a given claim.Identifier.
 // Multiple results for a given identifier are aggregated as an array under the same key.
@@ -44,7 +44,7 @@ func RecordResult(report types.SpecReport) { //nolint:gocritic // From Ginkgo
 		aFailureReason = report.FailureMessage()
 	}
 	if claimID, ok := identifiers.TestIDToClaimID[report.LeafNodeText]; ok {
-		results[report.LeafNodeText] = append(results[report.LeafNodeText], claim.Result{
+		results[report.LeafNodeText] = claim.Result{
 			Duration:           int(report.RunTime.Nanoseconds()),
 			FailureLocation:    report.FailureLocation().String(),
 			FailureLineContent: report.FailureLocation().ContentsOfLine(),
@@ -65,7 +65,7 @@ func RecordResult(report types.SpecReport) { //nolint:gocritic // From Ginkgo
 				BestPracticeReference: identifiers.Catalog[claimID].BestPracticeReference,
 				ExceptionProcess:      identifiers.Catalog[claimID].ExceptionProcess,
 			},
-		})
+		}
 		if report.State == types.SpecStateAborted {
 			testhelper.AbortTrigger = claimID.Id
 		}
@@ -80,14 +80,13 @@ func RecordResult(report types.SpecReport) { //nolint:gocritic // From Ginkgo
 // RecordResult.  The combination of the two forms a Claim's results.
 func GetReconciledResults() map[string]interface{} {
 	resultMap := make(map[string]interface{})
-	for key, vals := range results {
+	//nolint:gocritic
+	for key, val := range results {
 		// initializes the result map, if necessary
 		if _, ok := resultMap[key]; !ok {
 			resultMap[key] = make([]claim.Result, 0)
 		}
-		for _, val := range vals { //nolint:gocritic // Only done once at the end
-			resultMap[key] = append(resultMap[key].([]claim.Result), val)
-		}
+		resultMap[key] = val
 	}
 	return resultMap
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "partner_tag": "v4.5.6",
-  "claimFormat": "v0.1.0",
-  "parserTag": "v0.1.4"
+  "claimFormat": "v0.2.0",
+  "parserTag": "v0.2.0"
 }


### PR DESCRIPTION
Cherry picked the changes from #1666 which was targeted for the `ginkgo_removal` branch and brought them back to main.  I'm not entirely sure this is needed but none of the changes were specific to `ginkgo_removal` so we could still do with removing the slice of results in main as well.  

Also it would make the transition easier for the parser and the gradetool repos once we merge everything in.

This would bump the `claimFormat` value to v0.2.0 and `parserTag` to v0.2.0.