### PR TITLE
workflows: use the tnf check command instead of the gradetool

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -13,8 +13,6 @@ env:
   TNF_IMAGE_TAG: unstable
   OCT_IMAGE_NAME: testnetworkfunction/oct
   OCT_IMAGE_TAG: latest
-  GRADETOOL_IMAGE_NAME: testnetworkfunction/gradetool
-  GRADETOOL_IMAGE_TAG: latest
   TNF_CONTAINER_CLIENT: docker
   TNF_NON_INTRUSIVE_ONLY: false
   TNF_ALLOW_PREFLIGHT_INSECURE: false
@@ -275,28 +273,8 @@ jobs:
       - name: Remove tarball(s) to save disk space.
         run: rm -f cnf-certification-test/*.tar.gz
 
-      - name: Run gradetool on the claim.json.
-        run: |
-          docker run \
-            --rm \
-            --volume "${GITHUB_WORKSPACE}"/generated_policy.json:/policy.json \
-            --volume "${GITHUB_WORKSPACE}"/cnf-certification-test/claim.json:/claim.json \
-            ${REGISTRY}/${GRADETOOL_IMAGE_NAME}:${GRADETOOL_IMAGE_TAG} \
-              --OutputPath results.txt \
-              --policy /policy.json \
-              --results /claim.json \
-              >"${GITHUB_WORKSPACE}"/results.txt
-          docker system prune --volumes -f
-
-      - name: Check that their are 0 failed tests in the gradetool results
-        run: |
-          if $(jq '.[] | .Fail | length' "${GITHUB_WORKSPACE}"/results.txt | grep -q 0); then
-            echo OK
-          else
-            echo "Gradetool has found failing tests in the following:"
-            jq '.[] | .Fail | .[].id' "${GITHUB_WORKSPACE}"/results.txt
-            exit 1
-          fi
+      - name: Check the smoke test results against the expected results template
+        run: make check-results
 
       - name: 'Test: Run preflight specific test suite'
         run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./run-cnf-suites.sh -l "preflight"
@@ -465,28 +443,8 @@ jobs:
       - name: Remove tarball(s) to save disk space.
         run: rm -f ${{ env.TNF_OUTPUT_DIR }}/*.tar.gz
 
-      - name: Run gradetool on the claim.json.
-        run: |
-          docker run \
-            --rm \
-            --volume "${GITHUB_WORKSPACE}"/generated_policy.json:/policy.json \
-            --volume "${TNF_OUTPUT_DIR}"/claim.json:/claim.json \
-            ${REGISTRY}/${GRADETOOL_IMAGE_NAME}:${GRADETOOL_IMAGE_TAG} \
-              --OutputPath results.txt \
-              --policy /policy.json \
-              --results /claim.json \
-              >"${GITHUB_WORKSPACE}"/results.txt
-          docker system prune --volumes -f
-
-      - name: Check that their are 0 failed tests in the gradetool results
-        run: |
-          if $(jq '.[] | .Fail | length' "${GITHUB_WORKSPACE}"/results.txt | grep -q 0); then
-            echo OK
-          else
-            echo "Gradetool has found failing tests in the following:"
-            jq '.[] | .Fail | .[].id' "${GITHUB_WORKSPACE}"/results.txt
-            exit 1
-          fi
+      - name: Check the smoke test results against the expected results template
+        run: make check-results
 
       - name: 'Test: Run Preflight Specific Smoke Tests in a TNF container'
         run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./run-tnf-container.sh ${{ env.TESTING_CMD_PARAMS }} -l "preflight"

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -273,6 +273,9 @@ jobs:
       - name: Remove tarball(s) to save disk space.
         run: rm -f cnf-certification-test/*.tar.gz
 
+      - name: Build the TNF tool
+        run: make build-tnf-tool
+
       - name: Check the smoke test results against the expected results template
         run: make check-results
 
@@ -442,6 +445,9 @@ jobs:
 
       - name: Remove tarball(s) to save disk space.
         run: rm -f ${{ env.TNF_OUTPUT_DIR }}/*.tar.gz
+
+      - name: Build the TNF tool
+        run: make build-tnf-tool
 
       - name: Check the smoke test results against the expected results template
         run: make check-results

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -450,7 +450,7 @@ jobs:
         run: make build-tnf-tool
 
       - name: Check the smoke test results against the expected results template
-        run: make check-results
+        run: ./tnf check results --log-file="${TNF_OUTPUT_DIR}"/cnf-certsuite.log
 
       - name: 'Test: Run Preflight Specific Smoke Tests in a TNF container'
         run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./run-tnf-container.sh ${{ env.TESTING_CMD_PARAMS }} -l "preflight"

--- a/Makefile
+++ b/Makefile
@@ -172,3 +172,6 @@ build-image-tnf:
 
 results-html:
 	script/get-results-html.sh ${PARSER_RELEASE}
+
+check-results:
+	./tnf check results


### PR DESCRIPTION
The "tnf check results" command verifies that the test results are equal to the expected results found in a template file.

It provides a simpler and more integrated way of verification than the external gradetool.