### PR TITLE
Avoid unnecessary rebuild of the test environment

### DIFF
--- a/cnf-certification-test/preflight/suite.go
+++ b/cnf-certification-test/preflight/suite.go
@@ -193,7 +193,7 @@ func generatePreflightOperatorCnfCertTest(checksGroup *checksdb.ChecksGroup, tes
 	}, identifiers.TagPreflight)
 
 	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(aID)).
-		WithSkipCheckFn(testhelper.GetNoContainersUnderTestSkipFn(&env)).
+		WithSkipCheckFn(testhelper.GetNoOperatorsSkipFn(&env)).
 		WithCheckFn(func(check *checksdb.Check) error {
 			var compliantObjects []*testhelper.ReportObject
 			var nonCompliantObjects []*testhelper.ReportObject

--- a/cnf-certification-test/preflight/suite.go
+++ b/cnf-certification-test/preflight/suite.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"strings"
 
-	plibRuntime "github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/common"
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/identifiers"
 	"github.com/test-network-function/cnf-certification-test/internal/log"
@@ -110,13 +109,13 @@ func testPreflightOperators(checksGroup *checksdb.ChecksGroup, env *provider.Tes
 	// Note: We only care about the `testEntry` variable below because we need its 'Description' and 'Suggestion' variables.
 	for testName, testEntry := range getUniqueTestEntriesFromOperatorResults(env.Operators) {
 		log.Info("Setting Preflight operator test results for %q", testName)
-		generatePreflightOperatorCnfCertTest(checksGroup, testName, testEntry.Metadata().Description, testEntry.Help().Suggestion, env.Operators)
+		generatePreflightOperatorCnfCertTest(checksGroup, testName, testEntry.Description, testEntry.Remediation, env.Operators)
 	}
 }
 
 func testPreflightContainers(checksGroup *checksdb.ChecksGroup, env *provider.TestEnvironment) {
 	// Using a cache to prevent unnecessary processing of images if we already have the results available
-	preflightImageCache := make(map[string]plibRuntime.Results)
+	preflightImageCache := make(map[string]provider.PreflightResultsDB)
 
 	// Loop through all of the containers, run preflight, and set their results into their respective objects
 	for _, cut := range env.Containers {
@@ -133,17 +132,17 @@ func testPreflightContainers(checksGroup *checksdb.ChecksGroup, env *provider.Te
 	// Note: We only care about the `testEntry` variable below because we need its 'Description' and 'Suggestion' variables.
 	for testName, testEntry := range getUniqueTestEntriesFromContainerResults(env.Containers) {
 		log.Info("Setting Preflight container test results for %q", testName)
-		generatePreflightContainerCnfCertTest(checksGroup, testName, testEntry.Metadata().Description, testEntry.Help().Suggestion, env.Containers)
+		generatePreflightContainerCnfCertTest(checksGroup, testName, testEntry.Description, testEntry.Remediation, env.Containers)
 	}
 }
 
 // func generatePreflightContainerCnfCertTest(testName, testID string, tags []string, containers []*provider.Container) {
-func generatePreflightContainerCnfCertTest(checksGroup *checksdb.ChecksGroup, testName, description, suggestion string, containers []*provider.Container) {
+func generatePreflightContainerCnfCertTest(checksGroup *checksdb.ChecksGroup, testName, description, remediation string, containers []*provider.Container) {
 	// Based on a single test "name", we will be passing/failing in our test framework.
 	// Brute force-ish type of method.
 
 	// Store the test names into the Catalog map for results to be dynamically printed
-	aID := identifiers.AddCatalogEntry(testName, common.PreflightTestKey, description, suggestion, "", "", false, map[string]string{
+	aID := identifiers.AddCatalogEntry(testName, common.PreflightTestKey, description, remediation, "", "", false, map[string]string{
 		identifiers.FarEdge:  identifiers.Optional,
 		identifiers.Telco:    identifiers.Optional,
 		identifiers.NonTelco: identifiers.Optional,
@@ -157,21 +156,21 @@ func generatePreflightContainerCnfCertTest(checksGroup *checksdb.ChecksGroup, te
 			var nonCompliantObjects []*testhelper.ReportObject
 			for _, cut := range containers {
 				for _, r := range cut.PreflightResults.Passed {
-					if r.Name() == testName {
+					if r.Name == testName {
 						check.LogInfo("Container %q has passed Preflight test %q", cut, testName)
 						compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container has passed preflight test "+testName, true))
 					}
 				}
 				for _, r := range cut.PreflightResults.Failed {
-					if r.Name() == testName {
+					if r.Name == testName {
 						check.LogError("Container %q has failed Preflight test %q", cut, testName)
 						nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container has failed preflight test "+testName, false))
 					}
 				}
 				for _, r := range cut.PreflightResults.Errors {
-					if r.Name() == testName {
-						check.LogError("Container %q has errored Preflight test %q", cut, testName)
-						nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, fmt.Sprintf("Container has errored preflight test %s, err=%v", testName, r.Error()), false))
+					if r.Name == testName {
+						check.LogError("Container %q has errored Preflight test %q, err: %v", cut, testName, r.Error)
+						nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, fmt.Sprintf("Container has errored preflight test %s, err: %v", testName, r.Error), false))
 					}
 				}
 			}
@@ -181,12 +180,12 @@ func generatePreflightContainerCnfCertTest(checksGroup *checksdb.ChecksGroup, te
 		}))
 }
 
-func generatePreflightOperatorCnfCertTest(checksGroup *checksdb.ChecksGroup, testName, description, suggestion string, operators []*provider.Operator) {
+func generatePreflightOperatorCnfCertTest(checksGroup *checksdb.ChecksGroup, testName, description, remediation string, operators []*provider.Operator) {
 	// Based on a single test "name", we will be passing/failing in our test framework.
 	// Brute force-ish type of method.
 
 	// Store the test names into the Catalog map for results to be dynamically printed
-	aID := identifiers.AddCatalogEntry(testName, common.PreflightTestKey, description, suggestion, "", "", false, map[string]string{
+	aID := identifiers.AddCatalogEntry(testName, common.PreflightTestKey, description, remediation, "", "", false, map[string]string{
 		identifiers.FarEdge:  identifiers.Optional,
 		identifiers.Telco:    identifiers.Optional,
 		identifiers.NonTelco: identifiers.Optional,
@@ -201,21 +200,21 @@ func generatePreflightOperatorCnfCertTest(checksGroup *checksdb.ChecksGroup, tes
 
 			for _, op := range operators {
 				for _, r := range op.PreflightResults.Passed {
-					if r.Name() == testName {
+					if r.Name == testName {
 						check.LogInfo("Operator %q has passed Preflight test %q", op, testName)
 						compliantObjects = append(compliantObjects, testhelper.NewOperatorReportObject(op.Namespace, op.Name, "Operator passed preflight test "+testName, true))
 					}
 				}
 				for _, r := range op.PreflightResults.Failed {
-					if r.Name() == testName {
+					if r.Name == testName {
 						check.LogError("Operator %q has failed Preflight test %q", op, testName)
 						nonCompliantObjects = append(nonCompliantObjects, testhelper.NewOperatorReportObject(op.Namespace, op.Name, "Operator failed preflight test "+testName, false))
 					}
 				}
 				for _, r := range op.PreflightResults.Errors {
-					if r.Name() == testName {
-						check.LogError("Operator %q has errored Preflight test %q", op, testName)
-						nonCompliantObjects = append(nonCompliantObjects, testhelper.NewOperatorReportObject(op.Namespace, op.Name, "Operator has errored preflight test "+testName, false))
+					if r.Name == testName {
+						check.LogError("Operator %q has errored Preflight test %q, err: %v", op, testName, r.Error)
+						nonCompliantObjects = append(nonCompliantObjects, testhelper.NewOperatorReportObject(op.Namespace, op.Name, fmt.Sprintf("Operator has errored preflight test %s, err: %v", testName, r.Error), false))
 					}
 				}
 			}
@@ -225,37 +224,37 @@ func generatePreflightOperatorCnfCertTest(checksGroup *checksdb.ChecksGroup, tes
 		}))
 }
 
-func getUniqueTestEntriesFromContainerResults(containers []*provider.Container) map[string]plibRuntime.Result {
-	// If containers are sharing the same image, they should "presumably" have the same results returned from preflight.
-	testEntries := make(map[string]plibRuntime.Result)
+func getUniqueTestEntriesFromContainerResults(containers []*provider.Container) map[string]provider.PreflightTest {
+	// If containers are sharing the same image, they should "presumably" have the same results returned from Preflight.
+	testEntries := make(map[string]provider.PreflightTest)
 	for _, cut := range containers {
 		for _, r := range cut.PreflightResults.Passed {
-			testEntries[r.Name()] = r
+			testEntries[r.Name] = r
 		}
 		// Failed Results have more information than the rest
 		for _, r := range cut.PreflightResults.Failed {
-			testEntries[r.Name()] = r
+			testEntries[r.Name] = r
 		}
 		for _, r := range cut.PreflightResults.Errors {
-			testEntries[r.Name()] = r
+			testEntries[r.Name] = r
 		}
 	}
 
 	return testEntries
 }
 
-func getUniqueTestEntriesFromOperatorResults(operators []*provider.Operator) map[string]plibRuntime.Result {
-	testEntries := make(map[string]plibRuntime.Result)
+func getUniqueTestEntriesFromOperatorResults(operators []*provider.Operator) map[string]provider.PreflightTest {
+	testEntries := make(map[string]provider.PreflightTest)
 	for _, op := range operators {
 		for _, r := range op.PreflightResults.Passed {
-			testEntries[r.Name()] = r
+			testEntries[r.Name] = r
 		}
 		// Failed Results have more information than the rest
 		for _, r := range op.PreflightResults.Failed {
-			testEntries[r.Name()] = r
+			testEntries[r.Name] = r
 		}
 		for _, r := range op.PreflightResults.Errors {
-			testEntries[r.Name()] = r
+			testEntries[r.Name] = r
 		}
 	}
 	return testEntries

--- a/pkg/certsuite/certsuite.go
+++ b/pkg/certsuite/certsuite.go
@@ -113,9 +113,8 @@ func Run(labelsFilter, outputFolder string) error {
 
 	fmt.Println("Running discovery of CNF target resources...")
 	fmt.Print("\n")
-	var env provider.TestEnvironment
-	env.SetNeedsRefresh()
-	env = provider.GetTestEnvironment()
+
+	env := provider.GetTestEnvironment()
 
 	claimBuilder, err := claimhelper.NewClaimBuilder()
 	if err != nil {

--- a/pkg/provider/containers.go
+++ b/pkg/provider/containers.go
@@ -64,7 +64,7 @@ type Container struct {
 	Runtime                  string
 	UID                      string
 	ContainerImageIdentifier ContainerImageIdentifier
-	PreflightResults         plibRuntime.Results
+	PreflightResults         PreflightResultsDB
 }
 
 func NewContainer() *Container {
@@ -87,7 +87,7 @@ func (c *Container) GetUID() (string, error) {
 	return uid, nil
 }
 
-func (c *Container) SetPreflightResults(preflightImageCache map[string]plibRuntime.Results, env *TestEnvironment) error {
+func (c *Container) SetPreflightResults(preflightImageCache map[string]PreflightResultsDB, env *TestEnvironment) error {
 	log.Info("Running Preflight container test for container %q with image %q", c, c.Image)
 
 	// Short circuit if the image already exists in the cache
@@ -135,12 +135,13 @@ func (c *Container) SetPreflightResults(preflightImageCache map[string]plibRunti
 		}
 	}
 
-	// Take all of the preflight logs and stick them into our log.
+	// Take all of the Preflight logs and stick them into our log.
 	log.Info(logbytes.String())
 
-	// Store the result into the cache and store the Results into the container's PreflightResults var.
-	preflightImageCache[c.Image] = results
-	c.PreflightResults = preflightImageCache[c.Image]
+	// Store the Preflight test results into the container's PreflightResults var and into the cache.
+	resultsDB := GetPreflightResultsDB(&results)
+	c.PreflightResults = resultsDB
+	preflightImageCache[c.Image] = resultsDB
 	return nil
 }
 

--- a/pkg/provider/operators.go
+++ b/pkg/provider/operators.go
@@ -52,7 +52,7 @@ type Operator struct {
 	Version               string                                `yaml:"version" json:"version"`
 	Channel               string                                `yaml:"channel" json:"channel"`
 	PackageFromCsvName    string                                `yaml:"packagefromcsvname" json:"packagefromcsvname"`
-	PreflightResults      plibRuntime.Results
+	PreflightResults      PreflightResultsDB
 }
 
 type CsvInstallPlan struct {
@@ -123,7 +123,7 @@ func (op *Operator) SetPreflightResults(env *TestEnvironment) error {
 	}
 
 	log.Info("Storing operator Preflight results into object for %q", bundleImage)
-	op.PreflightResults = results
+	op.PreflightResults = GetPreflightResultsDB(&results)
 	return nil
 }
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -29,6 +29,7 @@ import (
 
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	olmv1Alpha "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	plibRuntime "github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/internal/log"
 	"github.com/test-network-function/cnf-certification-test/pkg/autodiscover"
@@ -157,6 +158,18 @@ type deviceInfo struct {
 
 type pci struct {
 	PciAddress string `json:"pci-address"`
+}
+type PreflightTest struct {
+	Name        string
+	Description string
+	Remediation string
+	Error       error
+}
+
+type PreflightResultsDB struct {
+	Passed []PreflightTest
+	Failed []PreflightTest
+	Errors []PreflightTest
 }
 
 var (
@@ -597,4 +610,22 @@ func (env *TestEnvironment) GetBaremetalNodes() []Node {
 		}
 	}
 	return baremetalNodes
+}
+
+func GetPreflightResultsDB(results *plibRuntime.Results) PreflightResultsDB {
+	resultsDB := PreflightResultsDB{}
+	for _, res := range results.Passed {
+		test := PreflightTest{Name: res.Name(), Description: res.Metadata().Description, Remediation: res.Help().Suggestion}
+		resultsDB.Passed = append(resultsDB.Passed, test)
+	}
+	for _, res := range results.Failed {
+		test := PreflightTest{Name: res.Name(), Description: res.Metadata().Description, Remediation: res.Help().Suggestion}
+		resultsDB.Failed = append(resultsDB.Failed, test)
+	}
+	for _, res := range results.Errors {
+		test := PreflightTest{Name: res.Name(), Description: res.Metadata().Description, Remediation: res.Help().Suggestion, Error: res.Error()}
+		resultsDB.Errors = append(resultsDB.Errors, test)
+	}
+
+	return resultsDB
 }


### PR DESCRIPTION
The logs show that the test environment is built twice before starting running the test cases, which should not be necessary. However, disabling this rebuild of the test environment lead to an error while marshaling the `TestConfiguration` to JSON format. This PR refactors the way the Preflight test results are processed in order to produce an output of the test environment adequate for JSON marshaling without the need to rebuild it.

The problem came with the direct addition of the struct `plibRuntime.Results` into our `Container` struct. This former struct contains an interface that prevents the struct to be properly transformed to JSON. To solve this issue, another struct called `PreflightResultsDB` that only contains the information needed has been used instead. 

The test environment rebuild hid this problem because the Preflight results were cleared in the process, allowing the JSON marshaling to work correctly. The results could be retrieved later (even after being cleared) due to the fact that the old results were stored in the closure that contains the test function (defined in `WithCheckFn()`). 