### PR TITLE
Update GolangCI-lint to v1.56.2

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.55
+          version: v1.56
           args: --timeout 10m0s
 
       - name: Checkmake

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,7 +72,6 @@ linters:
     - lll
     - misspell
     - nolintlint
-    - revive
     - rowserrcheck
     - staticcheck
     - stylecheck
@@ -96,6 +95,7 @@ linters:
   # - nestif
   # - noctx
   # - prealloc
+  # - revive
   # - exportloopref
   # - structcheck
   # - testpackage
@@ -123,6 +123,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.55.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.56.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ GIT_COMMIT=$(shell script/create-version-files.sh)
 GIT_RELEASE=$(shell script/get-git-release.sh)
 GIT_PREVIOUS_RELEASE=$(shell script/get-git-previous-release.sh)
 CLAIM_FORMAT_VERSION=$(shell script/get-claim-version.sh)
-GOLANGCI_VERSION=v1.55.1
+GOLANGCI_VERSION=v1.56.2
 LINKER_TNF_RELEASE_FLAGS=-X github.com/test-network-function/cnf-certification-test/pkg/versions.GitCommit=${GIT_COMMIT}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/pkg/versions.GitRelease=${GIT_RELEASE}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/pkg/versions.GitPreviousRelease=${GIT_PREVIOUS_RELEASE}

--- a/docs/test-standalone.md
+++ b/docs/test-standalone.md
@@ -28,7 +28,7 @@ need to be installed in your environment prior to runtime.
 Dependency|Minimum Version
 ---|---
 [GoLang](https://golang.org/dl/)|1.21
-[golangci-lint](https://golangci-lint.run/usage/install/)|1.55.1
+[golangci-lint](https://golangci-lint.run/usage/install/)|1.56.2
 [jq](https://stedolan.github.io/jq/)|1.6
 [OpenShift Client](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/)|4.12
 


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.56.2 

I had to disable the `revive` linter because it was flagging unit testing func calls that are mocked.