### PR TITLE
Build image first for QE PR runs

### DIFF
--- a/.github/workflows/qe-hosted.yml
+++ b/.github/workflows/qe-hosted.yml
@@ -10,11 +10,42 @@ on:
 env:
   QE_REPO: test-network-function/cnfcert-tests-verification
 
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  # Build the image used for testing first, then pass the reference to the QE tests.
+  # This saves time and resources by not building the image in each QE suite.
+  build-image-for-qe:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Setup docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build temporary image tag for this PR
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          tags: quay.io/testnetworkfunction/cnf-certification-test:localtest
+          outputs: type=docker,dest=/tmp/testimage.tar
+      
+      - name: Store image as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: testimage
+          path: /tmp/testimage.tar
+
   qe-testing:
     runs-on: ubuntu-22.04
+    needs: build-image-for-qe
+    if: needs.build-image-for-qe.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -37,18 +68,15 @@ jobs:
       - name: Run initial setup
         uses: ./.github/actions/setup
 
+      # Download the image from the artifact and load it into the docker daemon.
+      - name: Setup docker buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y python3-pip
           sudo pip3 install j2cli
-
-      - name: Build the test image
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 90
-          max_attempts: 3
-          command: make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
 
       # Create a Kind cluster for testing.
       - name: Check out `cnf-certification-test-partner`
@@ -77,6 +105,15 @@ jobs:
           cat /etc/docker/daemon.json
           sudo systemctl restart docker
           sudo ls -la /mnt/docker-storage
+
+      - name: Download image from artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: testimage
+          path: /tmp
+
+      - name: Load image into docker
+        run: docker load --input /tmp/testimage.tar
 
       - name: Run 'make rebuild-cluster'
         uses: nick-fields/retry@v3
@@ -110,9 +147,6 @@ jobs:
         uses: depends-on/depends-on-action@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build the test image
-        run: make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
 
       - name: Run the tests
         uses: nick-fields/retry@v3


### PR DESCRIPTION
Playing around with concurrency to see if I can speed up the overall QE testing for PRs.

- Builds the image first in job, and if it is successful then runs all of the QE PR checks.
- This saves roughly ~3-5 minutes off of each workflow job.  Which can help improve overall resource usage on the free tier of github actions as we only have 20 available runner slots at any given time.