### PR TITLE
CLI output improvements: check's elapsed time and last log trace.

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/sirupsen/logrus"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/accesscontrol/namespace"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/accesscontrol/rbac"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/accesscontrol/resources"
@@ -651,8 +650,6 @@ func testPodClusterRoleBindings(check *checksdb.Check, env *provider.TestEnviron
 				AddField(testhelper.ClusterRoleName, roleRefName))
 			continue
 		}
-
-		logrus.Debugf("topOwners=%v", topOwners)
 
 		csvNamespace, csvName, isOwnedByClusterWideOperator := OwnedByClusterWideOperator(topOwners, env)
 		// Pod is using a cluster role binding but is owned by a cluster wide operator, so it is ok

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2,6 +2,11 @@ package cli
 
 import (
 	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/term"
 )
 
 const (
@@ -14,6 +19,8 @@ const (
 	Cyan   = "\033[36m"
 	Gray   = "\033[37m"
 	White  = "\033[97m"
+
+	ClearLineCode = "\r\033[2K\r"
 )
 
 // ASCII art generated on http://www.patorjk.com/software/taag/ with
@@ -41,8 +48,98 @@ const (
 	CheckResultTagError   = Red + "ERROR" + Reset
 )
 
+var CliCheckLogSniffer = &cliCheckLogSniffer{}
+
+var (
+	isTTY bool
+
+	checkLoggerChan chan string
+	stopChan        chan bool
+)
+
+func init() {
+	isTTY = term.IsTerminal(int(os.Stdin.Fd()))
+}
+
 func PrintBanner() {
 	fmt.Print(banner)
+}
+
+type cliCheckLogSniffer struct{}
+
+func updateRunningCheckLine(checkName string, stopChan <-chan bool) {
+	startTime := time.Now()
+
+	// Local string var to save the last received log line from the running check.
+	lastCheckLogLine := ""
+
+	tickerPeriod := 1 * time.Second
+	if !isTTY {
+		// Increase it to avoid flooding the text output.
+		tickerPeriod = 10 * time.Second
+	}
+
+	timer := time.NewTicker(tickerPeriod)
+	for {
+		select {
+		case <-timer.C:
+			printRunningCheckLine(checkName, startTime, lastCheckLogLine)
+		case newLogLine := <-checkLoggerChan:
+			lastCheckLogLine = newLogLine
+			printRunningCheckLine(checkName, startTime, lastCheckLogLine)
+		case <-stopChan:
+			timer.Stop()
+			return
+		}
+	}
+}
+
+func getTerminalWidth() int {
+	width, _, _ := term.GetSize(int(os.Stdin.Fd()))
+	return width
+}
+
+func cropLogLine(line string, maxAvailableWidth int) string {
+	// Remove line feeds to avoid the log line to break the cli output.
+	filteredLine := strings.ReplaceAll(line, "\n", " ")
+	// Print only the chars that fit in the available space.
+	if len(filteredLine) > maxAvailableWidth {
+		return filteredLine[:maxAvailableWidth]
+	}
+	return filteredLine
+}
+
+func printRunningCheckLine(checkName string, startTime time.Time, logLine string) {
+	// Minimum space on the right needed to show the current last log line.
+	const minColsNeededForLogLine = 40
+
+	elapsedTime := time.Since(startTime).Round(time.Second)
+	line := "[ " + CheckResultTagRunning + " ] " + checkName + " (" + elapsedTime.String() + ")"
+	if !isTTY {
+		fmt.Print(line + "\n")
+		return
+	}
+
+	// Add check's last log line only if the program is running in a tty/ptty.
+	maxAvailableWidth := getTerminalWidth() - len(line) - 5
+	if logLine != "" && maxAvailableWidth > minColsNeededForLogLine {
+		// Append a cropped log line only if it makes sense due to the available space on the right.
+		line += "   " + cropLogLine(logLine, maxAvailableWidth)
+	}
+
+	fmt.Print(ClearLineCode + line)
+}
+
+// Implements the io.Write for the checks' custom handler for slog.
+func (c *cliCheckLogSniffer) Write(p []byte) (n int, err error) {
+	// Send to channel, or ignore it in case the channel is not ready or is closed.
+	// This way we avoid blocking the whole program.
+	select {
+	case checkLoggerChan <- string(p):
+	default:
+	}
+
+	return len(p), nil
 }
 
 func PrintResultsTable(results map[string][]int) {
@@ -58,4 +155,61 @@ func PrintResultsTable(results map[string][]int) {
 		fmt.Println("-----------------------------------------------------------")
 	}
 	fmt.Printf("\n")
+}
+
+func stopCheckLineGoroutine() {
+	if stopChan == nil {
+		// This may happen for checks that were skipped if no compliant nor non-compliant objects found.
+		return
+	}
+
+	stopChan <- true
+	// Make this chnanel immediately unavailable.
+	stopChan = nil
+}
+
+func PrintCheckSkipped(checkName, reason string) {
+	// It shouldn't happen too often, but some checks might be set as skipped inside the checkFn
+	// if neither compliant objects nor non-compliant objects were found.
+	stopCheckLineGoroutine()
+
+	fmt.Print(ClearLineCode + "[ " + CheckResultTagSkip + " ] " + checkName + "  (" + reason + ")\n")
+}
+
+func PrintCheckRunning(checkName string) {
+	stopChan = make(chan bool)
+	checkLoggerChan = make(chan string)
+
+	line := "[ " + CheckResultTagRunning + " ] " + checkName
+	if !isTTY {
+		line += "\n"
+	}
+
+	fmt.Print(line)
+
+	go updateRunningCheckLine(checkName, stopChan)
+}
+
+func PrintCheckPassed(checkName string) {
+	stopCheckLineGoroutine()
+
+	fmt.Print(ClearLineCode + "[ " + CheckResultTagPass + " ] " + checkName + "\n")
+}
+
+func PrintCheckFailed(checkName string) {
+	stopCheckLineGoroutine()
+
+	fmt.Print(ClearLineCode + "[ " + CheckResultTagFail + " ] " + checkName + "\n")
+}
+
+func PrintCheckAborted(checkName, reason string) {
+	stopCheckLineGoroutine()
+
+	fmt.Print(ClearLineCode + "[ " + CheckResultTagAborted + " ] " + checkName + "  (" + reason + ")\n")
+}
+
+func PrintCheckErrored(checkName string) {
+	stopCheckLineGoroutine()
+
+	fmt.Print(ClearLineCode + "[ " + CheckResultTagError + " ] " + checkName + "\n")
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -59,12 +59,17 @@ func GetLogger() *Logger {
 	return globalLogger
 }
 
-func GetMultiLogger(w io.Writer) *Logger {
+func GetMultiLogger(writers ...io.Writer) *Logger {
 	opts := Options{
 		Level: globalLogLevel,
 	}
 
-	return &Logger{l: slog.New(NewMultiHandler(globalLogger.l.Handler(), NewCustomHandler(w, &opts)))}
+	handlers := []slog.Handler{globalLogger.l.Handler()}
+	for _, writer := range writers {
+		handlers = append(handlers, NewCustomHandler(writer, &opts))
+	}
+
+	return &Logger{l: slog.New(NewMultiHandler(handlers...))}
 }
 
 // Top-level log functions

--- a/pkg/certsuite/certsuite.go
+++ b/pkg/certsuite/certsuite.go
@@ -2,6 +2,7 @@ package certsuite
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -91,6 +92,8 @@ func processFlags() time.Duration {
 func Run(labelsFilter, outputFolder string) error {
 	timeout := processFlags()
 	var returnErr bool
+
+	fmt.Println("Running discovery of CNF target resources...")
 	var env provider.TestEnvironment
 	env.SetNeedsRefresh()
 	env = provider.GetTestEnvironment()

--- a/pkg/checksdb/check.go
+++ b/pkg/checksdb/check.go
@@ -65,7 +65,7 @@ func NewCheck(id string, labels []string) *Check {
 		logArchive: &strings.Builder{},
 	}
 
-	check.logger = log.GetMultiLogger(check.logArchive).With("check", check.ID)
+	check.logger = log.GetMultiLogger(check.logArchive, cli.CliCheckLogSniffer).With("check", check.ID)
 
 	return check
 }
@@ -253,7 +253,7 @@ func (check *Check) Run() error {
 		return fmt.Errorf("unable to run due to a previously existing error: %v", check.Error)
 	}
 
-	fmt.Printf("[ %s ] %s", cli.CheckResultTagRunning, check.ID)
+	cli.PrintCheckRunning(check.ID)
 
 	check.StartTime = time.Now()
 	defer func() {
@@ -282,16 +282,17 @@ func (check *Check) Run() error {
 	return nil
 }
 
-const nbCharsToAvoidLineAliasing = 20
-
 func printCheckResult(check *Check) {
-	checkID := check.ID + strings.Repeat(" ", nbCharsToAvoidLineAliasing)
 	switch check.Result {
 	case CheckResultPassed:
-		fmt.Printf("\r[ %s ] %s\n", cli.CheckResultTagPass, checkID)
+		cli.PrintCheckPassed(check.ID)
 	case CheckResultFailed:
-		fmt.Printf("\r[ %s ] %s\n", cli.CheckResultTagFail, checkID)
+		cli.PrintCheckFailed(check.ID)
 	case CheckResultSkipped:
-		fmt.Printf("\r[ %s ] %s\n", cli.CheckResultTagSkip, checkID)
+		cli.PrintCheckSkipped(check.ID, check.skipReason)
+	case CheckResultAborted:
+		cli.PrintCheckAborted(check.ID, check.skipReason)
+	case CheckResultError:
+		cli.PrintCheckErrored(check.ID)
 	}
 }

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -426,7 +426,6 @@ type TopOwner struct {
 // Recursively follow the ownership tree to find the top owners
 func followOwnerReferences(resourceList []*metav1.APIResourceList, dynamicClient dynamic.Interface, topOwners map[string]TopOwner, namespace string, ownerRefs []metav1.OwnerReference) (err error) {
 	for _, ownerRef := range ownerRefs {
-		fmt.Printf("-> Owner: %s/%s\n", ownerRef.Kind, ownerRef.Name)
 		// Get group resource version
 		gvr := getResourceSchema(resourceList, ownerRef.APIVersion, ownerRef.Kind)
 		// Get the owner resources


### PR DESCRIPTION
The aim of this change is adding a bit of visual responsiveness to the current cli output of the ginkoless branch when the checks run.

For each running check it will show the elapsed time and the last log line emitted using check.Log() func. Once the check finishes, the cli line will also be rewritten but only the result will be left.

E.g.: while the check is running:
```
[ RUNNING ] lifecycle-pod-recreation (4s)   INFO  [Dec 18 07:50:14.778] [suite.go: 642] [lifecycle-pod-recreation] Draining and Cordoning node kind-worker3:
```
And when it's finished:
```
[ PASS ] lifecycle-pod-recreation
```

Also, if the check was skipped, aborted/errored, the reason will also appear so the user can quickly have an idea of what happened to that check.

E.g:
```
[ SKIP ] performance-max-resources-exec-probes  (Not matching labels)
```

This per-running check's extra info is shown only in case the program runs in a tty/ptty mode (manual run through `cnf-run-suites.sh`).