### PR TITLE
Remove ginkgo.AbortSuite

### DIFF
--- a/cnf-certification-test/lifecycle/podrecreation/podrecreation.go
+++ b/cnf-certification-test/lifecycle/podrecreation/podrecreation.go
@@ -144,7 +144,7 @@ func CordonCleanup(node string, check *checksdb.Check) {
 	err := CordonHelper(node, Uncordon)
 	if err != nil {
 		logrus.Errorf("cleanup: error uncordoning the node: %s, err=%s", node, err)
-		check.SetResultAborted(fmt.Sprintf("cleanup: error uncordoning the node: %s, err=%s", node, err))
+		check.Abort()
 	}
 }
 

--- a/cnf-certification-test/lifecycle/podrecreation/podrecreation.go
+++ b/cnf-certification-test/lifecycle/podrecreation/podrecreation.go
@@ -22,9 +22,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/onsi/ginkgo/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
+	"github.com/test-network-function/cnf-certification-test/pkg/checksdb"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -140,11 +140,11 @@ func deletePod(pod *corev1.Pod, mode string, wg *sync.WaitGroup) error {
 	return nil
 }
 
-func CordonCleanup(node string) {
+func CordonCleanup(node string, check *checksdb.Check) {
 	err := CordonHelper(node, Uncordon)
 	if err != nil {
 		logrus.Errorf("cleanup: error uncordoning the node: %s, err=%s", node, err)
-		ginkgo.AbortSuite(fmt.Sprintf("cleanup: error uncordoning the node: %s, err=%s", node, err))
+		check.SetResultAborted(fmt.Sprintf("cleanup: error uncordoning the node: %s, err=%s", node, err))
 	}
 }
 

--- a/cnf-certification-test/lifecycle/suite.go
+++ b/cnf-certification-test/lifecycle/suite.go
@@ -634,7 +634,7 @@ func testPodsRecreation(check *checksdb.Check, env *provider.TestEnvironment) { 
 	}
 
 	for nodeName := range podsets.GetAllNodesForAllPodSets(env.Pods) {
-		defer podrecreation.CordonCleanup(nodeName) //nolint:gocritic // The defer in loop is intentional, calling the cleanup function once per node
+		defer podrecreation.CordonCleanup(nodeName, check) //nolint:gocritic // The defer in loop is intentional, calling the cleanup function once per node
 		err := podrecreation.CordonHelper(nodeName, podrecreation.Cordon)
 		if err != nil {
 			logrus.Errorf("error cordoning the node: %s", nodeName)

--- a/pkg/checksdb/check.go
+++ b/pkg/checksdb/check.go
@@ -54,6 +54,7 @@ type Check struct {
 	StartTime, EndTime time.Time
 	Timeout            time.Duration
 	Error              error
+	abortChan          chan bool
 }
 
 func NewCheck(id string, labels []string) *Check {
@@ -67,6 +68,17 @@ func NewCheck(id string, labels []string) *Check {
 	check.logger = log.GetMultiLogger(check.logArchive).With("check", check.ID)
 
 	return check
+}
+
+func (check *Check) Abort() {
+	check.mutex.Lock()
+	defer check.mutex.Unlock()
+
+	check.abortChan <- true
+}
+
+func (check *Check) SetAbortChan(abortChan chan bool) {
+	check.abortChan = abortChan
 }
 
 func (check *Check) LogDebug(msg string, args ...any) {

--- a/pkg/checksdb/checksdb.go
+++ b/pkg/checksdb/checksdb.go
@@ -25,6 +25,7 @@ func AddCheck(check *Check) {
 	db = append(db, check)
 }
 
+//nolint:funlen
 func RunChecks(labelsExpr string, timeout time.Duration) error {
 	dbLock.Lock()
 	defer dbLock.Unlock()
@@ -49,17 +50,25 @@ func RunChecks(labelsExpr string, timeout time.Duration) error {
 
 		// Stop channel, so we can send a stop signal to group.RunChecks()
 		stopChan := make(chan bool, 1)
+		abortChan := make(chan bool, 1)
 
 		// Done channel for the goroutine that runs group.RunChecks().
 		groupDone := make(chan bool)
 		go func() {
-			errs = append(errs, group.RunChecks(labelsExpr, stopChan)...)
+			errs = append(errs, group.RunChecks(labelsExpr, stopChan, abortChan)...)
 			groupDone <- true
 		}()
 
 		select {
 		case <-groupDone:
 			logrus.Tracef("Group %s finished running checks.", group.name)
+		case <-abortChan:
+			logrus.Warnf("Group %s aborted.", group.name)
+			stopChan <- true
+
+			abort = true
+			abortReason = "Test suite aborted due to error"
+			_ = group.OnAbort(labelsExpr, abortReason)
 		case <-timeOutChan:
 			logrus.Warnf("Running all checks timed-out.")
 			stopChan <- true

--- a/pkg/checksdb/checksgroup.go
+++ b/pkg/checksdb/checksgroup.go
@@ -282,7 +282,7 @@ func runCheck(check *Check, group *ChecksGroup, remainingChecks []*Check) (err e
 //   - AfterEach panic: Set check as error.
 //
 //nolint:funlen
-func (group *ChecksGroup) RunChecks(labelsExpr string, stopChan <-chan bool) (errs []error) {
+func (group *ChecksGroup) RunChecks(labelsExpr string, stopChan <-chan bool, abortChan chan bool) (errs []error) {
 	logrus.Infof("Running group %q checks.", group.name)
 
 	labelsExprEvaluator, err := NewLabelsExprEvaluator(labelsExpr)
@@ -344,6 +344,7 @@ func (group *ChecksGroup) RunChecks(labelsExpr string, stopChan <-chan bool) (er
 			if skip {
 				skipCheck(check, strings.Join(reasons, ", "))
 			} else {
+				check.SetAbortChan(abortChan) // Set the abort channel for the check.
 				err := runCheck(check, group, remainingChecks)
 				if err != nil {
 					errs = append(errs, err)


### PR DESCRIPTION
Created an `abortChan` that the check itself is able to trigger if we need to abort the entire suite.