### PR TITLE
Add functionality for running against local CRC instances

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,6 +107,16 @@ export TNF_ENABLE_XML_CREATION=true
 
 This will create a file named `cnf-certification-test/cnf-certification-tests_junit.xml`.
 
+#### Enable running container against OpenShift Local
+
+While running the test suite as a container, you can enable the container to be able to reach the local CRC instance by setting:
+
+```shell
+export TNF_ENABLE_CRC_TESTING=true
+```
+
+This utilizes the `--add-host` flag in Docker to be able to point `api.crc.testing` to the host gateway.
+
 ### Exceptions
 
 These options allow adding exceptions to skip several checks for different resources. The exceptions must be justified in order to pass the CNF Certification.

--- a/script/run-container.sh
+++ b/script/run-container.sh
@@ -160,6 +160,10 @@ if [ -n "${DNS_ARG}" ]; then
 	DNS_ARG="--dns $DNS_ARG"
 fi
 
+if [ -n "${TNF_ENABLE_CRC_TESTING}" ]; then
+	ADD_HOST_ARG="--add-host api.crc.testing:host-gateway"
+fi
+
 set -x
 # shellcheck disable=SC2068,SC2086 # Double quote array expansions.
 ${TNF_CONTAINER_CLIENT} run --rm $DNS_ARG \
@@ -168,6 +172,7 @@ ${TNF_CONTAINER_CLIENT} run --rm $DNS_ARG \
 	${container_tnf_dockercfg_volumes_cmd_args[@]} \
 	$CONFIG_VOLUME_MOUNT_ARG \
 	$TNF_OFFLINE_DB_MOUNT_ARG \
+	$ADD_HOST_ARG \
 	-v $OUTPUT_LOC:$CONTAINER_TNF_DIR/claim:Z \
 	-e KUBECONFIG=$CONTAINER_TNF_KUBECONFIG \
 	-e PFLT_DOCKERCONFIG=$CONTAINER_TNF_DOCKERCFG \


### PR DESCRIPTION
https://developers.redhat.com/products/openshift-local/overview

If you are running an instance of OpenShift Local (formerly CodeReady Containers) on your local machine and want to run the containerized version of the test suite against it, you have to use `--add-host` for the container to be able reach the apiserver correctly.