### PR TITLE
Add filter for tainted node test

### DIFF
--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -272,8 +272,22 @@ func testTainted(check *checksdb.Check, env *provider.TestEnvironment) {
 	// Loop through the debug pods that are tied to each node.
 	for _, dp := range env.DebugPods {
 		nodeName := dp.Spec.NodeName
-
 		check.LogInfo("Testing node %q", nodeName)
+
+		// Ensure we are only testing nodes that have CNF workload deployed on them.
+		nodeHasWorkload := false
+		for _, p := range env.Pods {
+			if p.Spec.NodeName == nodeName {
+				check.LogInfo("Node %q has a CNF workload deployed on it", nodeName)
+				nodeHasWorkload = true
+				break
+			}
+		}
+
+		if !nodeHasWorkload {
+			check.LogInfo("Node %q does not have a CNF workload deployed on it. Skipping node.", nodeName)
+			continue
+		}
 
 		ocpContext := clientsholder.NewContext(dp.Namespace, dp.Name, dp.Spec.Containers[0].Name)
 		tf := nodetainted.NewNodeTaintedTester(&ocpContext, nodeName)

--- a/pkg/provider/nodes.go
+++ b/pkg/provider/nodes.go
@@ -147,3 +147,12 @@ func (node *Node) IsHyperThreadNode(env *TestEnvironment) (bool, error) {
 	}
 	return num > 1, nil
 }
+
+func (node *Node) HasWorkloadDeployed(podsUnderTest []*Pod) bool {
+	for _, pod := range podsUnderTest {
+		if pod.Spec.NodeName == node.Data.Name {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/provider/nodes_test.go
+++ b/pkg/provider/nodes_test.go
@@ -15,3 +15,67 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestHasWorkloadDeployed(t *testing.T) {
+	generateNode := func(nodeName string) *Node {
+		return &Node{
+			Data: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		testNodeName string
+		testPods     []*Pod
+		expected     bool
+	}{
+		{
+			testNodeName: "node1",
+			testPods: []*Pod{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod1",
+						},
+						Spec: corev1.PodSpec{
+							NodeName: "node1",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			testNodeName: "node1",
+			testPods: []*Pod{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod1",
+						},
+						Spec: corev1.PodSpec{
+							NodeName: "node2",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		n := generateNode(testCase.testNodeName)
+		assert.Equal(t, testCase.expected, n.HasWorkloadDeployed(testCase.testPods))
+	}
+}


### PR DESCRIPTION
Add a simple loop to check and make sure we are only testing nodes that have CNF workload deployed on them for the tainted node test.

A scenario this applies to would be if a user was purposefully tainting some nodes.  The debug daemonset would be spawned on those nodes but the CNF workload would not.