### PR TITLE
Additional unit test coverage

### DIFF
--- a/cmd/tnf/generate/catalog/catalog_test.go
+++ b/cmd/tnf/generate/catalog/catalog_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/test-network-function/cnf-certification-test/pkg/arrayhelper"
 	"github.com/test-network-function/test-network-function-claim/pkg/claim"
 )
 
@@ -57,33 +56,6 @@ func TestEmitTextFromFile(t *testing.T) {
 
 func TestRunGenerateMarkdownCmd(t *testing.T) {
 	assert.Nil(t, runGenerateMarkdownCmd(nil, nil))
-}
-
-func TestUnique(t *testing.T) {
-	testCases := []struct {
-		testSlice     []string
-		expectedSlice []string
-	}{
-		{
-			testSlice:     []string{"one", "two", "three"},
-			expectedSlice: []string{"one", "two", "three"},
-		},
-		{
-			testSlice:     []string{"one", "two", "three", "three"},
-			expectedSlice: []string{"one", "two", "three"},
-		},
-		{
-			testSlice:     []string{},
-			expectedSlice: []string{},
-		},
-	}
-
-	for _, tc := range testCases {
-		sort.Strings(tc.expectedSlice)
-		results := arrayhelper.Unique(tc.testSlice)
-		sort.Strings(results)
-		assert.True(t, reflect.DeepEqual(tc.expectedSlice, results))
-	}
 }
 
 func TestGetSuitesFromIdentifiers(t *testing.T) {

--- a/cnf-certification-test/accesscontrol/rbac/automount.go
+++ b/cnf-certification-test/accesscontrol/rbac/automount.go
@@ -20,15 +20,14 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/internal/log"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1typed "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-func AutomountServiceAccountSetOnSA(serviceAccountName, podNamespace string) (*bool, error) {
-	clientsHolder := clientsholder.GetClientsHolder()
-	sa, err := clientsHolder.K8sClient.CoreV1().ServiceAccounts(podNamespace).Get(context.TODO(), serviceAccountName, metav1.GetOptions{})
+func AutomountServiceAccountSetOnSA(client corev1typed.CoreV1Interface, serviceAccountName, podNamespace string) (*bool, error) {
+	sa, err := client.ServiceAccounts(podNamespace).Get(context.TODO(), serviceAccountName, metav1.GetOptions{})
 	if err != nil {
 		log.Error("executing serviceaccount command failed with error: %v", err)
 		return nil, err
@@ -37,7 +36,7 @@ func AutomountServiceAccountSetOnSA(serviceAccountName, podNamespace string) (*b
 }
 
 //nolint:gocritic
-func EvaluateAutomountTokens(put *corev1.Pod) (bool, string) {
+func EvaluateAutomountTokens(client corev1typed.CoreV1Interface, put *corev1.Pod) (bool, string) {
 	// The token can be specified in the pod directly
 	// or it can be specified in the service account of the pod
 	// if no service account is configured, then the pod will use the configuration
@@ -50,7 +49,7 @@ func EvaluateAutomountTokens(put *corev1.Pod) (bool, string) {
 	}
 
 	// Collect information about the service account attached to the pod.
-	saAutomountServiceAccountToken, err := AutomountServiceAccountSetOnSA(put.Spec.ServiceAccountName, put.Namespace)
+	saAutomountServiceAccountToken, err := AutomountServiceAccountSetOnSA(client, put.Spec.ServiceAccountName, put.Namespace)
 	if err != nil {
 		return false, ""
 	}

--- a/cnf-certification-test/accesscontrol/rbac/automount_test.go
+++ b/cnf-certification-test/accesscontrol/rbac/automount_test.go
@@ -80,8 +80,8 @@ func TestAutomountServiceAccountSetOnSA(t *testing.T) {
 		var testRuntimeObjects []runtime.Object
 		testRuntimeObjects = append(testRuntimeObjects, &testSA)
 
-		_ = clientsholder.GetTestClientsHolder(testRuntimeObjects)
-		isSet, err := AutomountServiceAccountSetOnSA("testSA", "podNS")
+		client := clientsholder.GetTestClientsHolder(testRuntimeObjects)
+		isSet, err := AutomountServiceAccountSetOnSA(client.K8sClient.CoreV1(), "testSA", "podNS")
 		assert.Nil(t, err)
 		assert.Equal(t, tc.automountServiceTokenSet, *isSet)
 	}
@@ -138,8 +138,8 @@ func TestEvaluateAutomountTokens(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		_ = clientsholder.GetTestClientsHolder(buildServiceAccountTokenTestObjects())
-		podPassed, msg := EvaluateAutomountTokens(tc.testPod)
+		client := clientsholder.GetTestClientsHolder(buildServiceAccountTokenTestObjects())
+		podPassed, msg := EvaluateAutomountTokens(client.K8sClient.CoreV1(), tc.testPod)
 		assert.Equal(t, tc.expectedMsg, msg)
 		assert.Equal(t, tc.expectedResult, podPassed)
 	}

--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -692,7 +692,8 @@ func testAutomountServiceToken(check *checksdb.Check, env *provider.TestEnvironm
 		}
 
 		// Evaluate the pod's automount service tokens and any attached service accounts
-		podPassed, newMsg := rbac.EvaluateAutomountTokens(put.Pod)
+		client := clientsholder.GetClientsHolder()
+		podPassed, newMsg := rbac.EvaluateAutomountTokens(client.K8sClient.CoreV1(), put.Pod)
 		if !podPassed {
 			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, newMsg, false))
 			msg = append(msg, newMsg)

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -43,6 +43,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apiextv1fake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sFakeClient "k8s.io/client-go/kubernetes/fake"
@@ -121,6 +122,8 @@ func GetTestClientsHolder(k8sMockObjects []runtime.Object) *ClientsHolder {
 		case *policyv1.PodDisruptionBudget:
 			k8sClientObjects = append(k8sClientObjects, v)
 		case *scalingv1.HorizontalPodAutoscaler:
+			k8sClientObjects = append(k8sClientObjects, v)
+		case *storagev1.StorageClass:
 			k8sClientObjects = append(k8sClientObjects, v)
 
 		// K8s Extension Client Objects

--- a/pkg/arrayhelper/arrayhelper_test.go
+++ b/pkg/arrayhelper/arrayhelper_test.go
@@ -18,6 +18,7 @@ package arrayhelper
 
 import (
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -83,5 +84,32 @@ func TestArgListToMap(t *testing.T) {
 
 	for _, tc := range testCases {
 		assert.True(t, reflect.DeepEqual(tc.expectedMap, ArgListToMap(tc.argList)))
+	}
+}
+
+func TestUnique(t *testing.T) {
+	testCases := []struct {
+		testSlice     []string
+		expectedSlice []string
+	}{
+		{
+			testSlice:     []string{"one", "two", "three"},
+			expectedSlice: []string{"one", "two", "three"},
+		},
+		{
+			testSlice:     []string{"one", "two", "three", "three"},
+			expectedSlice: []string{"one", "two", "three"},
+		},
+		{
+			testSlice:     []string{},
+			expectedSlice: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		sort.Strings(tc.expectedSlice)
+		results := Unique(tc.testSlice)
+		sort.Strings(results)
+		assert.True(t, reflect.DeepEqual(tc.expectedSlice, results))
 	}
 }

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -129,7 +129,7 @@ func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData 
 	oc := clientsholder.GetClientsHolder()
 
 	var err error
-	data.StorageClasses, err = getAllStorageClasses()
+	data.StorageClasses, err = getAllStorageClasses(oc.K8sClient.StorageV1())
 	if err != nil {
 		log.Error("Failed to retrieve storageClasses - err: %v", err)
 		os.Exit(1)
@@ -196,21 +196,21 @@ func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData 
 	data.Deployments = findDeploymentByLabel(oc.K8sClient.AppsV1(), podsUnderTestLabelsObjects, data.Namespaces)
 	data.StatefulSet = findStatefulSetByLabel(oc.K8sClient.AppsV1(), podsUnderTestLabelsObjects, data.Namespaces)
 	// Find ClusterRoleBindings
-	clusterRoleBindings, err := getClusterRoleBindings()
+	clusterRoleBindings, err := getClusterRoleBindings(oc.K8sClient.RbacV1())
 	if err != nil {
 		log.Error("Cannot get cluster role bindings, error: %v", err)
 		os.Exit(1)
 	}
 	data.ClusterRoleBindings = clusterRoleBindings
 	// Find RoleBindings
-	roleBindings, err := getRoleBindings()
+	roleBindings, err := getRoleBindings(oc.K8sClient.RbacV1())
 	if err != nil {
 		log.Error("Cannot get cluster role bindings, error: %v", err)
 		os.Exit(1)
 	}
 	data.RoleBindings = roleBindings
 	// find roles
-	roles, err := getRoles()
+	roles, err := getRoles(oc.K8sClient.RbacV1())
 	if err != nil {
 		log.Error("Cannot get roles, error: %v", err)
 		os.Exit(1)

--- a/pkg/autodiscover/autodiscover_events.go
+++ b/pkg/autodiscover/autodiscover_events.go
@@ -25,10 +25,6 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-type Event struct {
-	*corev1.Event
-}
-
 func findAbnormalEvents(oc corev1client.CoreV1Interface, namespaces []string) (abnormalEvents []corev1.Event) {
 	abnormalEvents = []corev1.Event{}
 	for _, ns := range namespaces {

--- a/pkg/autodiscover/autodiscover_events_test.go
+++ b/pkg/autodiscover/autodiscover_events_test.go
@@ -15,3 +15,53 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package autodiscover
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestFindAbnormalEvents(t *testing.T) {
+	testCases := []struct {
+		expectedEvents []*corev1.Event
+	}{
+		{
+			expectedEvents: []*corev1.Event{
+				{
+					Reason: "FailedMount",
+					Type:   "Warning",
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-namespace",
+						Name:      "test-event",
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		var runtimeObjects []runtime.Object
+		for _, event := range testCase.expectedEvents {
+			runtimeObjects = append(runtimeObjects, event)
+		}
+
+		// Create fake client
+		client := k8sfake.NewSimpleClientset(runtimeObjects...)
+		abnormalEvents := findAbnormalEvents(client.CoreV1(), []string{"test-namespace"})
+		assert.Len(t, abnormalEvents, len(testCase.expectedEvents))
+
+		for _, event := range abnormalEvents {
+			for _, event2 := range testCase.expectedEvents {
+				if event.Name == event2.Name {
+					assert.Equal(t, event.Reason, event2.Reason)
+					assert.Equal(t, event.Type, event2.Type)
+				}
+			}
+		}
+	}
+}

--- a/pkg/autodiscover/autodiscover_networkpolicies_test.go
+++ b/pkg/autodiscover/autodiscover_networkpolicies_test.go
@@ -15,3 +15,43 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package autodiscover
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetNetworkPolicies(t *testing.T) {
+	testCases := []struct {
+		expectedNetworkPolicies []*networkingv1.NetworkPolicy
+	}{
+		{
+			expectedNetworkPolicies: []*networkingv1.NetworkPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-network-policy",
+						Namespace: "test-namespace",
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		var runtimeObjects []runtime.Object
+		for _, networkPolicy := range testCase.expectedNetworkPolicies {
+			runtimeObjects = append(runtimeObjects, networkPolicy)
+		}
+
+		// Create fake client
+		client := k8sfake.NewSimpleClientset(runtimeObjects...)
+		networkPolicies, err := getNetworkPolicies(client.NetworkingV1())
+		assert.Nil(t, err)
+		assert.Len(t, networkPolicies, len(testCase.expectedNetworkPolicies))
+	}
+}

--- a/pkg/autodiscover/autodiscover_podset_test.go
+++ b/pkg/autodiscover/autodiscover_podset_test.go
@@ -217,3 +217,79 @@ func TestFindHpaControllers(t *testing.T) {
 		assert.Equal(t, tc.expectedResults, hpas)
 	}
 }
+
+func TestFindDeploymentByNameByNamespace(t *testing.T) {
+	generateDeployment := func(name, namespace string) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+	}
+
+	testCases := []struct {
+		testDeploymentName      string
+		testDeploymentNamespace string
+		expectedResults         *appsv1.Deployment
+	}{
+		{
+			testDeploymentName:      "testName",
+			testDeploymentNamespace: "testNamespace",
+			expectedResults: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testName",
+					Namespace: "testNamespace",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		var testRuntimeObjects []runtime.Object
+		testRuntimeObjects = append(testRuntimeObjects, generateDeployment(tc.testDeploymentName, tc.testDeploymentNamespace))
+		oc := clientsholder.GetTestClientsHolder(testRuntimeObjects)
+
+		deployment, err := FindDeploymentByNameByNamespace(oc.K8sClient.AppsV1(), tc.testDeploymentNamespace, tc.testDeploymentName)
+		assert.Nil(t, err)
+		assert.Equal(t, tc.expectedResults, deployment)
+	}
+}
+
+func TestFindStatefulSetByNameByNamespace(t *testing.T) {
+	generateStatefulSet := func(name, namespace string) *appsv1.StatefulSet {
+		return &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+	}
+
+	testCases := []struct {
+		testStatefulSetName      string
+		testStatefulSetNamespace string
+		expectedResults          *appsv1.StatefulSet
+	}{
+		{
+			testStatefulSetName:      "testName",
+			testStatefulSetNamespace: "testNamespace",
+			expectedResults: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testName",
+					Namespace: "testNamespace",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		var testRuntimeObjects []runtime.Object
+		testRuntimeObjects = append(testRuntimeObjects, generateStatefulSet(tc.testStatefulSetName, tc.testStatefulSetNamespace))
+		oc := clientsholder.GetTestClientsHolder(testRuntimeObjects)
+
+		statefulSet, err := FindStatefulsetByNameByNamespace(oc.K8sClient.AppsV1(), tc.testStatefulSetNamespace, tc.testStatefulSetName)
+		assert.Nil(t, err)
+		assert.Equal(t, tc.expectedResults, statefulSet)
+	}
+}

--- a/pkg/autodiscover/autodiscover_pv.go
+++ b/pkg/autodiscover/autodiscover_pv.go
@@ -19,12 +19,12 @@ package autodiscover
 import (
 	"context"
 
-	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/internal/log"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	storagev1typed "k8s.io/client-go/kubernetes/typed/storage/v1"
 )
 
 func getPersistentVolumes(oc corev1client.CoreV1Interface) ([]corev1.PersistentVolume, error) {
@@ -43,9 +43,8 @@ func getPersistentVolumeClaims(oc corev1client.CoreV1Interface) ([]corev1.Persis
 	return pvcs.Items, nil
 }
 
-func getAllStorageClasses() ([]storagev1.StorageClass, error) {
-	o := clientsholder.GetClientsHolder()
-	storageclasslist, err := o.K8sClient.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{})
+func getAllStorageClasses(client storagev1typed.StorageV1Interface) ([]storagev1.StorageClass, error) {
+	storageclasslist, err := client.StorageClasses().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		log.Error("Error when listing, err: %v", err)
 		return nil, err

--- a/pkg/autodiscover/autodiscover_pv_test.go
+++ b/pkg/autodiscover/autodiscover_pv_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -95,5 +96,42 @@ func TestGetPersistentVolumeClaims(t *testing.T) {
 		PersistentVolumesClaims, err := getPersistentVolumeClaims(oc.K8sClient.CoreV1())
 		assert.Nil(t, err)
 		assert.Equal(t, tc.expectedRQs[0].Name, PersistentVolumesClaims[0].Name)
+	}
+}
+
+func TestGetAllStorageClasses(t *testing.T) {
+	generateStorageClasses := func(name string) *storagev1.StorageClass {
+		return &storagev1.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Provisioner: name,
+		}
+	}
+
+	testCases := []struct {
+		scName      string
+		expectedRQs []storagev1.StorageClass
+	}{
+		{
+			scName: "test1",
+			expectedRQs: []storagev1.StorageClass{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test1",
+					},
+					Provisioner: "test1",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		var testRuntimeObjects []runtime.Object
+		testRuntimeObjects = append(testRuntimeObjects, generateStorageClasses(tc.scName))
+		oc := clientsholder.GetTestClientsHolder(testRuntimeObjects)
+		StorageClasses, err := getAllStorageClasses(oc.K8sClient.StorageV1())
+		assert.Nil(t, err)
+		assert.Equal(t, tc.expectedRQs[0].Name, StorageClasses[0].Name)
 	}
 }

--- a/pkg/autodiscover/autodiscover_rbac.go
+++ b/pkg/autodiscover/autodiscover_rbac.go
@@ -19,17 +19,16 @@ package autodiscover
 import (
 	"context"
 
-	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/internal/log"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rbacv1typed "k8s.io/client-go/kubernetes/typed/rbac/v1"
 )
 
 // getRoleBindings returns all of the rolebindings in the cluster
-func getRoleBindings() ([]rbacv1.RoleBinding, error) {
+func getRoleBindings(client rbacv1typed.RbacV1Interface) ([]rbacv1.RoleBinding, error) {
 	// Get all of the rolebindings from all namespaces
-	clientsHolder := clientsholder.GetClientsHolder()
-	roleList, roleErr := clientsHolder.K8sClient.RbacV1().RoleBindings("").List(context.TODO(), metav1.ListOptions{})
+	roleList, roleErr := client.RoleBindings("").List(context.TODO(), metav1.ListOptions{})
 	if roleErr != nil {
 		log.Error("executing rolebinding command failed with error: %v", roleErr)
 		return nil, roleErr
@@ -38,11 +37,10 @@ func getRoleBindings() ([]rbacv1.RoleBinding, error) {
 }
 
 // getClusterRoleBindings returns all of the clusterrolebindings in the cluster
-func getClusterRoleBindings() ([]rbacv1.ClusterRoleBinding, error) {
+func getClusterRoleBindings(client rbacv1typed.RbacV1Interface) ([]rbacv1.ClusterRoleBinding, error) {
 	// Get all of the clusterrolebindings from the cluster
 	// These are not namespaced so we want all of them
-	clientsHolder := clientsholder.GetClientsHolder()
-	crbList, crbErr := clientsHolder.K8sClient.RbacV1().ClusterRoleBindings().List(context.TODO(), metav1.ListOptions{})
+	crbList, crbErr := client.ClusterRoleBindings().List(context.TODO(), metav1.ListOptions{})
 	if crbErr != nil {
 		log.Error("executing clusterrolebinding command failed with error: %v", crbErr)
 		return nil, crbErr
@@ -51,10 +49,9 @@ func getClusterRoleBindings() ([]rbacv1.ClusterRoleBinding, error) {
 }
 
 // getRoles returns all of the roles in the cluster
-func getRoles() ([]rbacv1.Role, error) {
+func getRoles(client rbacv1typed.RbacV1Interface) ([]rbacv1.Role, error) {
 	// Get all of the roles from all namespaces
-	clientsHolder := clientsholder.GetClientsHolder()
-	roleList, roleErr := clientsHolder.K8sClient.RbacV1().Roles("").List(context.TODO(), metav1.ListOptions{})
+	roleList, roleErr := client.Roles("").List(context.TODO(), metav1.ListOptions{})
 	if roleErr != nil {
 		log.Error("executing roles command failed with error: %v", roleErr)
 		return nil, roleErr

--- a/pkg/autodiscover/autodiscover_rbac_test.go
+++ b/pkg/autodiscover/autodiscover_rbac_test.go
@@ -73,15 +73,22 @@ func buildTestObjects() []runtime.Object {
 }
 
 func TestGetClusterRoleBinding(t *testing.T) {
-	_ = clientsholder.GetTestClientsHolder(buildTestObjects())
-	gatheredCRBs, err := getClusterRoleBindings()
+	client := clientsholder.GetTestClientsHolder(buildTestObjects())
+	gatheredCRBs, err := getClusterRoleBindings(client.K8sClient.RbacV1())
 	assert.Nil(t, err)
 	assert.Equal(t, "testCRB", gatheredCRBs[0].Name)
 }
 
 func TestGetRoleBinding(t *testing.T) {
-	_ = clientsholder.GetTestClientsHolder(buildTestObjects())
-	gatheredRBs, err := getRoleBindings()
+	client := clientsholder.GetTestClientsHolder(buildTestObjects())
+	gatheredRBs, err := getRoleBindings(client.K8sClient.RbacV1())
 	assert.Nil(t, err)
 	assert.Equal(t, "testRB", gatheredRBs[0].Name)
+}
+
+func TestGetRoles(t *testing.T) {
+	client := clientsholder.GetTestClientsHolder(buildTestObjects())
+	gatheredRoles, err := getRoles(client.K8sClient.RbacV1())
+	assert.Nil(t, err)
+	assert.Equal(t, "testRole", gatheredRoles[0].Name)
 }


### PR DESCRIPTION
Various unit tests and k8s client parameter adjustments.  Instead of calling the `clientsholder` everytime we need the k8s client, just pass the client in as a parameter to make it easier for unit testing.

This isn't _all_ of the references to the `clientsholder`, just a couple of low hanging fruit.