### PR TITLE
Specify network interface for ICMP tests

### DIFF
--- a/cnf-certification-test/networking/icmp/icmp.go
+++ b/cnf-certification-test/networking/icmp/icmp.go
@@ -63,10 +63,7 @@ func BuildNetTestContext(pods []*provider.Pod, aIPVersion netcommons.IPVersion, 
 			}
 			for netKey, multusNetworkInterface := range put.MultusNetworkInterfaces {
 				// The first container is used to get the network namespace
-				// Loop through all the network interfaces and their IPs
-				for _, networkInterface := range multusNetworkInterface {
-					processContainerIpsPerNet(put.Containers[0], netKey, networkInterface.IPs, networkInterface.Interface, netsUnderTest, aIPVersion, logger)
-				}
+				processContainerIpsPerNet(put.Containers[0], netKey, multusNetworkInterface.IPs, multusNetworkInterface.Interface, netsUnderTest, aIPVersion, logger)
 			}
 			continue
 		}

--- a/cnf-certification-test/networking/icmp/icmp.go
+++ b/cnf-certification-test/networking/icmp/icmp.go
@@ -63,7 +63,10 @@ func BuildNetTestContext(pods []*provider.Pod, aIPVersion netcommons.IPVersion, 
 			}
 			for netKey, multusNetworkInterface := range put.MultusNetworkInterfaces {
 				// The first container is used to get the network namespace
-				processContainerIpsPerNet(put.Containers[0], netKey, multusNetworkInterface[0].IPs, multusNetworkInterface[0].Interface, netsUnderTest, aIPVersion, logger)
+				// Loop through all the network interfaces and their IPs
+				for _, networkInterface := range multusNetworkInterface {
+					processContainerIpsPerNet(put.Containers[0], netKey, networkInterface.IPs, networkInterface.Interface, netsUnderTest, aIPVersion, logger)
+				}
 			}
 			continue
 		}
@@ -104,6 +107,9 @@ func processContainerIpsPerNet(containerID *provider.Container,
 		entry.TesterSource.ContainerIdentifier = containerID
 		// if multiple interfaces are present for this network on this container/pod, pick the first one as the tester source ip
 		entry.TesterSource.IP = ipAddressesFiltered[firstIPIndex]
+		if ifName != "" {
+			entry.TesterSource.InterfaceName = ifName
+		}
 		// do no include tester's IP in the list of destination IPs to ping
 		firstIPIndex++
 	}

--- a/cnf-certification-test/networking/icmp/icmp_test.go
+++ b/cnf-certification-test/networking/icmp/icmp_test.go
@@ -523,7 +523,7 @@ func TestBuildNetTestContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for idx := range tt.args.pods {
-				tt.args.pods[idx].MultusNetworkInterfaces = make(map[string][]provider.CniNetworkInterface)
+				tt.args.pods[idx].MultusNetworkInterfaces = make(map[string]provider.CniNetworkInterface)
 				var err error
 				tt.args.pods[idx].MultusNetworkInterfaces, err = provider.GetPodIPsPerNet(tt.args.pods[idx].GetAnnotations()[provider.CniNetworksStatusKey])
 				if err != nil {
@@ -572,20 +572,16 @@ var (
 				},
 			},
 		},
-		MultusNetworkInterfaces: map[string][]provider.CniNetworkInterface{
+		MultusNetworkInterfaces: map[string]provider.CniNetworkInterface{
 			"tnf/mynet-ipv4-0": {
-				{
-					Interface: "net1",
-					Name:      "mynet-ipv4-0",
-					IPs:       []string{"192.168.0.3"},
-				},
+				Interface: "net1",
+				Name:      "mynet-ipv4-0",
+				IPs:       []string{"192.168.0.3"},
 			},
 			"tnf/mynet-ipv4-1": {
-				{
-					Interface: "net2",
-					Name:      "mynet-ipv4-1",
-					IPs:       []string{"192.168.1.3"},
-				},
+				Interface: "net2",
+				Name:      "mynet-ipv4-1",
+				IPs:       []string{"192.168.1.3"},
 			},
 		},
 		SkipNetTests:       false,
@@ -623,20 +619,16 @@ var (
 				},
 			},
 		},
-		MultusNetworkInterfaces: map[string][]provider.CniNetworkInterface{
+		MultusNetworkInterfaces: map[string]provider.CniNetworkInterface{
 			"tnf/mynet-ipv4-0": {
-				{
-					Interface: "net1",
-					Name:      "mynet-ipv4-0",
-					IPs:       []string{"192.168.0.4"},
-				},
+				Interface: "net1",
+				Name:      "mynet-ipv4-0",
+				IPs:       []string{"192.168.0.4"},
 			},
 			"tnf/mynet-ipv4-1": {
-				{
-					Interface: "net2",
-					Name:      "mynet-ipv4-1",
-					IPs:       []string{"192.168.1.4"},
-				},
+				Interface: "net2",
+				Name:      "mynet-ipv4-1",
+				IPs:       []string{"192.168.1.4"},
 			},
 		},
 		SkipNetTests:       false,
@@ -674,7 +666,7 @@ var (
 				},
 			},
 		},
-		MultusNetworkInterfaces: map[string][]provider.CniNetworkInterface{
+		MultusNetworkInterfaces: map[string]provider.CniNetworkInterface{
 			"": {},
 		},
 		SkipNetTests:       true,
@@ -712,7 +704,7 @@ var (
 				},
 			},
 		},
-		MultusNetworkInterfaces: map[string][]provider.CniNetworkInterface{
+		MultusNetworkInterfaces: map[string]provider.CniNetworkInterface{
 			"": {},
 		},
 		SkipNetTests:       false,

--- a/cnf-certification-test/networking/icmp/icmp_test.go
+++ b/cnf-certification-test/networking/icmp/icmp_test.go
@@ -408,7 +408,8 @@ func TestBuildNetTestContext(t *testing.T) {
 			wantNetsUnderTest: map[string]netcommons.NetTestContext{
 				"tnf/mynet-ipv4-0": {
 					TesterSource: netcommons.ContainerIP{
-						IP: "192.168.0.3",
+						IP:            "192.168.0.3",
+						InterfaceName: "net1",
 						ContainerIdentifier: &provider.Container{
 							Container: &corev1.Container{
 								Name: "test1",
@@ -422,7 +423,8 @@ func TestBuildNetTestContext(t *testing.T) {
 					},
 					DestTargets: []netcommons.ContainerIP{
 						{
-							IP: "192.168.0.4",
+							IP:            "192.168.0.4",
+							InterfaceName: "net1",
 							ContainerIdentifier: &provider.Container{
 								Container: &corev1.Container{
 									Name: "test2",
@@ -439,7 +441,8 @@ func TestBuildNetTestContext(t *testing.T) {
 				"tnf/mynet-ipv4-1": {
 					TesterContainerNodeName: "",
 					TesterSource: netcommons.ContainerIP{
-						IP: "192.168.1.3",
+						IP:            "192.168.1.3",
+						InterfaceName: "net2",
 						ContainerIdentifier: &provider.Container{
 							Container: &corev1.Container{
 								Name: "test1",
@@ -453,7 +456,8 @@ func TestBuildNetTestContext(t *testing.T) {
 					},
 					DestTargets: []netcommons.ContainerIP{
 						{
-							IP: "192.168.1.4",
+							IP:            "192.168.1.4",
+							InterfaceName: "net2",
 							ContainerIdentifier: &provider.Container{
 								Container: &corev1.Container{
 									Name: "test2",
@@ -478,7 +482,8 @@ func TestBuildNetTestContext(t *testing.T) {
 			wantNetsUnderTest: map[string]netcommons.NetTestContext{
 				"tnf/mynet-ipv4-0": {
 					TesterSource: netcommons.ContainerIP{
-						IP: "192.168.0.3",
+						IP:            "192.168.0.3",
+						InterfaceName: "net1",
 						ContainerIdentifier: &provider.Container{
 							Container: &corev1.Container{
 								Name: "test1",
@@ -495,7 +500,8 @@ func TestBuildNetTestContext(t *testing.T) {
 				"tnf/mynet-ipv4-1": {
 					TesterContainerNodeName: "",
 					TesterSource: netcommons.ContainerIP{
-						IP: "192.168.1.3",
+						IP:            "192.168.1.3",
+						InterfaceName: "net2",
 						ContainerIdentifier: &provider.Container{
 							Container: &corev1.Container{
 								Name: "test1",
@@ -519,9 +525,7 @@ func TestBuildNetTestContext(t *testing.T) {
 			for idx := range tt.args.pods {
 				tt.args.pods[idx].MultusNetworkInterfaces = make(map[string][]provider.CniNetworkInterface)
 				var err error
-				tt.args.pods[idx].MultusNetworkInterfaces, err = provider.GetPodIPsPerNet(
-					tt.args.pods[idx].GetAnnotations()[provider.CniNetworksStatusKey],
-				)
+				tt.args.pods[idx].MultusNetworkInterfaces, err = provider.GetPodIPsPerNet(tt.args.pods[idx].GetAnnotations()[provider.CniNetworksStatusKey])
 				if err != nil {
 					fmt.Printf("Could not decode networks-status annotation")
 				}
@@ -569,7 +573,20 @@ var (
 			},
 		},
 		MultusNetworkInterfaces: map[string][]provider.CniNetworkInterface{
-			"": {},
+			"tnf/mynet-ipv4-0": {
+				{
+					Interface: "net1",
+					Name:      "mynet-ipv4-0",
+					IPs:       []string{"192.168.0.3"},
+				},
+			},
+			"tnf/mynet-ipv4-1": {
+				{
+					Interface: "net2",
+					Name:      "mynet-ipv4-1",
+					IPs:       []string{"192.168.1.3"},
+				},
+			},
 		},
 		SkipNetTests:       false,
 		SkipMultusNetTests: false,
@@ -607,7 +624,20 @@ var (
 			},
 		},
 		MultusNetworkInterfaces: map[string][]provider.CniNetworkInterface{
-			"": {},
+			"tnf/mynet-ipv4-0": {
+				{
+					Interface: "net1",
+					Name:      "mynet-ipv4-0",
+					IPs:       []string{"192.168.0.4"},
+				},
+			},
+			"tnf/mynet-ipv4-1": {
+				{
+					Interface: "net2",
+					Name:      "mynet-ipv4-1",
+					IPs:       []string{"192.168.1.4"},
+				},
+			},
 		},
 		SkipNetTests:       false,
 		SkipMultusNetTests: false,

--- a/cnf-certification-test/networking/icmp/icmp_test.go
+++ b/cnf-certification-test/networking/icmp/icmp_test.go
@@ -306,6 +306,7 @@ func TestProcessContainerIpsPerNet(t *testing.T) {
 				tt.args.containerID,
 				tt.args.netKey,
 				tt.args.ipAddresses,
+				"",
 				tt.args.netsUnderTest,
 				tt.args.aIPVersion,
 				log.GetLogger(),
@@ -516,9 +517,9 @@ func TestBuildNetTestContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for idx := range tt.args.pods {
-				tt.args.pods[idx].MultusIPs = make(map[string][]string)
+				tt.args.pods[idx].MultusNetworkInterfaces = make(map[string][]provider.CniNetworkInterface)
 				var err error
-				tt.args.pods[idx].MultusIPs, err = provider.GetPodIPsPerNet(
+				tt.args.pods[idx].MultusNetworkInterfaces, err = provider.GetPodIPsPerNet(
 					tt.args.pods[idx].GetAnnotations()[provider.CniNetworksStatusKey],
 				)
 				if err != nil {
@@ -567,7 +568,7 @@ var (
 				},
 			},
 		},
-		MultusIPs: map[string][]string{
+		MultusNetworkInterfaces: map[string][]provider.CniNetworkInterface{
 			"": {},
 		},
 		SkipNetTests:       false,
@@ -605,7 +606,7 @@ var (
 				},
 			},
 		},
-		MultusIPs: map[string][]string{
+		MultusNetworkInterfaces: map[string][]provider.CniNetworkInterface{
 			"": {},
 		},
 		SkipNetTests:       false,
@@ -643,7 +644,7 @@ var (
 				},
 			},
 		},
-		MultusIPs: map[string][]string{
+		MultusNetworkInterfaces: map[string][]provider.CniNetworkInterface{
 			"": {},
 		},
 		SkipNetTests:       true,
@@ -681,7 +682,7 @@ var (
 				},
 			},
 		},
-		MultusIPs: map[string][]string{
+		MultusNetworkInterfaces: map[string][]provider.CniNetworkInterface{
 			"": {},
 		},
 		SkipNetTests:       false,

--- a/cnf-certification-test/networking/netcommons/netcommons.go
+++ b/cnf-certification-test/networking/netcommons/netcommons.go
@@ -80,10 +80,12 @@ type ContainerIP struct {
 	IP string
 	// targetContainerIdentifier container identifier including namespace, pod name, container name, node name, and container UID
 	ContainerIdentifier *provider.Container
+	// interfaceName is the interface we want to target for the ping test
+	InterfaceName string
 }
 
 // String displays the NetTestContext data structure
-func (testContext NetTestContext) String() string {
+func (testContext *NetTestContext) String() string {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("From initiating container: %s\n", testContext.TesterSource.String()))
 	if len(testContext.DestTargets) == 0 {

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -43,7 +43,7 @@ const (
 type Pod struct {
 	*corev1.Pod
 	Containers              []*Container
-	MultusNetworkInterfaces map[string][]CniNetworkInterface
+	MultusNetworkInterfaces map[string]CniNetworkInterface
 	MultusPCIs              []string
 	SkipNetTests            bool
 	SkipMultusNetTests      bool
@@ -52,7 +52,7 @@ type Pod struct {
 func NewPod(aPod *corev1.Pod) (out Pod) {
 	var err error
 	out.Pod = aPod
-	out.MultusNetworkInterfaces = make(map[string][]CniNetworkInterface)
+	out.MultusNetworkInterfaces = make(map[string]CniNetworkInterface)
 	out.MultusNetworkInterfaces, err = GetPodIPsPerNet(aPod.GetAnnotations()[CniNetworksStatusKey])
 	if err != nil {
 		log.Error("Could not get IPs for Pod %q (namespace %q), err: %v", aPod.Name, aPod.Namespace, err)

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -42,18 +42,18 @@ const (
 
 type Pod struct {
 	*corev1.Pod
-	Containers         []*Container
-	MultusIPs          map[string][]string
-	MultusPCIs         []string
-	SkipNetTests       bool
-	SkipMultusNetTests bool
+	Containers              []*Container
+	MultusNetworkInterfaces map[string][]CniNetworkInterface
+	MultusPCIs              []string
+	SkipNetTests            bool
+	SkipMultusNetTests      bool
 }
 
 func NewPod(aPod *corev1.Pod) (out Pod) {
 	var err error
 	out.Pod = aPod
-	out.MultusIPs = make(map[string][]string)
-	out.MultusIPs, err = GetPodIPsPerNet(aPod.GetAnnotations()[CniNetworksStatusKey])
+	out.MultusNetworkInterfaces = make(map[string][]CniNetworkInterface)
+	out.MultusNetworkInterfaces, err = GetPodIPsPerNet(aPod.GetAnnotations()[CniNetworksStatusKey])
 	if err != nil {
 		log.Error("Could not get IPs for Pod %q (namespace %q), err: %v", aPod.Name, aPod.Namespace, err)
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -134,7 +134,7 @@ type MachineConfig struct {
 	} `json:"config"`
 }
 
-type cniNetworkInterface struct {
+type CniNetworkInterface struct {
 	Name       string                 `json:"name"`
 	Interface  string                 `json:"interface"`
 	IPs        []string               `json:"ips"`
@@ -447,13 +447,13 @@ func GetRuntimeUID(cs *corev1.ContainerStatus) (runtime, uid string) {
 // GetPodIPsPerNet gets the IPs of a pod.
 // CNI annotation "k8s.v1.cni.cncf.io/networks-status".
 // Returns (ips, error).
-func GetPodIPsPerNet(annotation string) (ips map[string][]string, err error) {
+func GetPodIPsPerNet(annotation string) (ips map[string][]CniNetworkInterface, err error) {
 	// This is a map indexed with the network name (network attachment) and
 	// listing all the IPs created in this subnet and belonging to the pod namespace
 	// The list of ips pr net is parsed from the content of the "k8s.v1.cni.cncf.io/networks-status" annotation.
-	ips = make(map[string][]string)
+	ips = make(map[string][]CniNetworkInterface)
 
-	var cniInfo []cniNetworkInterface
+	var cniInfo []CniNetworkInterface
 	err = json.Unmarshal([]byte(annotation), &cniInfo)
 	if err != nil {
 		return nil, fmt.Errorf("could not unmarshal network-status annotation, err: %v", err)
@@ -462,14 +462,14 @@ func GetPodIPsPerNet(annotation string) (ips map[string][]string, err error) {
 	// Otherwise add all non default interfaces
 	for _, cniInterface := range cniInfo {
 		if !cniInterface.Default {
-			ips[cniInterface.Name] = cniInterface.IPs
+			ips[cniInterface.Name] = append(ips[cniInterface.Name], cniInterface)
 		}
 	}
 	return ips, nil
 }
 
 func GetPciPerPod(annotation string) (pciAddr []string, err error) {
-	var cniInfo []cniNetworkInterface
+	var cniInfo []CniNetworkInterface
 	err = json.Unmarshal([]byte(annotation), &cniInfo)
 	if err != nil {
 		return nil, fmt.Errorf("could not unmarshal network-status annotation, err: %v", err)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -447,11 +447,11 @@ func GetRuntimeUID(cs *corev1.ContainerStatus) (runtime, uid string) {
 // GetPodIPsPerNet gets the IPs of a pod.
 // CNI annotation "k8s.v1.cni.cncf.io/networks-status".
 // Returns (ips, error).
-func GetPodIPsPerNet(annotation string) (ips map[string][]CniNetworkInterface, err error) {
+func GetPodIPsPerNet(annotation string) (ips map[string]CniNetworkInterface, err error) {
 	// This is a map indexed with the network name (network attachment) and
 	// listing all the IPs created in this subnet and belonging to the pod namespace
 	// The list of ips pr net is parsed from the content of the "k8s.v1.cni.cncf.io/networks-status" annotation.
-	ips = make(map[string][]CniNetworkInterface)
+	ips = make(map[string]CniNetworkInterface)
 
 	var cniInfo []CniNetworkInterface
 	err = json.Unmarshal([]byte(annotation), &cniInfo)
@@ -462,7 +462,7 @@ func GetPodIPsPerNet(annotation string) (ips map[string][]CniNetworkInterface, e
 	// Otherwise add all non default interfaces
 	for _, cniInterface := range cniInfo {
 		if !cniInterface.Default {
-			ips[cniInterface.Name] = append(ips[cniInterface.Name], cniInterface)
+			ips[cniInterface.Name] = cniInterface
 		}
 	}
 	return ips, nil


### PR DESCRIPTION
Changes include:
- Changing `MultusIPs: map[string][]string` to `MultusNetworkInterfaces: map[string][]provider.CniNetworkInterface`.
- Making `provider.CniNetworkInterface` struct public.
- Modifying the TestPing() func to accept interface name.