### PR TITLE
Adding configurable cpu requests/limit for the debug daemonset

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -217,7 +217,7 @@ require (
 	github.com/redhat-openshift-ecosystem/openshift-preflight v0.0.0-20231218171045-b6bcc3506c0d
 	github.com/robert-nix/ansihtml v1.0.1
 	github.com/test-network-function/oct v0.0.4
-	github.com/test-network-function/privileged-daemonset v1.0.18
+	github.com/test-network-function/privileged-daemonset v1.0.19
 	golang.org/x/term v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/kubectl v0.29.1

--- a/go.sum
+++ b/go.sum
@@ -570,8 +570,8 @@ github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/test-network-function/oct v0.0.4 h1:rU4kps/gbAHkR0rc5WzVtTOcJt/NBcse85RaG7WTuYw=
 github.com/test-network-function/oct v0.0.4/go.mod h1:oOPuUMnX6YR+cl3usBJfwCllsv7Hphw9jVi7VtniAzo=
-github.com/test-network-function/privileged-daemonset v1.0.18 h1:BFGAz5A77VxJCfHx6YEI+QehEINfCHm7KB+35QebsWs=
-github.com/test-network-function/privileged-daemonset v1.0.18/go.mod h1:zIxnKlnvftN62+38OCu/H7bLDjW3fzkpTY+lhyfxlPM=
+github.com/test-network-function/privileged-daemonset v1.0.19 h1:NMBYe/t35N0SQGVcXIHETWUvZUoaT+TVBnX2tt2PN+0=
+github.com/test-network-function/privileged-daemonset v1.0.19/go.mod h1:Fr6KEeVgZaJAGOkntvu1a4pkI9SPrfgLSiqx85qG60w=
 github.com/test-network-function/test-network-function-claim v1.0.33 h1:thLfqtzpXMNlmA8ZGpee3BUN+OfhRiFoTuEHWsE3d7Y=
 github.com/test-network-function/test-network-function-claim v1.0.33/go.mod h1:+0c6DMF/ycFmEH3EB5mJ9rSQ+3T/d48NuqmY2aXjrqQ=
 github.com/urfave/cli v1.22.12/go.mod h1:sSBEIC79qR6OvcmsD4U3KABeOTxDqQtdDnaFuUN30b8=

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -105,4 +105,8 @@ type TestParameters struct {
 	OmitArtifactsZipFile          bool   `split_words:"true" default:"false"`
 	EnableDataCollection          bool   `split_words:"true" envconfig:"ENABLE_DATA_COLLECTION" default:"false"`
 	EnableXMLCreation             bool   `split_words:"true" envconfig:"TNF_ENABLE_XML_CREATION" default:"false"`
+	DaemonsetCPUReq               string `default:"100m" split_words:"true"`
+	DaemonsetCPULim               string `default:"100m" split_words:"true"`
+	DaemonsetMemReq               string `default:"100M" split_words:"true"`
+	DaemonsetMemLim               string `default:"100M" split_words:"true"`
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -188,7 +188,12 @@ func deployDaemonSet(namespace string) error {
 	matchLabels := make(map[string]string)
 	matchLabels["name"] = DaemonSetName
 	matchLabels["test-network-function.com/app"] = DaemonSetName
-	_, err := k8sPrivilegedDs.CreateDaemonSet(DaemonSetName, namespace, containerName, dsImage, matchLabels, debugPodsTimeout)
+	_, err := k8sPrivilegedDs.CreateDaemonSet(DaemonSetName, namespace, containerName, dsImage, matchLabels, debugPodsTimeout,
+		configuration.GetTestParameters().DaemonsetCPUReq,
+		configuration.GetTestParameters().DaemonsetCPULim,
+		configuration.GetTestParameters().DaemonsetMemReq,
+		configuration.GetTestParameters().DaemonsetMemLim,
+	)
 	if err != nil {
 		return fmt.Errorf("could not deploy tnf daemonset, err=%v", err)
 	}


### PR DESCRIPTION
This is to reserve CPU and memory for the daemonset in case resources are scarce