### PR TITLE
Only capture ctrl-c while tests are running

### DIFF
--- a/pkg/checksdb/checksdb.go
+++ b/pkg/checksdb/checksdb.go
@@ -39,8 +39,6 @@ func RunChecks(labelsExpr string, timeout time.Duration) error {
 	const SIGINTBufferLen = 10
 	sigIntChan := make(chan os.Signal, SIGINTBufferLen)
 	signal.Notify(sigIntChan, syscall.SIGINT, syscall.SIGTERM)
-	// turn off ctrl-c capture on exit
-	defer signal.Stop(sigIntChan)
 
 	//  Labels expression parser not implemented yet. Assume labelsExpr is just a label.
 	abort := false


### PR DESCRIPTION
This allows terminating the program when running in webserver mode