### PR TITLE
cmd/tnf: add subcommand to run the test suite

### DIFF
--- a/cmd/tnf/main.go
+++ b/cmd/tnf/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/cmd/tnf/check"
 	"github.com/test-network-function/cnf-certification-test/cmd/tnf/claim"
 	"github.com/test-network-function/cnf-certification-test/cmd/tnf/generate"
+	"github.com/test-network-function/cnf-certification-test/cmd/tnf/run"
 )
 
 var (
@@ -22,6 +23,7 @@ func main() {
 	rootCmd.AddCommand(claim.NewCommand())
 	rootCmd.AddCommand(generate.NewCommand())
 	rootCmd.AddCommand(check.NewCommand())
+	rootCmd.AddCommand(run.NewCommand())
 
 	if err := rootCmd.Execute(); err != nil {
 		log.Error("%v", err)

--- a/cmd/tnf/run/run.go
+++ b/cmd/tnf/run/run.go
@@ -48,7 +48,7 @@ func initFlags(cmd *cobra.Command) {
 func runTestSuite(cmd *cobra.Command, _ []string) error {
 	initFlags(cmd)
 
-	certsuite.Startup()
+	certsuite.Startup(false)
 	defer certsuite.Shutdown()
 
 	err := certsuite.Run(*flags.LabelsFlag, *flags.OutputDir)

--- a/cmd/tnf/run/run.go
+++ b/cmd/tnf/run/run.go
@@ -1,0 +1,60 @@
+package run
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/test-network-function/cnf-certification-test/internal/log"
+	"github.com/test-network-function/cnf-certification-test/pkg/certsuite"
+	"github.com/test-network-function/cnf-certification-test/pkg/flags"
+)
+
+const timeoutFlagDefaultvalue = 24 * time.Hour
+
+var (
+	runCmd = &cobra.Command{
+		Use:   "run",
+		Short: "Run the Red Hat Best Practices Test Suite for Kubernetes",
+		RunE:  runTestSuite,
+	}
+)
+
+func NewCommand() *cobra.Command {
+	runCmd.PersistentFlags().String("output-dir", "cnf-certification-test", "The directory where the output artifacts will be placed")
+	runCmd.PersistentFlags().String("label-filter", "none", "Label expression to filter test cases  (e.g. --label-filter 'access-control && !access-control-sys-admin-capability')")
+	runCmd.PersistentFlags().String("timeout", timeoutFlagDefaultvalue.String(), "Time allowed for the test suite execution to complete (e.g. --timeout 30m  or -timeout 1h30m)")
+	runCmd.PersistentFlags().String("config-file", "cnf-certification-test/tnf_config.yml", "Name of the workload configuration file")
+	runCmd.PersistentFlags().Bool("list", false, "Shows all the available checks/tests. Can be filtered with --label-filter.")
+	runCmd.PersistentFlags().Bool("server-mode", false, "Run the certsuite in web server mode.")
+
+	return runCmd
+}
+
+func initFlags(cmd *cobra.Command) {
+	outputDir, _ := cmd.Flags().GetString("output-dir")
+	labelFilter, _ := cmd.Flags().GetString("label-filter")
+	timeout, _ := cmd.Flags().GetString("timeout")
+	list, _ := cmd.Flags().GetBool("list")
+	serverMode, _ := cmd.Flags().GetBool("server-mode")
+	configFile, _ := cmd.Flags().GetString("config-file")
+
+	flags.OutputDir = &outputDir
+	flags.LabelsFlag = &labelFilter
+	flags.TimeoutFlag = &timeout
+	flags.ListFlag = &list
+	flags.ServerModeFlag = &serverMode
+	flags.ConfigurationFile = configFile
+}
+func runTestSuite(cmd *cobra.Command, _ []string) error {
+	initFlags(cmd)
+
+	certsuite.Startup()
+	defer certsuite.Shutdown()
+
+	err := certsuite.Run(*flags.LabelsFlag, *flags.OutputDir)
+	if err != nil {
+		log.Fatal("Failed to run CNF Certification Suite: %v", err) //nolint:gocritic // exitAfterDefer
+	}
+
+	return err
+}

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 )
 
 func main() {
-	certsuite.Startup()
+	certsuite.Startup(true)
 	defer certsuite.Shutdown()
 
 	if *flags.ServerModeFlag {

--- a/pkg/certsuite/certsuite.go
+++ b/pkg/certsuite/certsuite.go
@@ -101,8 +101,15 @@ func processFlags() {
 	}
 }
 
+func isTnfSubcommand() bool {
+	cmd := strings.Split(os.Args[0], "/")
+	return cmd[len(cmd)-1] == "tnf"
+}
+
 func Startup() {
-	flags.InitFlags()
+	if !isTnfSubcommand() {
+		flags.InitFlags()
+	}
 
 	err := configuration.LoadEnvironmentVariables()
 	if err != nil {

--- a/pkg/certsuite/certsuite.go
+++ b/pkg/certsuite/certsuite.go
@@ -101,13 +101,8 @@ func processFlags() {
 	}
 }
 
-func isTnfSubcommand() bool {
-	cmd := strings.Split(os.Args[0], "/")
-	return cmd[len(cmd)-1] == "tnf"
-}
-
-func Startup() {
-	if !isTnfSubcommand() {
+func Startup(initFlags bool) {
+	if initFlags {
 		flags.InitFlags()
 	}
 

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -53,6 +53,8 @@ var (
 	TimeoutFlag    *string
 	ListFlag       *bool
 	ServerModeFlag *bool
+
+	ConfigurationFile string
 )
 
 func InitFlags() {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -34,6 +34,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/internal/log"
 	"github.com/test-network-function/cnf-certification-test/pkg/autodiscover"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
+	"github.com/test-network-function/cnf-certification-test/pkg/flags"
 	k8sPrivilegedDs "github.com/test-network-function/privileged-daemonset"
 	"helm.sh/helm/v3/pkg/release"
 	scalingv1 "k8s.io/api/autoscaling/v1"
@@ -224,6 +225,9 @@ func buildTestEnvironment() { //nolint:funlen
 	env = TestEnvironment{}
 
 	env.variables = *configuration.GetTestParameters()
+	if flags.ConfigurationFile != "" {
+		env.variables.ConfigurationPath = flags.ConfigurationFile
+	}
 	config, err := configuration.LoadConfiguration(env.variables.ConfigurationPath)
 	if err != nil {
 		log.Fatal("Cannot load configuration file: %v", err)


### PR DESCRIPTION
Use `./tnf run <flags>` to run the test suite. See `./tnf run -h `for more info.

The original way of running the test suite using the "cnf-certification-test" binary and the bash scripts is still available and used in the GitHub CI. This change just add the possibility of running the test suite with the "tnf" command.