### PR TITLE
Update oct to v0.0.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -218,7 +218,7 @@ require (
 	github.com/openshift/machine-config-operator v0.0.1-0.20230515070935-49f32d46538e
 	github.com/redhat-openshift-ecosystem/openshift-preflight v0.0.0-20240130151146-4c9ea7cbd33f
 	github.com/robert-nix/ansihtml v1.0.1
-	github.com/test-network-function/oct v0.0.5
+	github.com/test-network-function/oct v0.0.6
 	github.com/test-network-function/privileged-daemonset v1.0.21
 	golang.org/x/term v0.17.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -456,6 +456,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/test-network-function/oct v0.0.5 h1:rZJh5QMzgPxfaMCTXBULuk5P8BqKdlabZV2b+M4PVus=
 github.com/test-network-function/oct v0.0.5/go.mod h1:2AJTqEvBLYb/zFl5EiuFrrMl+TvXUVACqPmgf0q4JtQ=
+github.com/test-network-function/oct v0.0.6 h1:iRJ5CUjXzrfdeFQ1dsKFrLc5aiAau/URPiM526jlQWk=
+github.com/test-network-function/oct v0.0.6/go.mod h1:ywRnblvVfLDVzpqk3hUiKxeu99xB6jlVKCmagoYf2c4=
 github.com/test-network-function/privileged-daemonset v1.0.21 h1:uC+sW7OFxd5UYQEizlzYnKVtjVef/wBKGaHlP1QtmvE=
 github.com/test-network-function/privileged-daemonset v1.0.21/go.mod h1:xWMllRvSyDUvFUFOGob8erHBgSe0xoKL140QcYeTdJc=
 github.com/test-network-function/test-network-function-claim v1.0.34 h1:OoCvKueaOlKL6n4BSQaDkIsYe0usaXy9dSJZjEY1Qqc=


### PR DESCRIPTION
For some reason the dependabot isn't finding `v0.0.6` as a release.  Manually running the update.

https://github.com/test-network-function/oct/releases/tag/v0.0.6 