### PR TITLE
Add 4.15 and 4.16 to RHCOS versions script

### DIFF
--- a/script/rhcos_versions.sh
+++ b/script/rhcos_versions.sh
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-CHANNELS=(4.14 4.13 4.12 4.11 4.10 4.9 4.8 4.7 4.6 4.5 4.4 4.3 4.2 4.1)
+CHANNELS=(4.16 4.15 4.14 4.13 4.12 4.11 4.10 4.9 4.8 4.7 4.6 4.5 4.4 4.3 4.2 4.1)
 CHANNEL_TYPES=(stable candidate)
 
 rm -f ./cnf-certification-test/platform/operatingsystem/files/rhcos_version_map &>/dev/null


### PR DESCRIPTION
The script was missing 4.15 and 4.16 which was causing failures in our new 4.15 OCP QE cluster.