### PR TITLE
Avoid loading preflight checks in web server mode.

### DIFF
--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -19,7 +19,6 @@ package clientsholder
 import (
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
@@ -147,13 +146,11 @@ func ClearTestClientsHolder() {
 
 // GetClientsHolder returns the singleton ClientsHolder object.
 func GetClientsHolder(filenames ...string) *ClientsHolder {
-	const exitUsage = 2
 	if clientsHolder.ready {
 		return &clientsHolder
 	}
 	if len(filenames) == 0 {
-		logrus.Errorf("Please provide a valid kubeconfig. Either set the KUBECONFIG environment variable or alternatively copy a kube config to $HOME/.kube/config")
-		os.Exit(exitUsage)
+		return nil
 	}
 	clientsHolder, err := newClientsHolder(filenames...)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -165,8 +165,14 @@ func main() {
 	logrus.Infof("Claim Format Version: %s", versions.ClaimFormatVersion)
 	logrus.Infof("Labels filter       : %v", *labelsFlag)
 
-	_ = clientsholder.GetClientsHolder(getK8sClientsConfigFileNames()...)
+	webServerMode := *serverModeFlag
 
+	client := clientsholder.GetClientsHolder(getK8sClientsConfigFileNames()...)
+	if !webServerMode && client == nil {
+		logrus.Fatalf("Please provide a valid kubeconfig. Either set the KUBECONFIG environment variable or alternatively copy a kube config to $HOME/.kube/config")
+	}
+
+	certsuite.SetWebServerMode(*serverModeFlag)
 	certsuite.LoadChecksDB(*labelsFlag)
 
 	if *listFlag {

--- a/pkg/certsuite/certsuite.go
+++ b/pkg/certsuite/certsuite.go
@@ -24,6 +24,14 @@ import (
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
 )
 
+var (
+	webServerMode bool
+)
+
+func SetWebServerMode(serverMode bool) {
+	webServerMode = serverMode
+}
+
 func LoadChecksDB(labelsExpr string) {
 	accesscontrol.LoadChecks()
 	certification.LoadChecks()
@@ -35,7 +43,9 @@ func LoadChecksDB(labelsExpr string) {
 	platform.LoadChecks()
 	operator.LoadChecks()
 
-	if preflight.ShouldRun(labelsExpr) {
+	// Avoid loading preflight checks in webserver mode, since the app may start
+	// without any kubeconfig file provided.
+	if !webServerMode && preflight.ShouldRun(labelsExpr) {
 		preflight.LoadChecks()
 	}
 }


### PR DESCRIPTION
This is a temporary workaround to allow running the app in web server mode when no kubeconfig file/env var has been provided.

For preflight, the clientsholder needs to be fully and correctly initialized in order to run the checks, otherwise it won't have any TestEnvironment to get the containers/operators under test.

For web server mode, there's no need to have a valid clientsholder yet, as the kubeconfig file is provided via web form, and it can be a different one on each run. The clientsholder is then created with the clientsholder.GetNewClientsHolder().

This workaround should probably be removed/refactored when PR #1684 is merged.