### PR TITLE
Remove macos runner from unit tests

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -113,7 +113,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-latest]
+        os: [ubuntu-22.04]
     env:
       SHELL: /bin/bash
 


### PR DESCRIPTION
It seems that there is a bug with the `macos-latest` runners (which are now ARM based).  Let's temporarily remove this.