### PR TITLE
Remove dependency with golang-set

### DIFF
--- a/cnf-certification-test/platform/cnffsdiff/fsdiff.go
+++ b/cnf-certification-test/platform/cnffsdiff/fsdiff.go
@@ -21,9 +21,9 @@ import (
 	"errors"
 	"fmt"
 
-	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/internal/log"
+	"github.com/test-network-function/cnf-certification-test/pkg/stringhelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
 )
 
@@ -37,7 +37,7 @@ var (
 
 	// targetFolders stores all the targetFolders that shouldn't have been
 	// modified in the container. All of them exist on UBI.
-	targetFolders = mapset.NewSet(
+	targetFolders = []string{
 		"/bin",
 		"/lib",
 		"/lib64",
@@ -48,7 +48,7 @@ var (
 		"/usr/sbin",
 		"/var/lib/rpm",
 		"/var/lib/dpkg",
-	)
+	}
 )
 
 // fsDiffJSON is a helper struct to unmarshall the "podman diff --format json" output: a slice of
@@ -90,8 +90,8 @@ func NewFsDiffTester(client clientsholder.Command, ctxt clientsholder.Context) *
 func intersectTargetFolders(src []string) []string {
 	var dst []string
 	for _, folder := range src {
-		if targetFolders.Contains(folder) {
-			log.Debug("Container's folder %s is altered.", folder)
+		if stringhelper.StringInSlice(targetFolders, folder, false) {
+			log.Warn("Container's folder %q is altered.", folder)
 			dst = append(dst, folder)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -208,7 +208,6 @@ require (
 )
 
 require (
-	github.com/deckarep/golang-set/v2 v2.6.0
 	github.com/fatih/color v1.16.0
 	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/stdr v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,6 @@ github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deckarep/golang-set/v2 v2.6.0 h1:XfcQbWM1LlMB8BsJ8N9vW5ehnnPVIw0je80NsVHagjM=
-github.com/deckarep/golang-set/v2 v2.6.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/distribution/distribution v2.7.1+incompatible h1:aGFx4EvJWKEh//lHPLwFhFgwFHKH06TzNVPamrMn04M=
 github.com/distribution/distribution/v3 v3.0.0-20221208165359-362910506bc2 h1:aBfCb7iqHmDEIp6fBvC/hQUddQfg+3qdYjwzaiP9Hnc=
 github.com/distribution/distribution/v3 v3.0.0-20221208165359-362910506bc2/go.mod h1:WHNsWjnIn2V1LYOrME7e8KxSeKunYHsxEm4am0BUtcI=


### PR DESCRIPTION
The functionality required was already provided by our `stringhelper` package.