### PR TITLE
Fix cluster bootstrapping step.

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -215,21 +215,21 @@ jobs:
         with:
           timeout_minutes: 90
           max_attempts: 3
-          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make bootstrap-cluster && make bootstrap-docker-ubuntu-local && make bootstrap-python-ubuntu-local
+          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner && make bootstrap-cluster && make bootstrap-docker-ubuntu-local && make bootstrap-python-ubuntu-local
 
       - name: Run 'make rebuild-cluster'
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 90
           max_attempts: 3
-          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make rebuild-cluster
+          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner && make rebuild-cluster
 
       - name: Run 'make install'
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 90
           max_attempts: 3
-          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make install
+          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner && make install
 
       # Perform smoke tests.
       - name: 'Test: Run test suites'
@@ -310,21 +310,21 @@ jobs:
         with:
           timeout_minutes: 90
           max_attempts: 3
-          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make bootstrap-cluster; make make bootstrap-docker-ubuntu-local; make bootstrap-python-ubuntu-local
+          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner && make bootstrap-cluster && make bootstrap-docker-ubuntu-local && make bootstrap-python-ubuntu-local
 
       - name: Run 'make rebuild-cluster'
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 90
           max_attempts: 3
-          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make rebuild-cluster
+          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner && make rebuild-cluster
 
       - name: Run 'make install'
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 90
           max_attempts: 3
-          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make install
+          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner && make install
 
       # needed by depends-on-action
       - name: Set up Go 1.21

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -215,7 +215,7 @@ jobs:
         with:
           timeout_minutes: 90
           max_attempts: 3
-          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make bootstrap-cluster; make make bootstrap-docker-ubuntu-local; make bootstrap-python-ubuntu-local
+          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make bootstrap-cluster && make bootstrap-docker-ubuntu-local && make bootstrap-python-ubuntu-local
 
       - name: Run 'make rebuild-cluster'
         uses: nick-fields/retry@v2
@@ -373,7 +373,7 @@ jobs:
           mkdir -p $TNF_CONFIG_DIR $TNF_OUTPUT_DIR
           cp cnf-certification-test/*.yml $TNF_CONFIG_DIR
         shell: bash
-        
+
       - name: Get Collector's CI credentials
         run: |
           echo "collector_ciuser=ciuser_${{ github.run_id }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
That "make make" was making the second step to fail silently, since the commands were separated by ";" instead of "&&."