### PR TITLE
Github ci: fixed example label for operators autodiscovery.

### DIFF
--- a/cnf-certification-test/tnf_config.yml
+++ b/cnf-certification-test/tnf_config.yml
@@ -3,8 +3,8 @@ targetNameSpaces:
 podsUnderTestLabels:
   - "test-network-function.com/generic: target"
 operatorsUnderTestLabels:
-  - "test-network-function.com/operator:"
-  - "test-network-function.com/operator1:new" 
+  - "test-network-function.com/operator:target"
+  - "test-network-function.com/operator1:new"
 targetCrdFilters:
   - nameSuffix: "group1.test.com"
     scalable: false


### PR DESCRIPTION
@jmontesi noticed that we're skipping too many test cases in the smoke tests of github CI.

I've been reviewing the operator test suite ones: no operators (csvs) were tested because of a misalignment in the expected labels in the csv. This started happening when the default/deprecated label was finally remvoed in PR #1760.