### PR TITLE
Update oct to v0.0.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -217,7 +217,7 @@ require (
 	github.com/openshift/machine-config-operator v0.0.1-0.20230515070935-49f32d46538e
 	github.com/redhat-openshift-ecosystem/openshift-preflight v0.0.0-20240304171931-f19c2a2f587f
 	github.com/robert-nix/ansihtml v1.0.1
-	github.com/test-network-function/oct v0.0.8
+	github.com/test-network-function/oct v0.0.9
 	github.com/test-network-function/privileged-daemonset v1.0.22
 	golang.org/x/term v0.19.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -447,8 +447,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/test-network-function/oct v0.0.8 h1:uvFxOu28x3Bbk8tiqlvO/w/d81fw1L9oHont9p/uLbc=
-github.com/test-network-function/oct v0.0.8/go.mod h1:uQkGcKyfiFfur/YqMuYgYC3+qwc4cKhUdHaenoyjyGo=
+github.com/test-network-function/oct v0.0.9 h1:8PoZE0KarH7Ad2pccePuKFLEed6RAQLXrPDQb3qVGIc=
+github.com/test-network-function/oct v0.0.9/go.mod h1:uQkGcKyfiFfur/YqMuYgYC3+qwc4cKhUdHaenoyjyGo=
 github.com/test-network-function/privileged-daemonset v1.0.22 h1:rYvZnh/+Cd7g03eGfKVbCsNOiSRMSIvtZZYI8bf3NmU=
 github.com/test-network-function/privileged-daemonset v1.0.22/go.mod h1:TCdk0HMqvNyCyRHmERQ0FW1pdECHJ8C4plwQQEwkF3s=
 github.com/test-network-function/test-network-function-claim v1.0.36 h1:Gez1dX3nIjDexd4e8qsnXBbV7v7EhxKfYmejBNIivMU=


### PR DESCRIPTION
`oct` had a bug that was not populating the offline db correctly and was not allowing for online database checks either.

See: https://github.com/test-network-function/oct/pull/104

v0.0.9 contains the fix to allow for the onlinecheck to actually work again.