### PR TITLE
Remove early return in networking suite

### DIFF
--- a/cnf-certification-test/networking/suite.go
+++ b/cnf-certification-test/networking/suite.go
@@ -267,7 +267,6 @@ func testNetworkConnectivity(env *provider.TestEnvironment, aIPVersion netcommon
 	check.LogDebug("%s", claimsLog.GetLogLines())
 	if skip {
 		check.LogInfo("There are no %s networks to test with at least 2 pods, skipping test", aIPVersion)
-		return
 	}
 	check.SetResult(report.CompliantObjectsOut, report.NonCompliantObjectsOut)
 }


### PR DESCRIPTION
Remove this early `return` in the networking suite that skips the `check.SetResult` if a skip occurs.

![image](https://github.com/test-network-function/cnf-certification-test/assets/4563082/531b6205-fe9e-479a-9fa5-c608b2edcabe)

QE networking suite now passes successfully with this change.