### PR TITLE
Switch gradetool image to latest

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -14,7 +14,7 @@ env:
   OCT_IMAGE_NAME: testnetworkfunction/oct
   OCT_IMAGE_TAG: latest
   GRADETOOL_IMAGE_NAME: testnetworkfunction/gradetool
-  GRADETOOL_IMAGE_TAG: test1
+  GRADETOOL_IMAGE_TAG: latest
   TNF_CONTAINER_CLIENT: docker
   TNF_NON_INTRUSIVE_ONLY: false
   TNF_ALLOW_PREFLIGHT_INSECURE: false


### PR DESCRIPTION
Identical to: #1680 

Gradetool now supports the new claim version and so does both `main` and `ginkgo_removal`.