### PR TITLE
Enable QE nightlies for ginkgo_removal

### DIFF
--- a/.github/workflows/qe-ocp-413-intrusive.yaml
+++ b/.github/workflows/qe-ocp-413-intrusive.yaml
@@ -18,6 +18,11 @@ jobs:
       matrix: 
         # Add more suites if more intrusive tests are added to the QE repo
         suite: [lifecycle]
+        include:
+          - test_suite_ref: main
+            qe_ref: main
+          - test_suite_ref: ginkgo_removal
+            qe_ref: ginkgo_removal
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/labuser/.kube/config'
@@ -32,7 +37,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ matrix.test_suite_ref }}
 
       - name: Run initial setup
         uses: ./.github/actions/setup
@@ -51,6 +56,7 @@ jobs:
         with:
           repository: ${{ env.QE_REPO }}
           path: cnfcert-tests-verification
+          ref: ${{ matrix.qe_ref }}
 
       - name: Preemptively potential QE namespaces
         run: ./scripts/delete-namespaces.sh

--- a/.github/workflows/qe-ocp-413.yaml
+++ b/.github/workflows/qe-ocp-413.yaml
@@ -17,6 +17,11 @@ jobs:
       fail-fast: false
       matrix: 
         suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
+        include:
+          - test_suite_ref: main
+            qe_ref: main
+          - test_suite_ref: ginkgo_removal
+            qe_ref: ginkgo_removal
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/labuser/.kube/config'
@@ -31,7 +36,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ matrix.test_suite_ref }}
 
       - name: Run initial setup
         uses: ./.github/actions/setup
@@ -50,6 +55,7 @@ jobs:
         with:
           repository: ${{ env.QE_REPO }}
           path: cnfcert-tests-verification
+          ref: ${{ matrix.qe_ref }}
 
       - name: Preemptively potential QE namespaces
         run: ./scripts/delete-namespaces.sh

--- a/.github/workflows/qe-ocp-414-intrusive.yaml
+++ b/.github/workflows/qe-ocp-414-intrusive.yaml
@@ -18,6 +18,11 @@ jobs:
       matrix: 
         # Add more suites if more intrusive tests are added to the QE repo
         suite: [lifecycle]
+        include:
+          - test_suite_ref: main
+            qe_ref: main
+          - test_suite_ref: ginkgo_removal
+            qe_ref: ginkgo_removal
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/labuser2/.kube/config'
@@ -32,7 +37,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ matrix.test_suite_ref }}
 
       - name: Run initial setup
         uses: ./.github/actions/setup
@@ -51,6 +56,7 @@ jobs:
         with:
           repository: ${{ env.QE_REPO }}
           path: cnfcert-tests-verification
+          ref: ${{ matrix.qe_ref }}
 
       - name: Preemptively potential QE namespaces
         run: ./scripts/delete-namespaces.sh

--- a/.github/workflows/qe-ocp-414.yaml
+++ b/.github/workflows/qe-ocp-414.yaml
@@ -17,6 +17,11 @@ jobs:
       fail-fast: false
       matrix: 
         suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
+        include:
+          - test_suite_ref: main
+            qe_ref: main
+          - test_suite_ref: ginkgo_removal
+            qe_ref: ginkgo_removal
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/labuser2/.kube/config'
@@ -31,7 +36,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ matrix.test_suite_ref }}
 
       - name: Run initial setup
         uses: ./.github/actions/setup
@@ -50,6 +55,7 @@ jobs:
         with:
           repository: ${{ env.QE_REPO }}
           path: cnfcert-tests-verification
+          ref: ${{ matrix.qe_ref }}
 
       - name: Preemptively potential QE namespaces
         run: ./scripts/delete-namespaces.sh


### PR DESCRIPTION
Following the documentation from here:

https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#example-expanding-configurations

I'm trying to enable the QE nightlies to run against the `ginkgo_removal` branch as well in both QE and here.

The reason I'm making this change on the main branch is because it is the default branch and that's where jobs are fired from.