### PR TITLE
Revert "Enable multi-platform image builds"

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -483,31 +483,9 @@ jobs:
           username: ${{ secrets.QUAY_ROBOT_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Build the `cnf-certification-test` images for multi-platform (x86)
+      - name: (if on main and upstream) Push the newly built image to Quay.io
         if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 90
-          max_attempts: 3
-          command: make build-image-local-x86
-        env:
-          IMAGE_TAG: ${TNF_IMAGE_TAG}
-
-      - name: Build the `cnf-certification-test` images for multi-platform (arm64)
-        if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 90
-          max_attempts: 3
-          command: make build-image-local-arm
-        env:
-          IMAGE_TAG: ${TNF_IMAGE_TAG}
-
-      - name: Create and push the manifest list for the `cnf-certification-test` image
-        if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
-        run: |
-          make create-manifest-local
-          docker manifest push ${REGISTRY}/${TNF_IMAGE_NAME}:${TNF_IMAGE_TAG}
+        run: docker push --all-tags ${REGISTRY}/${TNF_IMAGE_NAME}
 
   check-all-dependencies-are-merged:
     name: Check all the PR dependencies are merged

--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -115,15 +115,9 @@ jobs:
         with:
           ref: ${{ env.TNF_VERSION }}
 
-      - name: Build the `cnf-certification-test` images (both amd64 and arm64)
+      - name: Build the `cnf-certification-test` image
         run: |
           make build-image-tnf
-        env:
-          TNF_VERSION: ${{ env.TNF_VERSION }}
-
-      - name: Create docker manifest for the `cnf-certification-test` image
-        run: |
-          make create-manifest-tnf
         env:
           TNF_VERSION: ${{ env.TNF_VERSION }}
 
@@ -137,8 +131,8 @@ jobs:
           username: ${{ secrets.QUAY_ROBOT_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Push the newly built image manifest to Quay.io
-        run: docker manifest push ${REGISTRY}/${TNF_IMAGE_NAME}
+      - name: Push the newly built image to Quay.io
+        run: docker push --all-tags ${REGISTRY}/${TNF_IMAGE_NAME}
 
       - name: If failed to create the image, send alert msg to dev team.
         if: ${{ failure() }}

--- a/Makefile
+++ b/Makefile
@@ -152,51 +152,18 @@ get-db:
 delete-db:
 	rm -rf ${REPO_DIR}/offline-db
 
-# Runs against whatever architecture the host is
 build-image-local:
 	docker build --pull --no-cache \
 		-t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
 		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
 		-f Dockerfile .
 
-build-image-local-x86:
-	docker build --pull --no-cache --platform linux/amd64 \
-		-t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-amd64 \
-		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-amd64 \
+build-image-tnf:
+	docker build --pull --no-cache \
+		-t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
+		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
+		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${TNF_VERSION} \
 		-f Dockerfile .
-
-build-image-local-arm:
-	docker build --pull --no-cache --platform linux/arm64 \
-		-t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-arm64 \
-		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-arm64 \
-		-f Dockerfile .
-
-create-manifest-local:
-	docker manifest create ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
-		${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-amd64 \
-		${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-arm64
-
-# Multi-platform build for releases
-build-image-tnf: build-image-tnf-x86 build-image-tnf-arm
-
-build-image-tnf-x86:
-	docker build --pull --no-cache --platform linux/amd64 \
-		-t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-amd64 \
-		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-amd64 \
-		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${TNF_VERSION}-linux-amd64 \
-		-f Dockerfile .
-
-build-image-tnf-arm:
-	docker build --pull --no-cache --platform linux/arm64 \
-		-t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-arm64 \
-		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-arm64 \
-		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${TNF_VERSION}-linux-arm64 \
-		-f Dockerfile .
-
-create-manifest-tnf:
-	docker manifest create ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
-		${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-amd64 \
-		${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-arm64
 
 results-html:
 	script/get-results-html.sh ${PARSER_RELEASE}


### PR DESCRIPTION
Reverts test-network-function/cnf-certification-test#1942

I have found out a lot about multi-stage builds since merging this.  I am going to revert and improve with another PR.