### PR TITLE
Bug fix: avoid runtime panic (SIGSEGV) when using the list flag

### DIFF
--- a/pkg/certsuite/certsuite.go
+++ b/pkg/certsuite/certsuite.go
@@ -148,12 +148,12 @@ func Run(labelsFilter, outputFolder string) error {
 	_ = clientsholder.GetClientsHolder(getK8sClientsConfigFileNames()...)
 	LoadChecksDB(*flags.LabelsFlag)
 
-	processFlags()
-
 	// Create an evaluator to filter test cases with labels
 	if err := checksdb.InitLabelsExprEvaluator(labelsFilter); err != nil {
 		return fmt.Errorf("failed to initialize a test case label evaluator, err: %v", err)
 	}
+
+	processFlags()
 
 	fmt.Println("Running discovery of CNF target resources...")
 	fmt.Print("\n")


### PR DESCRIPTION
The evaluator for label expressions needs to be initialized before calling the method checksdb.FilterChecksIDs().