### PR TITLE
operator: add new test case operator-single-crd-owner

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -7,7 +7,7 @@ Depending on the CNF type, not all tests are required to pass to satisfy best pr
 
 ## Test cases summary
 
-### Total test cases: 106
+### Total test cases: 107
 
 ### Total suites: 10
 
@@ -19,7 +19,7 @@ Depending on the CNF type, not all tests are required to pass to satisfy best pr
 |manageability|2|
 |networking|11|
 |observability|4|
-|operator|4|
+|operator|5|
 |performance|6|
 |platform-alteration|13|
 |preflight|17|
@@ -36,11 +36,11 @@ Depending on the CNF type, not all tests are required to pass to satisfy best pr
 |---|---|
 |7|1|
 
-### Non-Telco specific tests only: 59
+### Non-Telco specific tests only: 60
 
 |Mandatory|Optional|
 |---|---|
-|39|20|
+|40|20|
 
 ### Telco specific tests only: 27
 
@@ -1177,6 +1177,22 @@ Property|Description
 Unique ID|operator-installed-operator-semantic-versioning
 Description|Tests whether an application Operator has a valid semantic versioning.
 Suggested Remediation|Ensure that the installed Operator has a valid semantic versioning.
+Best Practice Reference|https://test-network-function.github.io/cnf-best-practices-guide/#cnf-best-practices-cnf-operator-requirements
+Exception Process|No exceptions
+Tags|common,operator
+|**Scenario**|**Optional/Mandatory**|
+|Extended|Mandatory|
+|Far-Edge|Mandatory|
+|Non-Telco|Mandatory|
+|Telco|Mandatory|
+
+#### operator-single-crd-owner
+
+Property|Description
+---|---
+Unique ID|operator-single-crd-owner
+Description|Tests whether a CRD is owned by a single Operator.
+Suggested Remediation|Ensure that a CRD is owned by only one Operator
 Best Practice Reference|https://test-network-function.github.io/cnf-best-practices-guide/#cnf-best-practices-cnf-operator-requirements
 Exception Process|No exceptions
 Tags|common,operator

--- a/cnf-certification-test/identifiers/doclinks.go
+++ b/cnf-certification-test/identifiers/doclinks.go
@@ -107,6 +107,7 @@ const (
 	TestOperatorIsCertifiedIdentifierDocLink            = DocOperatorRequirement
 	TestOperatorIsInstalledViaOLMIdentifierDocLink      = DocOperatorRequirement
 	TestOperatorHasSemanticVersioningIdentifierDocLink  = DocOperatorRequirement
+	TestOperatorSingleCrdOwnerIdentifierDocLink         = DocOperatorRequirement
 
 	// Observability Test Suite
 	TestLoggingIdentifierDocLink                  = "https://test-network-function.github.io/cnf-best-practices-guide/#cnf-best-practices-logging"

--- a/cnf-certification-test/identifiers/identifiers.go
+++ b/cnf-certification-test/identifiers/identifiers.go
@@ -122,6 +122,7 @@ var (
 	TestHelmIsCertifiedIdentifier                     claim.Identifier
 	TestOperatorIsInstalledViaOLMIdentifier           claim.Identifier
 	TestOperatorHasSemanticVersioningIdentifier       claim.Identifier
+	TestOperatorSingleCrdOwnerIdentifier              claim.Identifier
 	TestPodNodeSelectorAndAffinityBestPractices       claim.Identifier
 	TestPodHighAvailabilityBestPractices              claim.Identifier
 	TestPodClusterRoleBindingsBestPracticesIdentifier claim.Identifier
@@ -916,6 +917,22 @@ tag. (2) It does not have any of the following prefixes: default, openshift-, is
 		OperatorHasSemanticVersioningRemediation,
 		NoExceptions,
 		TestOperatorHasSemanticVersioningIdentifierDocLink,
+		true,
+		map[string]string{
+			FarEdge:  Mandatory,
+			Telco:    Mandatory,
+			NonTelco: Mandatory,
+			Extended: Mandatory,
+		},
+		TagCommon)
+
+	TestOperatorSingleCrdOwnerIdentifier = AddCatalogEntry(
+		"single-crd-owner",
+		common.OperatorTestKey,
+		`Tests whether a CRD is owned by a single Operator.`,
+		OperatorSingleCrdOwnerRemediation,
+		NoExceptions,
+		TestOperatorSingleCrdOwnerIdentifierDocLink,
 		true,
 		map[string]string{
 			FarEdge:  Mandatory,

--- a/cnf-certification-test/identifiers/remediation.go
+++ b/cnf-certification-test/identifiers/remediation.go
@@ -81,6 +81,8 @@ const (
 
 	OperatorHasSemanticVersioningRemediation = `Ensure that the installed Operator has a valid semantic versioning.`
 
+	OperatorSingleCrdOwnerRemediation = `Ensure that a CRD is owned by only one Operator`
+
 	PodNodeSelectorAndAffinityBestPracticesRemediation = `In most cases, Pod's should not specify their host Nodes through nodeSelector or nodeAffinity. However, there are cases in which CNFs require specialized hardware specific to a particular class of Node.`
 
 	PodHighAvailabilityBestPracticesRemediation = `In high availability cases, Pod podAntiAffinity rule should be specified for pod scheduling and pod replica value is set to more than 1 .`

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -169,9 +169,13 @@ const (
 	PortNumber   = "Port Number"
 	PortProtocol = "Port Protocol"
 
-	//
+	// OLM
 	SubscriptionName = "Subscription Name"
 	OperatorPhase    = "Operator Phase"
+	OperatorName     = "Operator Name"
+
+	// Lists
+	OperatorList = "Operator List"
 )
 
 // When adding new object types, please update the following:


### PR DESCRIPTION
The test case verifies that every CRD is owned by only one operator.