### PR TITLE
Adjust the directories cleaned up in QE nightlies

### DIFF
--- a/.github/workflows/qe-ocp-413-intrusive.yaml
+++ b/.github/workflows/qe-ocp-413-intrusive.yaml
@@ -59,8 +59,8 @@ jobs:
       - name: Preemptively delete report and config folders
         shell: bash
         run: |
-          sudo rm -rf /tmp/tnf_config/
-          sudo rm -rf /tmp/tnf_report/
+          sudo rm -rf ${{env.TNF_CONFIG_DIR}}
+          sudo rm -rf ${{env.TNF_REPORT_DIR}}
 
       - name: Run the tests
         uses: nick-fields/retry@v2

--- a/.github/workflows/qe-ocp-413.yaml
+++ b/.github/workflows/qe-ocp-413.yaml
@@ -58,8 +58,8 @@ jobs:
       - name: Preemptively delete report and config folders
         shell: bash
         run: |
-          sudo rm -rf /tmp/tnf_config/
-          sudo rm -rf /tmp/tnf_report/
+          sudo rm -rf ${{env.TNF_CONFIG_DIR}}
+          sudo rm -rf ${{env.TNF_REPORT_DIR}}
 
       - name: Run the tests
         uses: nick-fields/retry@v2

--- a/.github/workflows/qe-ocp-414-intrusive.yaml
+++ b/.github/workflows/qe-ocp-414-intrusive.yaml
@@ -59,8 +59,8 @@ jobs:
       - name: Preemptively delete report and config folders
         shell: bash
         run: |
-          sudo rm -rf /tmp/tnf_config/
-          sudo rm -rf /tmp/tnf_report/
+          sudo rm -rf ${{env.TNF_CONFIG_DIR}}
+          sudo rm -rf ${{env.TNF_REPORT_DIR}}
 
       - name: Run the tests
         uses: nick-fields/retry@v2

--- a/.github/workflows/qe-ocp-414.yaml
+++ b/.github/workflows/qe-ocp-414.yaml
@@ -58,8 +58,8 @@ jobs:
       - name: Preemptively delete report and config folders
         shell: bash
         run: |
-          sudo rm -rf /tmp/tnf_config/
-          sudo rm -rf /tmp/tnf_report/
+          sudo rm -rf ${{env.TNF_CONFIG_DIR}}
+          sudo rm -rf ${{env.TNF_REPORT_DIR}}
 
       - name: Run the tests
         uses: nick-fields/retry@v2


### PR DESCRIPTION
Point these `rm -rf` calls to the actual directories being used instead of the hardcoded /tmp/ path.