### PR TITLE
clientsholder: change Kubeconfig precedence

### DIFF
--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -157,12 +157,16 @@ func GetClientsHolder(filenames ...string) *ClientsHolder {
 		return &clientsHolder
 	}
 	if len(filenames) == 0 {
-		log.Error("Please provide a valid Kubeconfig. Either set the KUBECONFIG environment variable or alternatively copy a kube config to $HOME/.kube/config")
+		errMsg := "Please provide a valid Kubeconfig. Either set the KUBECONFIG environment variable or alternatively copy a kube config to $HOME/.kube/config"
+		log.Error(errMsg)
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n", errMsg)
 		os.Exit(exitUsage)
 	}
 	clientsHolder, err := newClientsHolder(filenames...)
 	if err != nil {
-		log.Error("Failed to create k8s clients holder, err: %v", err)
+		errMsg := fmt.Sprintf("Failed to create k8s clients holder, err: %v", err)
+		log.Error(errMsg)
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n", errMsg)
 		os.Exit(1)
 	}
 	return clientsHolder
@@ -171,7 +175,9 @@ func GetClientsHolder(filenames ...string) *ClientsHolder {
 func GetNewClientsHolder(kubeconfigFile string) *ClientsHolder {
 	_, err := newClientsHolder(kubeconfigFile)
 	if err != nil {
-		log.Error("Failed to create k8s clients holder, err: %v", err)
+		errMsg := fmt.Sprintf("Failed to create k8s clients holder, err: %v", err)
+		log.Error(errMsg)
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n", errMsg)
 		os.Exit(1)
 	}
 

--- a/pkg/certsuite/certsuite.go
+++ b/pkg/certsuite/certsuite.go
@@ -54,6 +54,10 @@ const (
 func getK8sClientsConfigFileNames() []string {
 	params := configuration.GetTestParameters()
 	fileNames := []string{}
+	if params.Kubeconfig != "" {
+		// Add the kubeconfig path
+		fileNames = append(fileNames, params.Kubeconfig)
+	}
 	if params.Home != "" {
 		kubeConfigFilePath := filepath.Join(params.Home, ".kube", "config")
 		// Check if the kubeconfig path exists
@@ -65,10 +69,7 @@ func getK8sClientsConfigFileNames() []string {
 			log.Info("kubeconfig path %s is not present", kubeConfigFilePath)
 		}
 	}
-	if params.Kubeconfig != "" {
-		// Add the kubeconfig path
-		fileNames = append(fileNames, params.Kubeconfig)
-	}
+
 	return fileNames
 }
 


### PR DESCRIPTION
When the `KUBECONFIG` environment variable is set it should take precedence over the Kubeconfig stored in `$HOME/.kube/config`.