### PR TITLE
Changed alert msg to be sent to a slack webhook.

### DIFF
--- a/.github/actions/slack-webhook-sender/action.yml
+++ b/.github/actions/slack-webhook-sender/action.yml
@@ -1,0 +1,34 @@
+name: slack-webhook-sender
+description: 'Sends a slack message plus some more workflow job related fields to a slack webhook endpoint.'
+inputs:
+  message:
+    description: 'Text that will be send in the json .message field.'
+    required: true
+    default: 'Hello, world!'
+  slack_webhook:
+    description: 'Slack webhook where the data will be posted.'
+    required: true
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Post message data to slack's webhook url.
+      shell: bash
+      env:
+        MESSAGE: ${{ inputs.message }}
+        REPO_URL: 'https://github.com/${{ github.repository }}'
+        COMMIT_URL: 'https://github.com/${{ github.repository }}/commit/${{ github.sha }}'
+        JOB_URL: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}'
+        ATTEMPT: ${{ github.run_attempt }}
+      run: |
+          data="{                              \
+            \"message\"   : \"${MESSAGE}\",    \
+            \"repo_url\"  : \"${REPO_URL}\",   \
+            \"job_url\"   : \"${JOB_URL}\",    \
+            \"commit_url\": \"${COMMIT_URL}\", \
+            \"attempt\"   : \"${ATTEMPT}\"     \
+          }"
+
+          echo "Sending alert message data to slack webhook: $(echo $data | jq)"
+          curl -X POST --data "${data}" -H 'Content-type: application/json; charset=UTF-8' '${{ inputs.slack_webhook }}'

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -467,15 +467,10 @@ jobs:
 
       - name: (if on main and upstream) Send chat msg to dev team if failed to create container image.
         if: ${{ failure() && github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
-        env:
-          COMMIT_SHA: ${{ github.sha }}
-          JOB_RUN_ID: ${{ github.run_id }}
-          JOB_RUN_ATTEMPT: ${{ github.run_attempt }}
-          GITHUB_REPO: https://github.com/test-network-function/cnf-certification-test
-        run: |
-          curl -X POST --data "{
-              \"text\": \"🚨⚠️  Failed to create \`unstable\` container image from commit \<$GITHUB_REPO/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<$GITHUB_REPO/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"
-          }" -H 'Content-type: application/json; charset=UTF-8' '${{ secrets.GCHAT_WEBHOOK_URL }}'
+        uses: ./.github/actions/slack-webhook-sender
+        with:
+          message: 'Failed to create the *unstable* container image'
+          slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'
 
       # Push the new unstable TNF image to Quay.io.
       - name: (if on main and upstream) Authenticate against Quay.io

--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -136,12 +136,7 @@ jobs:
 
       - name: If failed to create the image, send alert msg to dev team.
         if: ${{ failure() }}
-        env:
-          COMMIT_SHA: ${{ github.sha }}
-          JOB_RUN_ID: ${{ github.run_id }}
-          JOB_RUN_ATTEMPT: ${{ github.run_attempt }}
-          GITHUB_REPO: 'https://github.com/${{ github.repository }}'
-        run: |
-          curl -X POST --data "{
-            \"text\": \"🚨⚠️  Failed to create container image version \`$TNF_VERSION\` from commit \<$GITHUB_REPO/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<$GITHUB_REPO/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"
-          }" -H 'Content-type: application/json; charset=UTF-8' '${{ secrets.GCHAT_WEBHOOK_URL }}'
+        uses: ./.github/actions/slack-webhook-sender
+        with:
+          message: 'Failed to create official container image version ${{ env.TNF_VERSION }}'
+          slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'


### PR DESCRIPTION
Created an action that sends a customizable message along with some static information related to the workflow's job it is running.

It's currently used in conjunction with `if: ${{ failure() }}` to send a message to configured webhook as an alert for a failing job, but can be reused for any other purpose, as long as the webhook endpoint accepts the json object that will be sent to.

The webhook is free to format the final message accordingly but these are the fields it will receive:
```
{
  "attempt": "1",
  "message": "Alert or custom message!",
  "job_url": "https:/github.com/path/to/workflow/job",
  "commit_url": "https://github.com/path/to/commit",
  "repo_url": "https://github.com/path/to/repo"
}
```

Where job_url, commit_url and attempt point to the job where the workflow is/was running, the commit_url of the commit that triggered the workflow and the job attempt number respectively.

Only the message is customizable by means of the step's `with.message` field. The other fields are internally set by the action.

The webhook URL should be stored in a secret and passed to the `with.slack_webook` field of the step.