### PR TITLE
Add retries for 'make build-image-local'

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -367,8 +367,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build the `cnf-certification-test` image
-        run: |
-          make build-image-local
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 90
+          max_attempts: 3
+          command: make build-image-local
         env:
           IMAGE_TAG: ${TNF_IMAGE_TAG}
 

--- a/.github/workflows/qe-hosted.yml
+++ b/.github/workflows/qe-hosted.yml
@@ -56,7 +56,11 @@ jobs:
           sudo pip3 install j2cli
 
       - name: Build the test image
-        run: make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 90
+          max_attempts: 3
+          command: make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
 
       # Create a Kind cluster for testing.
       - name: Check out `cnf-certification-test-partner`

--- a/.github/workflows/qe-ocp-413-intrusive.yaml
+++ b/.github/workflows/qe-ocp-413-intrusive.yaml
@@ -41,7 +41,11 @@ jobs:
         run: docker system prune -f --volumes
 
       - name: Build the test image
-        run: make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 90
+          max_attempts: 3
+          command: make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
 
       - name: Show pods
         run: oc get pods -A

--- a/.github/workflows/qe-ocp-413.yaml
+++ b/.github/workflows/qe-ocp-413.yaml
@@ -40,7 +40,11 @@ jobs:
         run: docker system prune -f --volumes
 
       - name: Build the test image
-        run: make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 90
+          max_attempts: 3
+          command: make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
 
       - name: Show pods
         run: oc get pods -A

--- a/.github/workflows/qe-ocp-414-intrusive.yaml
+++ b/.github/workflows/qe-ocp-414-intrusive.yaml
@@ -41,7 +41,11 @@ jobs:
         run: docker system prune -f --volumes
 
       - name: Build the test image
-        run: make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 90
+          max_attempts: 3
+          command: make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
 
       - name: Show pods
         run: oc get pods -A

--- a/.github/workflows/qe-ocp-414.yaml
+++ b/.github/workflows/qe-ocp-414.yaml
@@ -40,7 +40,11 @@ jobs:
         run: docker system prune -f --volumes
 
       - name: Build the test image
-        run: make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 90
+          max_attempts: 3
+          command: make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
 
       - name: Show pods
         run: oc get pods -A


### PR DESCRIPTION
I've seen a couple of times over the past couple of weeks where something upstream fails to pull/fetch/download/etc and fails the image build.  Adding retries should help smooth out the failures.