### PR TITLE
enable changing cnf suites timeout using env var

### DIFF
--- a/run-cnf-suites.sh
+++ b/run-cnf-suites.sh
@@ -26,7 +26,7 @@ usage_error() {
 	exit 1
 }
 
-TIMEOUT=24h0m0s
+TIMEOUT=${TIMEOUT:-24h0m0s}
 LABEL=''
 LIST=false
 SERVER_RUN=false


### PR DESCRIPTION
When running cnf cert operator we want to allow setting cnf suites run's timeout.
With this change we enable setting timeout using an environment variable.