### PR TITLE
Switch the build-and-push action for multi-arch

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -457,97 +457,22 @@ jobs:
 
       - name: 'Test: Run Preflight Specific Smoke Tests in a TNF container'
         run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./run-tnf-container.sh ${{ env.TESTING_CMD_PARAMS }} -l "preflight"
-  
-  # NOTE: This is an x86 runner that is doing a cross-compile.
-  # It will take a while to run.
-  # In the future, we may want to use a runner that is ARM-based.
-  build-arm-image:
-    name: Build ARM image
-    runs-on: ubuntu-22.04
-    needs: smoke-tests-container
-    if: needs.smoke-tests-container.result == 'success' && github.event_name != 'pull_request'
-    steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.sha }}
-
-      - name: Build the `cnf-certification-test` image for ARM
-        run: make build-image-local-arm
-        env:
-          IMAGE_TAG: ${TNF_IMAGE_TAG}
-      
-      - name: Login to Quay.io
-        uses: docker/login-action@v3
-        if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.QUAY_ROBOT_USERNAME }}
-          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
-
-      - name: Push the `cnf-certification-test` image for ARM
-        if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
-        run: |
-          docker push ${REGISTRY}/${TNF_IMAGE_NAME}:${TNF_IMAGE_TAG}-linux-arm64
-
-      - name: (if on main and upstream) Send chat msg to dev team if failed to create container image.
-        if: ${{ failure() && github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
-        uses: ./.github/actions/slack-webhook-sender
-        with:
-          message: 'Failed to create the *arm64* container image'
-          slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'
-
-  build-x86-image: 
-    name: Build x86 image
-    runs-on: ubuntu-22.04
-    needs: smoke-tests-container
-    if: needs.smoke-tests-container.result == 'success' && github.event_name != 'pull_request'
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.sha }}
-
-      - name: Build the `cnf-certification-test` image for x86
-        run: make build-image-local-x86
-        env:
-          IMAGE_TAG: ${TNF_IMAGE_TAG}
-      
-      - name: Login to Quay.io
-        uses: docker/login-action@v3
-        if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.QUAY_ROBOT_USERNAME }}
-          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
-
-      # Only push the x86 image if the branch is main and the owner is test-network-function.
-      - name: Push the `cnf-certification-test` image for x86
-        if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
-        run: |
-          docker push ${REGISTRY}/${TNF_IMAGE_NAME}:${TNF_IMAGE_TAG}-linux-amd64
-
-      - name: (if on main and upstream) Send chat msg to dev team if failed to create container image.
-        if: ${{ failure() && github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
-        uses: ./.github/actions/slack-webhook-sender
-        with:
-          message: 'Failed to create the *x86* container image'
-          slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'
 
   # Only run this job if the previous jobs are successful that build the ARM and x86 images.
   create-manifest-multiarch:
     name: Create manifest list for multi-arch image
     runs-on: ubuntu-22.04
-    needs: [build-arm-image, build-x86-image]
-    if: needs.build-arm-image.result == 'success' && needs.build-x86-image.result == 'success' && github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request'
     steps:
       - name: Check out code
         uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Quay.io
         uses: docker/login-action@v3
@@ -557,13 +482,16 @@ jobs:
           username: ${{ secrets.QUAY_ROBOT_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Create and push the manifest list for the `cnf-certification-test` image
+      - name: Build and push the unstable images for multi-arch
+        uses: docker/build-push-action@v5
         if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
-        run: |
-          make create-manifest-local
-          docker manifest push ${REGISTRY}/${TNF_IMAGE_NAME}:${TNF_IMAGE_TAG}
-        env:
-          IMAGE_TAG: ${TNF_IMAGE_TAG}
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.TNF_IMAGE_NAME }}:${{ env.TNF_IMAGE_TAG }}
       
       - name: (if on main and upstream) Send chat msg to dev team if failed to create container image.
         if: ${{ failure() && github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}

--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -3,7 +3,6 @@ name: 'Publish the `cnf-certification-test` image (latest release only)'
 "on":
   # Run the workflow when a new release gets published
   release:
-    target_commitish: main
     types: [published]
   # Run the workflow every day at 5 am UTC (1 am EST, 7am CET)
   # This is useful for keeping the image up-to-date with security
@@ -35,208 +34,10 @@ env:
   TESTING_CMD_PARAMS: '-n host -i ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${IMAGE_TAG} -t ${TNF_CONFIG_DIR} -o ${TNF_OUTPUT_DIR}'
   ON_DEMAND_DEBUG_PODS: false
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
-  build-x86-image:
-    name: Build x86 image
-    runs-on: ubuntu-22.04
-    env:
-      SHELL: /bin/bash
-      KUBECONFIG: '/home/runner/.kube/config'
-      PFLT_DOCKERCONFIG: '/home/runner/.docker/config'
-      CURRENT_VERSION_GENERIC_BRANCH: main
-      TNF_VERSION: ""
-      PARTNER_VERSION: ""
-    steps:
-      - name: Checkout generic working branch of the current version
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.CURRENT_VERSION_GENERIC_BRANCH }}
-          fetch-depth: '0'
-
-      - name: Get the latest TNF version from GIT
-        run: |
-          GIT_RELEASE=$(git tag --points-at HEAD | head -n 1)
-          GIT_PREVIOUS_RELEASE=$(git tag --no-contains HEAD --sort=v:refname | tail -n 1)
-          GIT_LATEST_RELEASE=$GIT_RELEASE
-          if [ -z "$GIT_RELEASE" ]; then
-            GIT_LATEST_RELEASE=$GIT_PREVIOUS_RELEASE
-          fi
-
-          echo "version_number=$GIT_LATEST_RELEASE" >> $GITHUB_OUTPUT
-        id: set_tnf_version
-
-      - name: Print the latest TNF version from GIT
-        run: |
-          echo Version tag: ${{ steps.set_tnf_version.outputs.version_number }}
-
-      - name: Get contents of the version.json file
-        run: echo "json=$(cat version.json | tr -d '[:space:]')" >> $GITHUB_OUTPUT
-        id: get_version_json_file
-
-      - name: Get the partner version number from file
-        run: |
-          echo Partner version tag: $VERSION_FROM_FILE_PARTNER
-          echo "partner_version_number=$VERSION_FROM_FILE_PARTNER" >> $GITHUB_OUTPUT
-        id: set_partner_version
-        env:
-          VERSION_FROM_FILE_PARTNER: ${{ fromJSON(steps.get_version_json_file.outputs.json).partner_tag }}
-
-      - name: Update env variables
-        run: |
-          echo "TNF_VERSION=${{ steps.set_tnf_version.outputs.version_number }}" >> $GITHUB_ENV
-          echo "PARTNER_VERSION=${{ steps.set_partner_version.outputs.partner_version_number }}" >> $GITHUB_ENV
-
-      - name: Ensure $TNF_VERSION and $IMAGE_TAG are set
-        run: '[[ -n "$TNF_VERSION" ]] && [[ -n "$IMAGE_TAG" ]] && [[ -n "$PARTNER_VERSION" ]]'
-
-      - name: Check whether the version tag exists on remote
-        run: git ls-remote --exit-code $TNF_SRC_URL refs/tags/$TNF_VERSION
-
-      - name: (if tag is missing) Display debug message
-        if: ${{ failure() }}
-        run: echo "Tag '$TNF_VERSION' does not exist on remote $TNF_SRC_URL"
-
-      - name: Check whether the version tag exists on remote
-        run: git ls-remote --exit-code ${{ env.PARTNER_SRC_URL }} refs/tags/$PARTNER_VERSION
-
-      - name: (if partner_tag is missing) Display debug message
-        if: ${{ failure() }}
-        run: echo "Tag '$PARTNER_VERSION' does not exist on remote $PARTNER_SRC_URL"
-
-      - name: Checkout the version tag
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.TNF_VERSION }}
-
-      - name: Login to Quay.io
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.QUAY_ROBOT_USERNAME }}
-          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
-
-      - name: Build the `cnf-certification-test` image for x86
-        run: |
-          docker build --pull --no-cache --platform linux/amd64 -t ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-amd64 -t ${REGISTRY}/${TNF_IMAGE_NAME}:${{ env.TNF_VERSION }}-linux-amd64 -f Dockerfile .
-
-      - name: Push the `cnf-certification-test` images (latest and release) for x86
-        run: |
-          docker push ${REGISTRY}/${TNF_IMAGE_NAME}:${{ env.TNF_VERSION }}-linux-amd64
-          docker push ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-amd64
-
-      - name: (if on main and upstream) Send chat msg to dev team if failed to create container image.
-        if: ${{ failure() && github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
-        uses: ./.github/actions/slack-webhook-sender
-        with:
-          message: 'Failed to create the *x86* container manifest'
-          slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'
-
-  build-arm-image:
-    name: Build ARM image
-    runs-on: ubuntu-22.04
-    env:
-      SHELL: /bin/bash
-      KUBECONFIG: '/home/runner/.kube/config'
-      PFLT_DOCKERCONFIG: '/home/runner/.docker/config'
-      CURRENT_VERSION_GENERIC_BRANCH: main
-      TNF_VERSION: ""
-      PARTNER_VERSION: ""
-    steps:
-      - name: Checkout generic working branch of the current version
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.CURRENT_VERSION_GENERIC_BRANCH }}
-          fetch-depth: '0'
-
-      - name: Get the latest TNF version from GIT
-        run: |
-          GIT_RELEASE=$(git tag --points-at HEAD | head -n 1)
-          GIT_PREVIOUS_RELEASE=$(git tag --no-contains HEAD --sort=v:refname | tail -n 1)
-          GIT_LATEST_RELEASE=$GIT_RELEASE
-          if [ -z "$GIT_RELEASE" ]; then
-            GIT_LATEST_RELEASE=$GIT_PREVIOUS_RELEASE
-          fi
-
-          echo "version_number=$GIT_LATEST_RELEASE" >> $GITHUB_OUTPUT
-        id: set_tnf_version
-
-      - name: Print the latest TNF version from GIT
-        run: |
-          echo Version tag: ${{ steps.set_tnf_version.outputs.version_number }}
-
-      - name: Get contents of the version.json file
-        run: echo "json=$(cat version.json | tr -d '[:space:]')" >> $GITHUB_OUTPUT
-        id: get_version_json_file
-
-      - name: Get the partner version number from file
-        run: |
-          echo Partner version tag: $VERSION_FROM_FILE_PARTNER
-          echo "partner_version_number=$VERSION_FROM_FILE_PARTNER" >> $GITHUB_OUTPUT
-        id: set_partner_version
-        env:
-          VERSION_FROM_FILE_PARTNER: ${{ fromJSON(steps.get_version_json_file.outputs.json).partner_tag }}
-
-      - name: Update env variables
-        run: |
-          echo "TNF_VERSION=${{ steps.set_tnf_version.outputs.version_number }}" >> $GITHUB_ENV
-          echo "PARTNER_VERSION=${{ steps.set_partner_version.outputs.partner_version_number }}" >> $GITHUB_ENV
-
-      - name: Ensure $TNF_VERSION and $IMAGE_TAG are set
-        run: '[[ -n "$TNF_VERSION" ]] && [[ -n "$IMAGE_TAG" ]] && [[ -n "$PARTNER_VERSION" ]]'
-
-      - name: Check whether the version tag exists on remote
-        run: git ls-remote --exit-code $TNF_SRC_URL refs/tags/$TNF_VERSION
-
-      - name: (if tag is missing) Display debug message
-        if: ${{ failure() }}
-        run: echo "Tag '$TNF_VERSION' does not exist on remote $TNF_SRC_URL"
-
-      - name: Check whether the version tag exists on remote
-        run: git ls-remote --exit-code ${{ env.PARTNER_SRC_URL }} refs/tags/$PARTNER_VERSION
-
-      - name: (if partner_tag is missing) Display debug message
-        if: ${{ failure() }}
-        run: echo "Tag '$PARTNER_VERSION' does not exist on remote $PARTNER_SRC_URL"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.TNF_VERSION }}
-
-      - name: Login to Quay.io
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.QUAY_ROBOT_USERNAME }}
-          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
-
-      - name: Build the `cnf-certification-test` image for ARM
-        run: |
-          docker build --pull --no-cache --platform linux/arm64 -t ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-arm64 -t ${REGISTRY}/${TNF_IMAGE_NAME}:${{ env.TNF_VERSION }}-linux-arm64 -f Dockerfile .
-
-      - name: Push the `cnf-certification-test` image for ARM
-        run: |
-          docker push ${REGISTRY}/${TNF_IMAGE_NAME}:${{ env.TNF_VERSION }}-linux-arm64
-          docker push ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-arm64
-
-      - name: (if on main and upstream) Send chat msg to dev team if failed to create container image.
-        if: ${{ failure() && github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
-        uses: ./.github/actions/slack-webhook-sender
-        with:
-          message: 'Failed to create the *arm64* container manifest'
-          slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'
-
   test-and-push-tnf-image-main:
     name: 'Test and push the `cnf-certification-test` image'
     runs-on: ubuntu-22.04
-    needs: [build-x86-image, build-arm-image] # Wait for the x86 and ARM images to be built
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.kube/config'
@@ -313,6 +114,11 @@ jobs:
         with:
           ref: ${{ env.TNF_VERSION }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       # Push the new TNF image to Quay.io.
       - name: Authenticate against Quay.io
         uses: docker/login-action@v3
@@ -323,17 +129,16 @@ jobs:
           username: ${{ secrets.QUAY_ROBOT_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      # Build the manifest for the `cnf-certification-test` image.
-      # At this point, both x86 and ARM images should be built and pushed to Quay.io.
-      - name: Create docker manifest for the `cnf-certification-test` image
-        run: |
-          docker manifest create ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG} ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-amd64 ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-arm64
-          docker manifest create ${REGISTRY}/${TNF_IMAGE_NAME}:${{ env.TNF_VERSION }} ${REGISTRY}/${TNF_IMAGE_NAME}:${{ env.TNF_VERSION }}-linux-amd64 ${REGISTRY}/${TNF_IMAGE_NAME}:${{ env.TNF_VERSION }}-linux-arm64
-
-      - name: Push the newly built image manifest to Quay.io
-        run: |
-          docker manifest push ${REGISTRY}/${TNF_IMAGE_NAME}:${{ env.TNF_VERSION }}
-          docker manifest push ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}
+      - name: Build and push the TNF image for multi-arch
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${REGISTRY}/${TNF_IMAGE_NAME}:${{ env.TNF_VERSION }}
+            ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}
 
       - name: If failed to create the image, send alert msg to dev team.
         if: ${{ failure() }}


### PR DESCRIPTION
Follow up to #1943 

Related to: https://github.com/test-network-function/cnf-certification-test-partner/pull/417

Turns out we don't need to do so much manual building and image creation when there's already an action that does all of this for us.