### PR TITLE
Adjust XML output

### DIFF
--- a/pkg/claimhelper/claimhelper_test.go
+++ b/pkg/claimhelper/claimhelper_test.go
@@ -46,6 +46,8 @@ func TestPopulateXMLFromClaim(t *testing.T) {
 			},
 			State:              "failed",
 			SkipReason:         failureMessage,
+			StartTime:          "2023-12-20 14:51:33 -0600 MST",
+			EndTime:            "2023-12-20 14:51:34 -0600 MST",
 			CheckDetails:       "",
 			CapturedTestOutput: "test output",
 			CategoryClassification: &claim.CategoryClassification{
@@ -72,7 +74,7 @@ func TestPopulateXMLFromClaim(t *testing.T) {
 				Disabled: strconv.Itoa(0),
 				Tests:    strconv.Itoa(1),
 				Errors:   strconv.Itoa(0),
-				Time:     strconv.Itoa(60),
+				Time:     strconv.Itoa(1),
 				Testsuite: Testsuite{
 
 					Name:     "test-suite1",
@@ -84,8 +86,8 @@ func TestPopulateXMLFromClaim(t *testing.T) {
 					Testcase: []TestCase{
 						{
 							Name: "test-case1",
-							Time: strconv.Itoa(60),
-							Failure: FailureMessage{
+							Time: strconv.Itoa(1),
+							Failure: &FailureMessage{
 								Message: "my custom failure message",
 							},
 						},
@@ -97,9 +99,9 @@ func TestPopulateXMLFromClaim(t *testing.T) {
 
 	for _, tc := range testCases {
 		// Build some 1 minute duration start and end time
-		startTime, err := time.Parse(DateTimeFormatDirective, "2006-01-02T15:04:05+00:00")
+		startTime, err := time.Parse(DateTimeFormatDirective, "2023-12-20 14:51:33 -0600 MST")
 		assert.Nil(t, err)
-		endTime, err := time.Parse(DateTimeFormatDirective, "2006-01-02T15:05:05+00:00")
+		endTime, err := time.Parse(DateTimeFormatDirective, "2023-12-20 14:51:34 -0600 MST")
 		assert.Nil(t, err)
 
 		xmlResult := populateXMLFromClaim(generateClaim(map[string]claim.Result{"test-case1": tc.testResult}), startTime, endTime)
@@ -108,9 +110,6 @@ func TestPopulateXMLFromClaim(t *testing.T) {
 		assert.Equal(t, tc.expectedXMLResult.Failures, xmlResult.Failures)
 		assert.Equal(t, tc.expectedXMLResult.Tests, xmlResult.Tests)
 		assert.Equal(t, tc.expectedXMLResult.Errors, xmlResult.Errors)
-		assert.Equal(t, tc.expectedXMLResult.Testsuite.Skipped, xmlResult.Testsuite.Skipped)
-
-		// convert "60.000" string to 60 int
 		expectedTimeFloat, err := strconv.ParseFloat(tc.expectedXMLResult.Time, 32)
 		assert.Nil(t, err)
 		actualTimeFloat, err := strconv.ParseFloat(xmlResult.Time, 32)

--- a/pkg/flags/flags_test.go
+++ b/pkg/flags/flags_test.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2020-2023 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package flags


### PR DESCRIPTION
Follow up to #1753 

Changes:
- Adds `omitempty` to all XML attr's.
- Parse the startTime and endTime stamps correctly and place the duration in the XML.
- Set `FailureMessage` and `SkippedMessage` structs to pointers so they can be nil if not used.

Additional:
- Sort XML output alphabetically.