### PR TITLE
Add retries for -partner setup calls

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -224,15 +224,26 @@ jobs:
           repository: test-network-function/cnf-certification-test-partner
           path: cnf-certification-test-partner
 
-      - name: Start the Kind cluster for `local-test-infra`
-        uses: ./cnf-certification-test-partner/.github/actions/start-k8s-cluster
+      - name: Bootstrap cluster, docker, and python
+        uses: nick-fields/retry@v2
         with:
-          working_directory: cnf-certification-test-partner
+          timeout_minutes: 90
+          max_attempts: 3
+          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make bootstrap-cluster; make make bootstrap-docker-ubuntu-local; make bootstrap-python-ubuntu-local
 
-      - name: Create `local-test-infra` OpenShift resources
-        uses: ./cnf-certification-test-partner/.github/actions/create-local-test-infra-resources
+      - name: Run 'make rebuild-cluster'
+        uses: nick-fields/retry@v2
         with:
-          working_directory: cnf-certification-test-partner
+          timeout_minutes: 90
+          max_attempts: 3
+          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make rebuild-cluster
+
+      - name: Run 'make install'
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 90
+          max_attempts: 3
+          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make install
 
       # Perform smoke tests.
       - name: 'Test: Run test suites'
@@ -320,23 +331,32 @@ jobs:
           repository: test-network-function/cnf-certification-test-partner
           path: cnf-certification-test-partner
 
-      - name: Start the Kind cluster for `local-test-infra`
-        uses: ./cnf-certification-test-partner/.github/actions/start-k8s-cluster
+      - name: Bootstrap cluster, docker, and python
+        uses: nick-fields/retry@v2
         with:
-          working_directory: cnf-certification-test-partner
+          timeout_minutes: 90
+          max_attempts: 3
+          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make bootstrap-cluster; make make bootstrap-docker-ubuntu-local; make bootstrap-python-ubuntu-local
 
-      - name: Create `local-test-infra` OpenShift resources
-        uses: ./cnf-certification-test-partner/.github/actions/create-local-test-infra-resources
+      - name: Run 'make rebuild-cluster'
+        uses: nick-fields/retry@v2
         with:
-          working_directory: cnf-certification-test-partner
+          timeout_minutes: 90
+          max_attempts: 3
+          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make rebuild-cluster
+
+      - name: Run 'make install'
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 90
+          max_attempts: 3
+          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make install
 
       # needed by depends-on-action
       - name: Set up Go 1.21
         uses: actions/setup-go@v5
         with:
           go-version: 1.21.5
-
-
 
       # Perform smoke tests using a TNF container.
       - name: Check out code into the Go module directory

--- a/.github/workflows/qe-hosted.yml
+++ b/.github/workflows/qe-hosted.yml
@@ -65,17 +65,26 @@ jobs:
           repository: test-network-function/cnf-certification-test-partner
           path: cnf-certification-test-partner
 
-      - name: Bootstrap the Kind and OC/Kubectl binaries for the `local-test-infra`
-        run: make bootstrap-cluster
-        working-directory: cnf-certification-test-partner
+      - name: Bootstrap cluster, docker, and python
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 90
+          max_attempts: 3
+          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make bootstrap-cluster; make make bootstrap-docker-ubuntu-local; make bootstrap-python-ubuntu-local
 
-      - name: Create `local-test-infra` OpenShift resources
-        run: make rebuild-cluster
-        working-directory: cnf-certification-test-partner
+      - name: Run 'make rebuild-cluster'
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 90
+          max_attempts: 3
+          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make rebuild-cluster
 
       - name: Install partner resources
-        run: make install-for-qe
-        working-directory: cnf-certification-test-partner
+        uses: nick-fields/retry@v2
+        with: 
+          timeout_minutes: 90
+          max_attempts: 3
+          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make install-for-qe
 
       - name: Show pods
         run: oc get pods -A


### PR DESCRIPTION
Wrap the calls for `make rebuild-cluster` and `make install` with retries to avoid any flapping.