### PR TITLE
Non graceful abort for unrecoverable/critical failures inside checkFn.

### DIFF
--- a/cnf-certification-test/lifecycle/podrecreation/podrecreation.go
+++ b/cnf-certification-test/lifecycle/podrecreation/podrecreation.go
@@ -143,8 +143,7 @@ func deletePod(pod *corev1.Pod, mode string, wg *sync.WaitGroup) error {
 func CordonCleanup(node string, check *checksdb.Check) {
 	err := CordonHelper(node, Uncordon)
 	if err != nil {
-		log.Error("cleanup: error uncordoning the node: %s, err=%s", node, err)
-		check.Abort()
+		check.Abort(fmt.Sprintf("cleanup: error uncordoning the node: %s, err=%s", node, err))
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -32,6 +32,14 @@ const banner = `
 
 `
 
+const (
+	CheckResultTagPass    = Green + "PASS" + Reset
+	CheckResultTagFail    = Red + "FAIL" + Reset
+	CheckResultTagSkip    = Yellow + "SKIP" + Reset
+	CheckResultTagRunning = Cyan + "RUNNING" + Reset
+	CheckResultTagAborted = Red + "ABORTED" + Reset
+)
+
 func PrintBanner() {
 	fmt.Print(banner)
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -38,6 +38,7 @@ const (
 	CheckResultTagSkip    = Yellow + "SKIP" + Reset
 	CheckResultTagRunning = Cyan + "RUNNING" + Reset
 	CheckResultTagAborted = Red + "ABORTED" + Reset
+	CheckResultTagError   = Red + "ERROR" + Reset
 )
 
 func PrintBanner() {

--- a/pkg/checksdb/checksdb.go
+++ b/pkg/checksdb/checksdb.go
@@ -25,6 +25,8 @@ var (
 	resultsDB = map[string]claim.Result{}
 )
 
+type AbortPanicMsg string
+
 func AddCheck(check *Check) {
 	db = append(db, check)
 }
@@ -43,7 +45,6 @@ func RunChecks(labelsExpr string, timeout time.Duration) (failedCtr int, err err
 	// turn off ctrl-c capture on exit
 	defer signal.Stop(sigIntChan)
 
-	//  Labels expression parser not implemented yet. Assume labelsExpr is just a label.
 	abort := false
 	var abortReason string
 	var errs []error
@@ -51,12 +52,13 @@ func RunChecks(labelsExpr string, timeout time.Duration) (failedCtr int, err err
 		if abort {
 			// ToDo: remove labelexpr checking.
 			_ = group.OnAbort(labelsExpr, abortReason)
+			group.RecordChecksResults()
 			continue
 		}
 
 		// Stop channel, so we can send a stop signal to group.RunChecks()
 		stopChan := make(chan bool, 1)
-		abortChan := make(chan bool, 1)
+		abortChan := make(chan string, 1)
 
 		// Done channel for the goroutine that runs group.RunChecks().
 		groupDone := make(chan bool)
@@ -70,12 +72,11 @@ func RunChecks(labelsExpr string, timeout time.Duration) (failedCtr int, err err
 		select {
 		case <-groupDone:
 			log.Debug("Group %s finished running checks.", group.name)
-		case <-abortChan:
+		case abortReason = <-abortChan:
 			log.Warn("Group %s aborted.", group.name)
 			stopChan <- true
 
 			abort = true
-			abortReason = "Test suite aborted due to error"
 			_ = group.OnAbort(labelsExpr, abortReason)
 		case <-timeOutChan:
 			log.Warn("Running all checks timed-out.")

--- a/pkg/checksdb/checksgroup.go
+++ b/pkg/checksdb/checksgroup.go
@@ -95,6 +95,7 @@ func skipAll(checks []*Check, reason string) {
 
 func onFailure(failureType, failureMsg string, group *ChecksGroup, currentCheck *Check, remainingChecks []*Check) error {
 	// Set current Check's result as error.
+	fmt.Printf("\r[ %s ] %-60s\n", cli.CheckResultTagError, currentCheck.ID)
 	currentCheck.SetResultError(failureType + ": " + failureMsg)
 	// Set the remaining checks as skipped, using a simplified reason msg.
 	reason := "group " + group.name + " " + failureType
@@ -414,7 +415,7 @@ func (group *ChecksGroup) OnAbort(labelsExpr, abortReason string) error {
 		// Abort the check that was running when it was aborted and skip the rest.
 		if i == group.currentRunningCheckIdx {
 			check.SetResultAborted(abortReason)
-			fmt.Printf("\r[ %s ] %s\n", cli.CheckResultTagAborted, check.ID)
+			fmt.Printf("\r[ %s ] %-60s\n", cli.CheckResultTagAborted, check.ID)
 		} else if i > group.currentRunningCheckIdx {
 			fmt.Printf("[ %s ] %s\n", cli.CheckResultTagSkip, check.ID)
 			check.SetResultSkipped(abortReason)

--- a/pkg/checksdb/checksgroup.go
+++ b/pkg/checksdb/checksgroup.go
@@ -10,6 +10,10 @@ import (
 	"github.com/test-network-function/cnf-certification-test/internal/log"
 )
 
+const (
+	checkIdxNone = -1
+)
+
 type ChecksGroup struct {
 	name   string
 	checks []*Check
@@ -35,8 +39,9 @@ func NewChecksGroup(groupName string) *ChecksGroup {
 	}
 
 	group = &ChecksGroup{
-		name:   groupName,
-		checks: []*Check{},
+		name:                   groupName,
+		checks:                 []*Check{},
+		currentRunningCheckIdx: checkIdxNone,
 	}
 	dbByGroup[groupName] = group
 
@@ -77,7 +82,7 @@ func (group *ChecksGroup) Add(check *Check) {
 func skipCheck(check *Check, reason string) {
 	check.LogInfo("Skipping check %s, reason: %s", check.ID, reason)
 
-	fmt.Printf("[ "+cli.Yellow+"SKIP"+cli.Reset+" ] %s\n", check.ID)
+	fmt.Printf("[ %s ] %s\n", cli.CheckResultTagSkip, check.ID)
 
 	check.SetResultSkipped(reason)
 }
@@ -253,6 +258,13 @@ func runCheck(check *Check, group *ChecksGroup, remainingChecks []*Check) (err e
 	check.LogInfo("Running check")
 	defer func() {
 		if r := recover(); r != nil {
+			// Don't do anything in case the check was manually aborted by check.Abort().
+			if msg, ok := r.(AbortPanicMsg); ok {
+				log.Warn("Check was manually aborted, msg: %v", msg)
+				err = fmt.Errorf("%v", msg)
+				return
+			}
+
 			stackTrace := fmt.Sprint(r) + "\n" + string(debug.Stack())
 
 			check.LogError("Panic while running check %s function:\n%v", check.ID, stackTrace)
@@ -283,7 +295,7 @@ func runCheck(check *Check, group *ChecksGroup, remainingChecks []*Check) (err e
 //   - AfterEach panic: Set check as error.
 //
 //nolint:funlen
-func (group *ChecksGroup) RunChecks(labelsExpr string, stopChan <-chan bool, abortChan chan bool) (errs []error, failedChecks int) {
+func (group *ChecksGroup) RunChecks(labelsExpr string, stopChan <-chan bool, abortChan chan string) (errs []error, failedChecks int) {
 	log.Info("Running group %q checks.", group.name)
 	fmt.Printf("Running suite %s\n", strings.ToUpper(group.name))
 
@@ -380,14 +392,31 @@ func (group *ChecksGroup) OnAbort(labelsExpr, abortReason string) error {
 		return fmt.Errorf("invalid labels expression: %v", err)
 	}
 
+	// If this wasn't the group with the aborted check.
+	if group.currentRunningCheckIdx == checkIdxNone {
+		fmt.Printf("Skipping checks from suite %s\n", strings.ToUpper(group.name))
+	}
+
 	for i, check := range group.checks {
 		if !labelsExprEvaluator.Eval(check.Labels) {
+			fmt.Printf("[ %s ] %s\n", cli.CheckResultTagSkip, check.ID)
+			check.SetResultSkipped("Not matching labels")
 			continue
 		}
 
+		// If none of this group's checks was running yet, skip all.
+		if group.currentRunningCheckIdx == checkIdxNone {
+			fmt.Printf("[ %s ] %s\n", cli.CheckResultTagSkip, check.ID)
+			check.SetResultSkipped(abortReason)
+			continue
+		}
+
+		// Abort the check that was running when it was aborted and skip the rest.
 		if i == group.currentRunningCheckIdx {
 			check.SetResultAborted(abortReason)
+			fmt.Printf("\r[ %s ] %s\n", cli.CheckResultTagAborted, check.ID)
 		} else if i > group.currentRunningCheckIdx {
+			fmt.Printf("[ %s ] %s\n", cli.CheckResultTagSkip, check.ID)
 			check.SetResultSkipped(abortReason)
 		}
 	}


### PR DESCRIPTION
The check.Abort() has been modified to panic with a message wrapped in a checksdb type. The deferred function in runCheck() will do nothing in case that especial (own) panic is detected, and no other check of that group will run.

This way we stop the goroutine for group.RunChecks() as soon as possible to avoid race conditions with the main goroutine, which will call group.OnAbort() and will register all the remaining checks as skipped, using the reason from the msg channel.