### PR TITLE
Add depends-on PRs action to qe-hosted workflow

### DIFF
--- a/.github/workflows/qe-hosted.yml
+++ b/.github/workflows/qe-hosted.yml
@@ -49,6 +49,11 @@ jobs:
       - name: Run initial setup
         uses: ./.github/actions/setup
 
+      - name: Extract dependent Pull Requests
+        uses: depends-on/depends-on-action@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
Similar to #1381 

Adds the depends-on ability to the qe-hosted workflow in Github.  This will allow us to use PRs from the QE repo as dependencies.