### PR TITLE
Add configuration field for collector's endpoint

### DIFF
--- a/cnf-certification-test/tnf_config.yml
+++ b/cnf-certification-test/tnf_config.yml
@@ -38,3 +38,4 @@ servicesignorelist:
 executedBy: ""
 partnerName: ""
 collectorAppPassword: ""
+collectorAppEndpoint: "http://claims-collector.cnf-certifications.sysdeseng.com"

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -92,6 +92,7 @@ type DiscoveredTestData struct {
 	ExecutedBy             string
 	PartnerName            string
 	CollectorAppPassword   string
+	CollectorAppEndpoint   string
 }
 
 type labelObject struct {
@@ -250,6 +251,7 @@ func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData 
 	data.ExecutedBy = config.ExecutedBy
 	data.PartnerName = config.PartnerName
 	data.CollectorAppPassword = config.CollectorAppPassword
+	data.CollectorAppEndpoint = config.CollectorAppEndpoint
 
 	return data
 }

--- a/pkg/certsuite/certsuite.go
+++ b/pkg/certsuite/certsuite.go
@@ -48,7 +48,7 @@ func LoadChecksDB(labelsExpr string) {
 
 const (
 	junitXMLOutputFileName = "cnf-certification-tests_junit.xml"
-	collectorAppEndPoint   = "http://44.195.143.94"
+	collectorAppDNS        = "http://claims-collector.cnf-certifications.sysdeseng.com"
 )
 
 func getK8sClientsConfigFileNames() []string {
@@ -150,7 +150,10 @@ func Run(labelsFilter, outputFolder string) error {
 
 	// Send claim file to the collector if specified by env var
 	if configuration.GetTestParameters().EnableDataCollection {
-		err = collector.SendClaimFileToCollector(collectorAppEndPoint, claimOutputFile, env.ExecutedBy, env.PartnerName, env.CollectorAppPassword)
+		if env.CollectorAppEndpoint == "" {
+			env.CollectorAppEndpoint = collectorAppDNS
+		}
+		err = collector.SendClaimFileToCollector(env.CollectorAppEndpoint, claimOutputFile, env.ExecutedBy, env.PartnerName, env.CollectorAppPassword)
 		if err != nil {
 			log.Error("Failed to send post request to the collector: %v", err)
 		}

--- a/pkg/certsuite/certsuite.go
+++ b/pkg/certsuite/certsuite.go
@@ -48,7 +48,7 @@ func LoadChecksDB(labelsExpr string) {
 
 const (
 	junitXMLOutputFileName = "cnf-certification-tests_junit.xml"
-	collectorAppDNS        = "http://claims-collector.cnf-certifications.sysdeseng.com"
+	collectorAppURL        = "http://claims-collector.cnf-certifications.sysdeseng.com"
 )
 
 func getK8sClientsConfigFileNames() []string {
@@ -151,7 +151,7 @@ func Run(labelsFilter, outputFolder string) error {
 	// Send claim file to the collector if specified by env var
 	if configuration.GetTestParameters().EnableDataCollection {
 		if env.CollectorAppEndpoint == "" {
-			env.CollectorAppEndpoint = collectorAppDNS
+			env.CollectorAppEndpoint = collectorAppURL
 		}
 		err = collector.SendClaimFileToCollector(env.CollectorAppEndpoint, claimOutputFile, env.ExecutedBy, env.PartnerName, env.CollectorAppPassword)
 		if err != nil {

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -89,6 +89,7 @@ type TestConfiguration struct {
 	ExecutedBy           string `yaml:"executedBy,omitempty" json:"executedBy,omitempty"`
 	PartnerName          string `yaml:"partnerName,omitempty" json:"partnerName,omitempty"`
 	CollectorAppPassword string `yaml:"collectorAppPassword,omitempty" json:"collectorAppPassword,omitempty"`
+	CollectorAppEndpoint string `yaml:"collectorAppEndpoint,omitempty" json:"collectorAppEndpoint,omitempty"`
 }
 
 type TestParameters struct {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -119,6 +119,7 @@ type TestEnvironment struct { // rename this with testTarget
 	ExecutedBy             string
 	PartnerName            string
 	CollectorAppPassword   string
+	CollectorAppEndpoint   string
 	SkipPreflight          bool
 }
 
@@ -298,6 +299,7 @@ func buildTestEnvironment() { //nolint:funlen
 	env.ExecutedBy = data.ExecutedBy
 	env.PartnerName = data.PartnerName
 	env.CollectorAppPassword = data.CollectorAppPassword
+	env.CollectorAppEndpoint = data.CollectorAppEndpoint
 
 	operators := createOperators(data.Csvs, data.Subscriptions, data.AllInstallPlans, data.AllCatalogSources, false, true)
 	env.Operators = operators


### PR DESCRIPTION
Configuration field for collector's endpoint was added to `tnf_config.yaml`.
In addition, prod collector's DNS was set as the default endpoint.