### PR TITLE
operator: delete very long debug log

### DIFF
--- a/cnf-certification-test/operator/suite.go
+++ b/cnf-certification-test/operator/suite.go
@@ -140,7 +140,6 @@ func testOperatorCrdOpenAPISpec(check *checksdb.Check, env *provider.TestEnviron
 
 		for _, version := range crd.Spec.Versions {
 			crdSchema := version.Schema.String()
-			check.LogDebug("CRD schema is %q", crdSchema)
 
 			containsOpenAPIV3SchemaSubstr := strings.Contains(strings.ToLower(crdSchema),
 				strings.ToLower(testhelper.OpenAPIV3Schema))


### PR DESCRIPTION
It pollutes the log file to the point that file editors struggle to handle it. Also, it does not seem to be helpful from a practical point of view in the way it is printed.