### PR TITLE
Remove free disk space cleanup

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -29,6 +29,7 @@ env:
   CM_BIN: /usr/local/bin/checkmake
   CM_URL_LINUX: https://github.com/mrtazz/checkmake/releases/download/0.2.2/checkmake-0.2.2.linux.amd64 # yamllint disable-line
   SMOKE_TESTS_LABELS_FILTER: '!affiliated-certification-container-is-certified-digest && !access-control-security-context'
+  SKIP_PRELOAD_IMAGES: true
 
 jobs:
   lint:
@@ -158,18 +159,6 @@ jobs:
       PFLT_DOCKERCONFIG: '/home/runner/.docker/config'
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          large-packages: true
-          android: true
-          dotnet: true
-          haskell: true
-          docker-images: true
-          swap-storage: true
-        continue-on-error: true
-
       - name: Write temporary docker file
         run: |
           mkdir -p /home/runner/.docker
@@ -303,18 +292,6 @@ jobs:
       PFLT_DOCKERCONFIG: '/home/runner/.docker/config'
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          large-packages: true
-          android: true
-          dotnet: true
-          haskell: true
-          docker-images: true
-          swap-storage: true
-        continue-on-error: true
-
       - name: Write temporary docker file
         run: |
           mkdir -p /home/runner/.docker

--- a/.github/workflows/qe-hosted.yml
+++ b/.github/workflows/qe-hosted.yml
@@ -29,18 +29,6 @@ jobs:
       SKIP_PRELOAD_IMAGES: true
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          large-packages: true
-          android: true
-          dotnet: true
-          haskell: true
-          docker-images: true
-          swap-storage: true
-        continue-on-error: true
-
       - name: Check out code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Now that the size of the virtual disks of the free tier is doubled, I'm testing whether or not we need these disk space cleanups anymore to speed up our runs.

See: https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/ 