### PR TITLE
Temporarily disable typos linter

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -94,8 +94,8 @@ jobs:
       - name: ShellCheck
         uses: ludeeus/action-shellcheck@master
 
-      - name: Typos
-        uses: crate-ci/typos@master
+      # - name: Typos
+      #   uses: crate-ci/typos@master
 
       - name: Yamllint
         uses: ibiqlik/action-yamllint@v3


### PR DESCRIPTION
https://github.com/crate-ci/typos/releases/tag/v1.20.0 seems to have broken our linting.  We can re-enable and fix later.