### PR TITLE
Remove early return with empty objects

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -961,9 +961,5 @@ func testCrdRoles(check *checksdb.Check, env *provider.TestEnvironment) {
 				testhelper.RoleType, false, env.Roles[roleIndex].Namespace, env.Roles[roleIndex].Name))
 		}
 	}
-	if len(nonCompliantObjects) == 0 && len(compliantObjects) == 0 {
-		check.LogInfo("No role contains rules that apply to at least one CRD under test")
-		return
-	}
 	check.SetResult(compliantObjects, nonCompliantObjects)
 }


### PR DESCRIPTION
We never get to the point of setting `check.SetResult` if we are missing nonCompliant or compliant objects.