### PR TITLE
checksdb: turn the labels evaluator into a global variable

### DIFF
--- a/pkg/certsuite/certsuite.go
+++ b/pkg/certsuite/certsuite.go
@@ -93,9 +93,14 @@ func Run(labelsFilter, outputFolder string) error {
 	timeout := processFlags()
 	var returnErr bool
 
+	// Create an evaluator to filter test cases with labels
+	if err := checksdb.InitLabelsExprEvaluator(labelsFilter); err != nil {
+		return fmt.Errorf("failed to initialize a test case label evaluator, err: %v", err)
+	}
+
 	// If the list flag is passed, print the checks filtered with --labels and leave
 	if *flags.ListFlag {
-		checksIDs, err := checksdb.FilterCheckIDs(labelsFilter)
+		checksIDs, err := checksdb.FilterCheckIDs()
 		if err != nil {
 			return fmt.Errorf("could not list test cases, err: %v", err)
 		}
@@ -120,7 +125,7 @@ func Run(labelsFilter, outputFolder string) error {
 
 	log.Info("Running checks matching labels expr %q with timeout %v", labelsFilter, timeout)
 	startTime := time.Now()
-	failedCtr, err := checksdb.RunChecks(labelsFilter, timeout)
+	failedCtr, err := checksdb.RunChecks(timeout)
 	if err != nil {
 		log.Error("%v", err)
 	}

--- a/pkg/checksdb/checksgroup.go
+++ b/pkg/checksdb/checksgroup.go
@@ -293,14 +293,9 @@ func runCheck(check *Check, group *ChecksGroup, remainingChecks []*Check) (err e
 //   - AfterEach panic: Set check as error.
 //
 //nolint:funlen
-func (group *ChecksGroup) RunChecks(labelsExpr string, stopChan <-chan bool, abortChan chan string) (errs []error, failedChecks int) {
+func (group *ChecksGroup) RunChecks(stopChan <-chan bool, abortChan chan string) (errs []error, failedChecks int) {
 	log.Info("Running group %q checks.", group.name)
 	fmt.Printf("Running suite %s\n", strings.ToUpper(group.name))
-
-	labelsExprEvaluator, err := NewLabelsExprEvaluator(labelsExpr)
-	if err != nil {
-		return []error{fmt.Errorf("invalid labels expression: %v", err)}, 0
-	}
 
 	// Get checks to run based on the label expr.
 	checks := []*Check{}
@@ -382,12 +377,7 @@ func (group *ChecksGroup) RunChecks(labelsExpr string, stopChan <-chan bool, abo
 	return errs, failedChecks
 }
 
-func (group *ChecksGroup) OnAbort(labelsExpr, abortReason string) error {
-	labelsExprEvaluator, err := NewLabelsExprEvaluator(labelsExpr)
-	if err != nil {
-		return fmt.Errorf("invalid labels expression: %v", err)
-	}
-
+func (group *ChecksGroup) OnAbort(abortReason string) error {
 	// If this wasn't the group with the aborted check.
 	if group.currentRunningCheckIdx == checkIdxNone {
 		fmt.Printf("Skipping checks from suite %s\n", strings.ToUpper(group.name))

--- a/pkg/checksdb/labels.go
+++ b/pkg/checksdb/labels.go
@@ -18,7 +18,7 @@ type labelsExprParser struct {
 	astRootNode ast.Expr
 }
 
-func NewLabelsExprEvaluator(labelsExpr string) (LabelsExprEvaluator, error) {
+func newLabelsExprEvaluator(labelsExpr string) (LabelsExprEvaluator, error) {
 	goLikeExpr := strings.ReplaceAll(labelsExpr, "-", "_")
 	goLikeExpr = strings.ReplaceAll(goLikeExpr, ",", "||")
 

--- a/pkg/checksdb/labels_test.go
+++ b/pkg/checksdb/labels_test.go
@@ -124,7 +124,7 @@ func TestIsWordInExpr(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Get labels expr evaluator
-			labelsExprEvaluator, err := NewLabelsExprEvaluator(tt.args.expr)
+			labelsExprEvaluator, err := newLabelsExprEvaluator(tt.args.expr)
 			assert.NotNil(t, labelsExprEvaluator)
 			assert.Nil(t, err)
 


### PR DESCRIPTION
The labels evaluator filtering mechanism is set at program startup and remains the same throughout its lifetime, so it seeems a better fit to have it as a global variable instead of recreating it every time it's needed.