### PR TITLE
docs: CNF Certification rename to Red Hat Best Practices for Kubernetes

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -1,13 +1,13 @@
 <!-- markdownlint-disable line-length no-bare-urls -->
-# cnf-certification-test catalog
+# Red Hat Best Practices Test Suite for Kubernetes catalog
 
-The catalog for cnf-certification-test contains a list of test cases aiming at testing CNF best practices in various areas. Test suites are defined in 10 areas : `platform-alteration`, `access-control`, `affiliated-certification`, `lifecycle`, `manageability`,`networking`, `observability`, `operator`, and `performance.`
+The catalog for the Red Hat Best Practices Test Suite for Kubernetes contains a list of test cases aiming at testing best practices in various areas. Test suites are defined in 10 areas : `platform-alteration`, `access-control`, `affiliated-certification`, `lifecycle`, `manageability`,`networking`, `observability`, `operator`, and `performance.`
 
-Depending on the CNF type, not all tests are required to pass to satisfy best practice requirements. The scenario section indicates which tests are mandatory or optional depending on the scenario. The following CNF types / scenarios are defined: `Telco`, `Non-Telco`, `Far-Edge`, `Extended`.
+Depending on the workload type, not all tests are required to pass to satisfy best practice requirements. The scenario section indicates which tests are mandatory or optional depending on the scenario. The following workload types / scenarios are defined: `Telco`, `Non-Telco`, `Far-Edge`, `Extended`.
 
 ## Test cases summary
 
-### Total test cases: 108
+### Total test cases: 109
 
 ### Total suites: 10
 
@@ -19,7 +19,7 @@ Depending on the CNF type, not all tests are required to pass to satisfy best pr
 |manageability|2|
 |networking|11|
 |observability|4|
-|operator|6|
+|operator|7|
 |performance|6|
 |platform-alteration|13|
 |preflight|17|
@@ -36,11 +36,11 @@ Depending on the CNF type, not all tests are required to pass to satisfy best pr
 |---|---|
 |7|1|
 
-### Non-Telco specific tests only: 61
+### Non-Telco specific tests only: 62
 
 |Mandatory|Optional|
 |---|---|
-|41|20|
+|42|20|
 
 ### Telco specific tests only: 27
 
@@ -50,7 +50,7 @@ Depending on the CNF type, not all tests are required to pass to satisfy best pr
 
 ## Test Case list
 
-Test Cases are the specifications used to perform a meaningful test. Test cases may run once, or several times against several targets. CNF Certification includes a number of normative and informative tests to ensure CNFs follow best practices. Here is the list of available Test Cases:
+Test Cases are the specifications used to perform a meaningful test. Test cases may run once, or several times against several targets. The Red Hat Best Practices Test Suite for Kubernetes includes a number of normative and informative tests to ensure that workloads follow best practices. Here is the list of available Test Cases:
 
 ### access-control
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CNF Certification Test
+# Red Hat Best Practices Test Suite for Kubernetes
 
 ![build](https://github.com/test-network-function/cnf-certification-test/actions/workflows/merge.yaml/badge.svg)
 [![go report](https://goreportcard.com/badge/github.com/test-network-function/test-network-function)](https://goreportcard.com/report/github.com/test-network-function/cnf-certification-test)

--- a/cmd/tnf/generate/catalog/catalog.go
+++ b/cmd/tnf/generate/catalog/catalog.go
@@ -206,8 +206,8 @@ func outputTestCases() (outString string, summary catalogSummary) { //nolint:fun
 	// Iterating the map by test and suite names
 	outString = "## Test Case list\n\n" +
 		"Test Cases are the specifications used to perform a meaningful test. " +
-		"Test cases may run once, or several times against several targets. CNF Certification includes " +
-		"a number of normative and informative tests to ensure CNFs follow best practices. " +
+		"Test cases may run once, or several times against several targets. The Red Hat Best Practices Test Suite for Kubernetes includes " +
+		"a number of normative and informative tests to ensure that workloads follow best practices. " +
 		"Here is the list of available Test Cases:\n"
 
 	summary.testPerScenario = make(map[string]map[string]int)
@@ -322,12 +322,12 @@ func generateJS(_ *cobra.Command, _ []string) error {
 
 func outputIntro() (out string) {
 	return "<!-- markdownlint-disable line-length no-bare-urls -->\n" +
-		"# cnf-certification-test catalog\n\n" +
-		"The catalog for cnf-certification-test contains a list of test cases " +
-		"aiming at testing CNF best practices in various areas. Test suites are defined in 10 areas : `platform-alteration`, `access-control`, `affiliated-certification`, " +
+		"# Red Hat Best Practices Test Suite for Kubernetes catalog\n\n" +
+		"The catalog for the Red Hat Best Practices Test Suite for Kubernetes contains a list of test cases " +
+		"aiming at testing best practices in various areas. Test suites are defined in 10 areas : `platform-alteration`, `access-control`, `affiliated-certification`, " +
 		"`lifecycle`, `manageability`,`networking`, `observability`, `operator`, and `performance.`" +
-		"\n\nDepending on the CNF type, not all tests are required to pass to satisfy best practice requirements. The scenario section" +
-		" indicates which tests are mandatory or optional depending on the scenario. The following CNF types / scenarios are defined: `Telco`, `Non-Telco`, `Far-Edge`, `Extended`.\n\n"
+		"\n\nDepending on the workload type, not all tests are required to pass to satisfy best practice requirements. The scenario section" +
+		" indicates which tests are mandatory or optional depending on the scenario. The following workload types / scenarios are defined: `Telco`, `Non-Telco`, `Far-Edge`, `Extended`.\n\n"
 }
 
 // runGenerateMarkdownCmd generates a markdown test catalog.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,13 +1,13 @@
 <!-- markdownlint-disable code-block-style line-length no-bare-urls -->
-# CNF Certification configuration
+# Red Hat Best Practices Test Suite for Kubernetes configuration
 
-The CNF Certification Test uses a YAML configuration file to certify a specific CNF workload. This file specifies the CNF resources to be certified, as well as any exceptions or other general configuration options.
+The Red Hat Best Practices Test Suite for Kubernetes uses a YAML configuration file to certify a specific workload. This file specifies the workload's resources to be certified, as well as any exceptions or other general configuration options.
 
-By default a file named _tnf_config.yml_ will be used. Here's an [example](https://github.com/test-network-function/cnf-certification-test/blob/main/cnf-certification-test/tnf_config.yml) of the CNF Config File. For a description of each config option see the section [CNF Config File options](#cnf-config-file-options).
+By default a file named _tnf_config.yml_ will be used. Here's an [example](https://github.com/test-network-function/cnf-certification-test/blob/main/cnf-certification-test/tnf_config.yml) of the Config File. For a description of each config option see the section [Config File options](#config-file-options).
 
-## CNF Config Generator
+## Config Generator
 
-The CNF config file can be created using the CNF Config Generator, which is part of the TNF tool shipped with the CNF Certification. The purpose of this particular tool is to help users configuring the CNF Certification providing a logical structure of the available options as well as the information required to make use of them. The result is a CNF config file in YAML format that the CNF Certification will parse to adapt the certification process to a specific CNF workload.
+The Config File can be created using the Config Generator, which is part of the TNF tool shipped with the Test Suite. The purpose of this particular tool is to help users configuring the Test Suite providing a logical structure of the available options as well as the information required to make use of them. The result is a Config File in YAML format that will be parsed to adapt the verification process to a specific workload.
 
 To compile the TNF tool:
 
@@ -15,7 +15,7 @@ To compile the TNF tool:
 make build-tnf-tool
 ```
 
-To launch the CNF Config Generator:
+To launch the Config Generator:
 
 ```shell
 ./tnf generate config
@@ -29,11 +29,11 @@ Here's an example of how to use the tool:
 </object>
 <!-- markdownlint-enable MD033 -->
 
-## CNF Config File options
+## Config File options
 
-### CNF resources
+### Workload resources
 
-These options allow configuring the workload resources of the CNF to be verified. Only the resources that the CNF uses are required to be configured. The rest can be left empty. Usually a basic configuration includes _Namespaces_ and _Pods_ at least.
+These options allow configuring the workload resources to be verified. Only the resources that the workload uses are required to be configured. The rest can be left empty. Usually a basic configuration includes _Namespaces_ and _Pods_ at least.
 
 !!! note
 
@@ -42,7 +42,7 @@ These options allow configuring the workload resources of the CNF to be verified
 
 #### targetNameSpaces
 
-The namespaces in which the CNF under test will be deployed.
+The namespaces in which the workload under test will be deployed.
 
 ``` { .yaml .annotate }
 targetNameSpaces:
@@ -51,7 +51,7 @@ targetNameSpaces:
 
 #### podsUnderTestLabels
 
-The labels that each Pod of the CNF under test must have to be verified by the CNF Certification Suite.
+The labels that each Pod of the workload under test must have to be verified by the Test Suite.
 
 !!! note "Highly recommended"
 
@@ -64,9 +64,9 @@ podsUnderTestLabels:
 
 #### operatorsUnderTestLabels
 
-The labels that each operator's CSV of the CNF under test must have to be verified by the CNF Certification Suite.
+The labels that each operator's CSV of the workload under test must have to be verified by the Test Suite.
 
-If a new label is used for this purpose make sure it is added to the CNF operator's CSVs.
+If a new label is used for this purpose make sure it is added to the workload operator's CSVs.
 
 ``` { .yaml .annotate }
 operatorsUnderTestLabels:
@@ -75,7 +75,7 @@ operatorsUnderTestLabels:
 
 #### targetCrdFilters
 
-The CRD name suffix used to filter the CNF's CRDs among all the CRDs present in the cluster. For each CRD it can also be specified if it's scalable or not in order to avoid some lifecycle test cases.
+The CRD name suffix used to filter the workload's CRDs among all the CRDs present in the cluster. For each CRD it can also be specified if it's scalable or not in order to avoid some lifecycle test cases.
 
 ``` { .yaml .annotate }
 targetCrdFilters:
@@ -124,11 +124,11 @@ This utilizes the `--add-host` flag in Docker to be able to point `api.crc.testi
 
 ### Exceptions
 
-These options allow adding exceptions to skip several checks for different resources. The exceptions must be justified in order to pass the CNF Certification.
+These options allow adding exceptions to skip several checks for different resources. The exceptions must be justified in order to satisfy the Red Hat Best Practices for Kubernetes.
 
 #### acceptedKernelTaints
 
-The list of kernel modules loaded by the CNF that make the Linux kernel mark itself as _tainted_ but that should skip verification.
+The list of kernel modules loaded by the workload that make the Linux kernel mark itself as _tainted_ but that should skip verification.
 
 Test cases affected: _platform-alteration-tainted-node-kernel_.
 
@@ -140,7 +140,7 @@ acceptedKernelTaints:
 
 #### skipHelmChartList
 
-The list of Helm charts that the CNF uses whose certification status will not be verified.
+The list of Helm charts that the workload uses whose certification status will not be verified.
 
 If no exception is configured, the certification status for all Helm charts will be checked in the [OpenShift Helms Charts repository](https://charts.openshift.io/).
 
@@ -197,7 +197,7 @@ skipScalingTestStatefulSetNames:
     namespace: tnf
 ```
 
-### CNF Certification settings
+### Red Hat Best Practices Test Suite settings
 
 #### debugDaemonSetNamespace
 
@@ -207,7 +207,7 @@ This is an optional field with the name of the namespace where a privileged Daem
 debugDaemonSetNamespace: cnf-cert
 ```
 
-This DaemonSet, called _tnf-debug_ is deployed and used internally by the CNF Certification tool to issue some shell commands that are needed in certain test cases. Some of these test cases might fail or be skipped in case it wasn't deployed correctly.
+This DaemonSet, called _tnf-debug_ is deployed and used internally by the Test Suite tool to issue some shell commands that are needed in certain test cases. Some of these test cases might fail or be skipped in case it wasn't deployed correctly.
 
 ### Other settings
 
@@ -228,4 +228,4 @@ The label _test-network-function.com/skip_multus_connectivity_tests_ excludes Po
 
 #### Affinity requirements
 
-For CNF workloads that require Pods to use Pod or Node Affinity rules, the label _AffinityRequired: true_ must be included on the Pod YAML. This will ensure that the affinity best practices are tested and prevent any test cases for anti-affinity to fail.
+For workloads that require Pods to use Pod or Node Affinity rules, the label _AffinityRequired: true_ must be included on the Pod YAML. This will ensure that the affinity best practices are tested and prevent any test cases for anti-affinity to fail.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,22 +1,22 @@
 <!-- markdownlint-disable line-length no-bare-urls no-emphasis-as-heading -->
 # Overview
 
-This repository provides a set of Cloud-Native Network Functions (CNF) test cases and the framework to add more test cases.
+This repository provides a set of test cases to verify the conformance of a workload with the Red Hat Best Practices for Kubernetes.
 
-!!! tip "CNF"
+!!! tip "Workload"
 
     The app (containers/pods/operators) we want to certify according Telco partner/Red Hat's best practices.
 
-!!! tip "TNF/Certification Test Suite"
+!!! tip "Red Hat Best Practices Test Suite for Kubernetes"
 
-    The tool we use to certify a CNF.
+    The tool we use to certify a workload.
 
-The purpose of the tests and the framework is to test the interaction of CNF with OpenShift Container Platform (OCP).  
+The purpose of the tests and the framework is to test the interaction of the workload with OpenShift Container Platform (OCP).  
 
 !!! info
 
-    This test suite is provided for the CNF Developers to test their CNFs readiness for certification.
-    Please see "CNF Developers" for more information.
+    This test suite is provided for the workload developers to test their workload's readiness for certification.
+    Please see the [Developers' Guide](developers.md) for more information.
 
 **Features**
 
@@ -30,8 +30,8 @@ The purpose of the tests and the framework is to test the interaction of CNF wit
 
 There are 3 building blocks in the above framework.
 
-* the `CNF` represents the CNF to be certified. The certification suite identifies the resources (containers/pods/operators etc) belonging to the CNF via labels or static data entries in the config file
+* the `CNF` represents the workload to be certified. The Test Suite identifies the resources (containers/pods/operators etc) belonging to the workload via labels or static data entries in the Config File
 
-* the `Certification container/exec` is the certification test suite running on the platform or in a container. The executable verifies the CNF under test configuration and its interactions with openshift
+* the `Certification container/exec` is the Test Suite running on the platform or in a container. The executable verifies the workload under test configuration and its interactions with OpenShift
 
-* the `Debug` pods are part of a Kubernetes daemonset responsible to run various **privileged commands** on kubernetes nodes. Debug pods are useful to run platform tests and test commands (e.g. ping) in container namespaces without changing the container image content. The debug daemonset is instantiated via the [privileged-daemonset](https://github.com/test-network-function/privileged-daemonset) repository.
+* the `Debug` pods are part of a Kubernetes daemonset responsible to run various **privileged commands** on Kubernetes nodes. Debug pods are useful to run platform tests and test commands (e.g. ping) in container namespaces without changing the container image content. The debug daemonset is instantiated via the [privileged-daemonset](https://github.com/test-network-function/privileged-daemonset) repository.

--- a/docs/test-output.md
+++ b/docs/test-output.md
@@ -3,7 +3,7 @@
 
 ## Claim File
 
-The test suite generates an output file, named **claim** file. This file is considered as the proof of CNFs test run, evaluated by Red Hat when **certified** status is considered.
+The test suite generates an output file, named **claim** file. This file is considered as the proof of the workload's test run, evaluated by Red Hat when **certified** status is considered.
 
 This file describes the following
 
@@ -15,7 +15,7 @@ This file describes the following
 
 When submitting results back to Red Hat for certification, please include the above mentioned claim file, the JUnit file, and any available console logs.
 
-**How to add a CNF platform test result to the existing claim file?**
+**How to add a workload platform test result to the existing claim file?**
 
 ```go
 go run cmd/tools/cmd/main.go claim-add --claimfile=claim.json
@@ -77,11 +77,11 @@ A standalone HTML page is available to decode the results.
 For more details, see:
 https://github.com/test-network-function/parser
 
-## Compare claim files from two different CNF Certification Suite runs
+## Compare claim files from two different Test Suite runs
 
 Partners can use the `tnf claim compare` tool in order to compare two claim files. The differences are shown in a table per section.
 This tool can be helpful when the result of some test cases is different between two (consecutive) runs, as it shows
-configuration differences in both the CNF Cert Suite config and the cluster nodes that could be the root cause for
+configuration differences in both the Test Suite config and the cluster nodes that could be the root cause for
 some of the test cases results discrepancy.
 
 All the compared sections, except the test cases results are compared blindly, traversing the whole json tree and
@@ -165,7 +165,7 @@ make build-tnf-tool
 
 #### Different test cases results
 
-Let's assume we have two claim files, claim1.json and claim2.json, obtained from two CNF Certification Suite runs in the same cluster.
+Let's assume we have two claim files, claim1.json and claim2.json, obtained from two Test Suite runs in the same cluster.
 
 During the second run, there was a test case that failed. Let's simulate it modifying manually the second run's claim file to switch one test case's state from "passed" to "failed".
 
@@ -182,7 +182,7 @@ The versions section comparison appears at the very beginning of the `tnf claim 
 <object type="image/svg+xml" data="../assets/images/claim-compare-versions.svg" width="100%" height=auto></object>
 <!-- markdownlint-disable MD033 -->
 
-Now, let's simulate that the cluster was a bit different when the second CNF Certification Suite run was performed. First, let's make a manual change in claim2.json to emulate a different CNI version in the first node.
+Now, let's simulate that the cluster was a bit different when the second Test Suite run was performed. First, let's make a manual change in claim2.json to emulate a different CNI version in the first node.
 
 <!-- markdownlint-disable MD033 -->
 <object type="image/svg+xml" data="../assets/images/claim-compare-cni.svg" width="100%" height=auto></object>

--- a/docs/test-spec.md
+++ b/docs/test-spec.md
@@ -3,22 +3,22 @@
 
 ## Available Test Specs
 
-There are two categories for CNF tests.
+There are two categories for workload tests.
 
 - **General**
 
-These tests are designed to test any commodity CNF running on OpenShift, and include specifications such as
+These tests are designed to test any commodity workload running on OpenShift, and include specifications such as
 `Default` network connectivity.
 
-- **CNF-Specific**
+- **Workload-Specific**
 
-These tests are designed to test some unique aspects of the CNF under test are behaving correctly. This could
+These tests are designed to test some unique aspects of the workload under test are behaving correctly. This could
 include specifications such as issuing a `GET` request to a web server, or passing traffic through an IPSEC tunnel.
 
 ### General tests
 
 These tests belong to multiple suites that can be run in any combination as is
-appropriate for the CNFs under test.
+appropriate for the workload under test.
 
 !!! info
 
@@ -31,13 +31,13 @@ Suite|Test Spec Description|Minimum OpenShift Version
 `lifecycle`| The lifecycle test suite verifies the pods deployment, creation, shutdown and  survivability. |4.6.0
 `networking`|The networking test suite contains tests that check connectivity and networking config related best practices.|4.6.0
 `operator`|The operator test suite is designed to test basic Kubernetes Operator functionality.|4.6.0
-`platform-alteration`| verifies that key platform configuration is not modified by the CNF under test|4.6.0
-`observability`|  the observability test suite contains tests that check CNF logging is following best practices and that CRDs have status fields|4.6.0
+`platform-alteration`| verifies that key platform configuration is not modified by the workload under test|4.6.0
+`observability`|  the observability test suite contains tests that check workload logging is following best practices and that CRDs have status fields|4.6.0
 
 !!! info
 
     Please refer [CATALOG.md](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md) for more details.
 
-### CNF-specific tests
+### Workload-specific tests
 
 TODO

--- a/docs/test-standalone.md
+++ b/docs/test-standalone.md
@@ -47,11 +47,11 @@ In order to build the test executable, first make sure you have satisfied the [d
 make build-cnf-tests
 ```
 
-*Gotcha:* The `make build*` commands run unit tests where appropriate. They do NOT test the CNF.
+*Gotcha:* The `make build*` commands run unit tests where appropriate. They do NOT test the workload.
 
-### 3. Test a CNF
+### 3. Test a workload
 
-A CNF is tested by specifying which suites to run using the `run-cnf-suites.sh` helper
+A workload is tested by specifying which suites to run using the `run-cnf-suites.sh` helper
 script.
 
 Run any combination of the suites keywords listed at in the [General tests](test-spec.md#general-tests) section, e.g.
@@ -120,7 +120,7 @@ To run the tests in an offline environment, skip the tests using the `l` option.
 
 Alternatively, if an offline DB for containers, helm charts and operators is available, there is no need to skip those tests if the environment variable `TNF_OFFLINE_DB` is set to the DB location. This DB can be generated using the [OCT tool](https://github.com/test-network-function/oct).
 
-Note: Only partner certified images are stored in the offline database. If Redhat images are checked against the offline database, they will show up as not certified. The online database includes both Partner and Redhat images.
+Note: Only partner certified images are stored in the offline database. If Red Hat images are checked against the offline database, they will show up as not certified. The online database includes both Partner and Redhat images.
 
 #### Output tar.gz file with results and web viewer files
 
@@ -133,6 +133,6 @@ Two env vars allow to control the web artifacts and the the new tar.gz file gene
 * TNF_OMIT_ARTIFACTS_ZIP_FILE=true/false : Defaulted to false in the launch scripts. If set to true, the tar.gz generation will be skipped.
 * TNF_INCLUDE_WEB_FILES_IN_OUTPUT_FOLDER=true/false : Defaulted to false in the launch scripts. If set to true, the web viewer/parser files will also be copied to the output (claim) folder.
 
-### Build + Test a CNF
+### Build + Test a workload
 
 Refer [Developers' Guide](developers.md)

--- a/docs/workload-developers.md
+++ b/docs/workload-developers.md
@@ -1,14 +1,14 @@
 <!-- markdownlint-disable header-increment line-length no-bare-urls no-emphasis-as-heading -->
-# CNF Developers Guidelines
+# Workload Guidelines for developers
 
-Developers of CNFs, particularly those targeting
-[CNF Certification with Red Hat on OpenShift](https://redhat-connect.gitbook.io/openshift-badges/badges/cloud-native-network-functions-cnf),
-can use this suite to test the interaction of their CNF with OpenShift.  If interested in CNF Certification
+Developers of Kubernetes workloads, particularly those targeting
+[certification with Red Hat on OpenShift](https://redhat-connect.gitbook.io/openshift-badges/badges/cloud-native-network-functions-cnf),
+can use this suite to test the interaction of their workload with OpenShift.  If interested in certification
 please contact [Red Hat](https://redhat-connect.gitbook.io/red-hat-partner-connect-general-guide/managing-your-account/getting-help/technology-partner-success-desk).
 
 **Requirements**
 
-- [OpenShift 4.10 installation](https://docs.openshift.com/container-platform/4.10/welcome/index.html) to run the CNFs
+- [OpenShift 4.10 installation](https://docs.openshift.com/container-platform/4.10/welcome/index.html) to run the workload
 - At least one extra machine to host the test suite
 
 ### To add private test cases

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 ---
-site_name: CNF Certification Test
+site_name: Red Hat Best Practices Test Suite for Kubernetes
 repo_name: GitHub
 repo_url: https://github.com/test-network-function/cnf-certification-test/
 theme:
@@ -74,6 +74,6 @@ nav:
   - Exception Process: "exception.md"
   - Developers' Guide:
       - Developers: "developers.md"
-      - CNF Developers: "cnf-developers.md"
+      - Workload Developers: "workload-developers.md"
   - Reference:
       - reference.md


### PR DESCRIPTION
The references to "CNF Certification" or "CNF Certification Suite" have been changed to "Red Hat Best Practices Test Suite for Kubernetes" or a simplified version of this name, such as "Test Suite", when the meaning is clear from the context.

Also, to broaden the scope of the potential targets of the Test Suite the work "CNF" has been replaced for "workload" where applicable.