### PR TITLE
Switch skip for nodePort test

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -273,7 +273,7 @@ func LoadChecks() {
 
 	testID, tags = identifiers.GetGinkgoTestIDAndLabels(identifiers.TestServicesDoNotUseNodeportsIdentifier)
 	checksGroup.Add(checksdb.NewCheck(testID, tags).
-		WithSkipCheckFn(testhelper.GetNoContainersUnderTestSkipFn(&env), testhelper.GetNoPodsUnderTestSkipFn(&env)).
+		WithSkipCheckFn(testhelper.GetNoServicesUnderTestSkipFn(&env)).
 		WithCheckFn(func(c *checksdb.Check) error {
 			testNodePort(c, &env)
 			return nil


### PR DESCRIPTION
The actual test is looping through `env.Services`.  Currently in `main` we also skip if no pods or no containers exist but in the new ginkgo_removal branch, we only consider a test "passed" if there are no `nonCompliantObjects` and >0 `compliantObjects`.