### PR TITLE
autodiscover: modify Istio Service Mesh detection

### DIFF
--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -191,7 +191,6 @@ func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData 
 		log.Error("Cannot get the K8s version, err: %v", err)
 		os.Exit(1)
 	}
-	data.IstioServiceMeshFound = isIstioServiceMeshInstalled(data.AllNamespaces)
 	data.ValidProtocolNames = config.ValidProtocolNames
 	data.ServicesIgnoreList = config.ServicesIgnoreList
 
@@ -201,6 +200,10 @@ func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData 
 	data.K8sVersion = k8sVersion.GitVersion
 	data.Deployments = findDeploymentByLabel(oc.K8sClient.AppsV1(), podsUnderTestLabelsObjects, data.Namespaces)
 	data.StatefulSet = findStatefulSetByLabel(oc.K8sClient.AppsV1(), podsUnderTestLabelsObjects, data.Namespaces)
+
+	// Check if the Istio Service Mesh is present
+	data.IstioServiceMeshFound = isIstioServiceMeshInstalled(oc.K8sClient.AppsV1(), data.AllNamespaces)
+
 	// Find ClusterRoleBindings
 	clusterRoleBindings, err := getClusterRoleBindings(oc.K8sClient.RbacV1())
 	if err != nil {


### PR DESCRIPTION
The Istio Service Mesh detection required a two step process:
  1) Check for the existence of the "istio-system" namespace.
  2) Check for the presence of a CR from the Istio Operator called
     "installed-state".

But it has been reported that when Istio is installed using the Helm chart method this CR is not created. So, the step 2 above has been replaced for checking the presence of the "istiod" Deployment, which is in charge of running the Istio discovery service.