### PR TITLE
flags: change "claimloc" for "output-dir"

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	logFile, err := createLogFile(*flags.ClaimPath)
+	logFile, err := createLogFile(*flags.OutputDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not create the log file, err: %v", err)
 		os.Exit(1)
@@ -90,7 +90,7 @@ func main() {
 	fmt.Printf("CNFCERT version: %s\n", versions.GitVersion())
 	fmt.Printf("Claim file version: %s\n", versions.ClaimFormatVersion)
 	fmt.Printf("Checks filter: %s\n", *flags.LabelsFlag)
-	fmt.Printf("Output folder: %s\n", *flags.ClaimPath)
+	fmt.Printf("Output folder: %s\n", *flags.OutputDir)
 	fmt.Printf("Log file: %s\n", log.LogFileName)
 	fmt.Printf("\n")
 
@@ -102,13 +102,13 @@ func main() {
 	}
 
 	// Set clientsholder singleton with the filenames from the env vars.
-	log.Info("Output folder for the claim file: %s", *flags.ClaimPath)
+	log.Info("Output folder for the claim file: %s", *flags.OutputDir)
 	if *flags.ServerModeFlag {
 		log.Info("Running CNF Certification Suite in web server mode.")
-		webserver.StartServer(*flags.ClaimPath)
+		webserver.StartServer(*flags.OutputDir)
 	} else {
 		log.Info("Running CNF Certification Suite in stand-alone mode.")
-		err = certsuite.Run(*flags.LabelsFlag, *flags.ClaimPath)
+		err = certsuite.Run(*flags.LabelsFlag, *flags.OutputDir)
 		if err != nil {
 			log.Error("Failed to run CNF Certification Suite: %v", err)
 			os.Exit(1)

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -22,8 +22,8 @@ import (
 )
 
 const (
-	claimPathFlagKey       = "claimloc"
-	defaultClaimPath       = "."
+	outputDirFlagKey       = "output-dir"
+	defaultOutputDir       = "."
 	NoLabelsExpr           = "none"
 	labelsFlagName         = "label-filter"
 	labelsFlagDefaultValue = "none"
@@ -47,7 +47,7 @@ const (
 )
 
 var (
-	ClaimPath *string
+	OutputDir *string
 	// labelsFlag holds the labels expression to filter the checks to run.
 	LabelsFlag     *string
 	TimeoutFlag    *string
@@ -56,8 +56,8 @@ var (
 )
 
 func InitFlags() {
-	ClaimPath = flag.String(claimPathFlagKey, defaultClaimPath,
-		"the path where the claimfile will be output")
+	OutputDir = flag.String(outputDirFlagKey, defaultOutputDir,
+		"the directory where the output artifacts will be placed")
 	LabelsFlag = flag.String(labelsFlagName, labelsFlagDefaultValue, labelsFlagUsage)
 	TimeoutFlag = flag.String(timeoutFlagName, TimeoutFlagDefaultvalue.String(), timeoutFlagUsage)
 	ListFlag = flag.Bool(listFlagName, listFlagDefaultValue, listFlagUsage)

--- a/run-cnf-suites.sh
+++ b/run-cnf-suites.sh
@@ -87,7 +87,7 @@ fi
 # Specify Junit report file name.
 EXTRA_ARGS="\
 --timeout=$TIMEOUT \
--claimloc $OUTPUT_LOC \
+--output-dir $OUTPUT_LOC \
 "
 
 if [ "$SERVER_RUN" = "true" ]; then


### PR DESCRIPTION
The directory not only contains the claim file but also the log file, the compressed file with the results and some other helper files.