### PR TITLE
Switch QE nightlies to use unstable image

### DIFF
--- a/.github/workflows/qe-ocp-414-intrusive.yaml
+++ b/.github/workflows/qe-ocp-414-intrusive.yaml
@@ -11,8 +11,31 @@ env:
   QE_REPO: test-network-function/cnfcert-tests-verification
 
 jobs:
+  pull-unstable-image:
+    runs-on: qe-ocp
+    env:
+      SHELL: /bin/bash
+      FORCE_DOWNLOAD_UNSTABLE: true
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Clone the QE repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.QE_REPO }}
+          path: cnfcert-tests-verification
+
+      - name: Run the script to pull the unstable image
+        run: ./scripts/download-unstable.sh
+        working-directory: cnfcert-tests-verification
+
   qe-ocp-414-intrusive-testing:
     runs-on: qe-ocp-414
+    needs: pull-unstable-image
+    if: needs.pull-unstable-image.result == 'success'
     strategy:
       fail-fast: false
       matrix: 
@@ -23,7 +46,7 @@ jobs:
       KUBECONFIG: '/home/labuser2/.kube/config'
       PFLT_DOCKERCONFIG: '/home/labuser2/.docker/config'
       TEST_TNF_IMAGE_NAME: quay.io/testnetworkfunction/cnf-certification-test
-      TEST_TNF_IMAGE_TAG: localtest
+      TEST_TNF_IMAGE_TAG: unstable
       DOCKER_CONFIG_DIR: '/home/labuser2/.docker'
       TNF_CONFIG_DIR: '/home/labuser2/tnf_config'
       TNF_REPORT_DIR: '/home/labuser2/tnf_report'
@@ -36,16 +59,6 @@ jobs:
 
       - name: Run initial setup
         uses: ./.github/actions/setup
-
-      - name: Preemptively prune docker resources
-        run: docker system prune -f --volumes
-
-      - name: Build the test image
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 90
-          max_attempts: 3
-          command: make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
 
       - name: Show pods
         run: oc get pods -A

--- a/.github/workflows/qe-ocp-414.yaml
+++ b/.github/workflows/qe-ocp-414.yaml
@@ -11,8 +11,31 @@ env:
   QE_REPO: test-network-function/cnfcert-tests-verification
 
 jobs:
+  pull-unstable-image:
+    runs-on: qe-ocp
+    env:
+      SHELL: /bin/bash
+      FORCE_DOWNLOAD_UNSTABLE: true
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Clone the QE repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.QE_REPO }}
+          path: cnfcert-tests-verification
+
+      - name: Run the script to pull the unstable image
+        run: ./scripts/download-unstable.sh
+        working-directory: cnfcert-tests-verification
+
   qe-ocp-414-testing:
     runs-on: qe-ocp-414
+    needs: pull-unstable-image
+    if: needs.pull-unstable-image.result == 'success'
     strategy:
       fail-fast: false
       matrix: 
@@ -22,7 +45,7 @@ jobs:
       KUBECONFIG: '/home/labuser2/.kube/config'
       PFLT_DOCKERCONFIG: '/home/labuser2/.docker/config'
       TEST_TNF_IMAGE_NAME: quay.io/testnetworkfunction/cnf-certification-test
-      TEST_TNF_IMAGE_TAG: localtest
+      TEST_TNF_IMAGE_TAG: unstable
       DOCKER_CONFIG_DIR: '/home/labuser2/.docker'
       TNF_CONFIG_DIR: '/home/labuser2/tnf_config'
       TNF_REPORT_DIR: '/home/labuser2/tnf_report'
@@ -35,16 +58,6 @@ jobs:
 
       - name: Run initial setup
         uses: ./.github/actions/setup
-
-      - name: Preemptively prune docker resources
-        run: docker system prune -f --volumes
-
-      - name: Build the test image
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 90
-          max_attempts: 3
-          command: make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
 
       - name: Show pods
         run: oc get pods -A

--- a/.github/workflows/qe-ocp-415-intrusive.yaml
+++ b/.github/workflows/qe-ocp-415-intrusive.yaml
@@ -11,8 +11,31 @@ env:
   QE_REPO: test-network-function/cnfcert-tests-verification
 
 jobs:
+  pull-unstable-image:
+    runs-on: qe-ocp
+    env:
+      SHELL: /bin/bash
+      FORCE_DOWNLOAD_UNSTABLE: true
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Clone the QE repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.QE_REPO }}
+          path: cnfcert-tests-verification
+
+      - name: Run the script to pull the unstable image
+        run: ./scripts/download-unstable.sh
+        working-directory: cnfcert-tests-verification
+
   qe-ocp-415-intrusive-testing:
     runs-on: qe-ocp
+    needs: pull-unstable-image
+    if: needs.pull-unstable-image.result == 'success'
     strategy:
       fail-fast: false
       matrix: 
@@ -23,7 +46,7 @@ jobs:
       KUBECONFIG: '/home/labuser/.kube/config'
       PFLT_DOCKERCONFIG: '/home/labuser/.docker/config'
       TEST_TNF_IMAGE_NAME: quay.io/testnetworkfunction/cnf-certification-test
-      TEST_TNF_IMAGE_TAG: localtest
+      TEST_TNF_IMAGE_TAG: unstable
       DOCKER_CONFIG_DIR: '/home/labuser/.docker'
       TNF_CONFIG_DIR: '/home/labuser/tnf_config'
       TNF_REPORT_DIR: '/home/labuser/tnf_report'
@@ -36,16 +59,6 @@ jobs:
 
       - name: Run initial setup
         uses: ./.github/actions/setup
-
-      - name: Preemptively prune docker resources
-        run: docker system prune -f --volumes
-
-      - name: Build the test image
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 90
-          max_attempts: 3
-          command: make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
 
       - name: Show pods
         run: oc get pods -A
@@ -75,7 +88,7 @@ jobs:
         with:
           timeout_minutes: 60
           max_attempts: 3
-          command: cd ${GITHUB_WORKSPACE}/cnfcert-tests-verification; FEATURES=${{matrix.suite}} TNF_REPO_PATH=${GITHUB_WORKSPACE} TNF_IMAGE=${{env.TEST_TNF_IMAGE_NAME}} TNF_IMAGE_TAG=${{env.TEST_TNF_IMAGE_TAG}} JOB_ID=${{github.run_id}} DISABLE_INTRUSIVE_TESTS=false ENABLE_PARALLEL=true ENABLE_FLAKY_RETRY=true make test-features
+          command: cd ${GITHUB_WORKSPACE}/cnfcert-tests-verification; FEATURES=${{matrix.suite}} TNF_REPO_PATH=${GITHUB_WORKSPACE} TNF_IMAGE=${{env.TEST_TNF_IMAGE_NAME}} TNF_IMAGE_TAG=${{env.TEST_TNF_IMAGE_TAG}} JOB_ID=${{github.run_id}} DISABLE_INTRUSIVE_TESTS=false ENABLE_PARALLEL=true ENABLE_FLAKY_RETRY=true make test-features 
 
       - name: (if on main and upstream) Send chat msg to dev team if failed to run QE tests
         if: ${{ failure() && github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}

--- a/.github/workflows/qe-ocp-415.yaml
+++ b/.github/workflows/qe-ocp-415.yaml
@@ -11,8 +11,31 @@ env:
   QE_REPO: test-network-function/cnfcert-tests-verification
 
 jobs:
+  pull-unstable-image:
+    runs-on: qe-ocp
+    env:
+      SHELL: /bin/bash
+      FORCE_DOWNLOAD_UNSTABLE: true
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Clone the QE repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.QE_REPO }}
+          path: cnfcert-tests-verification
+
+      - name: Run the script to pull the unstable image
+        run: ./scripts/download-unstable.sh
+        working-directory: cnfcert-tests-verification
+
   qe-ocp-415-testing:
     runs-on: qe-ocp
+    needs: pull-unstable-image
+    if: needs.pull-unstable-image.result == 'success'
     strategy:
       fail-fast: false
       matrix: 
@@ -22,7 +45,7 @@ jobs:
       KUBECONFIG: '/home/labuser/.kube/config'
       PFLT_DOCKERCONFIG: '/home/labuser/.docker/config'
       TEST_TNF_IMAGE_NAME: quay.io/testnetworkfunction/cnf-certification-test
-      TEST_TNF_IMAGE_TAG: localtest
+      TEST_TNF_IMAGE_TAG: unstable
       DOCKER_CONFIG_DIR: '/home/labuser/.docker'
       TNF_CONFIG_DIR: '/home/labuser/tnf_config'
       TNF_REPORT_DIR: '/home/labuser/tnf_report'
@@ -35,16 +58,6 @@ jobs:
 
       - name: Run initial setup
         uses: ./.github/actions/setup
-
-      - name: Preemptively prune docker resources
-        run: docker system prune -f --volumes
-
-      - name: Build the test image
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 90
-          max_attempts: 3
-          command: make build-image-local # quay.io/testnetworkfunction/cnf-certification-test:localtest
 
       - name: Show pods
         run: oc get pods -A


### PR DESCRIPTION
No need to build the image for these nightlies every run.  We already build the `unstable` image and it is available already.

Uses another job to pull the image prior to kicking off all of the tests.

Similar to: 
- https://github.com/test-network-function/cnf-certification-test-partner/pull/316
- https://github.com/test-network-function/cnfcert-tests-verification/pull/718