### PR TITLE
Add a workflow task to verify the "certsuite run" command

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -316,6 +316,12 @@ jobs:
       - name: Remove tarball(s) to save disk space
         run: rm -f cnf-certification-test/*.tar.gz
 
+      - name: 'Test: Run test suites with certsuite command'
+        run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./certsuite run --label-filter="${SMOKE_TESTS_LABELS_FILTER} --output-dir=certsuite-out"
+
+      - name: 'Check the smoke test results (run with the certsuite cmd) against the expected results template'
+        run: ./certsuite check results --log-file=certsuite-out/cnf-certsuite.log
+
   smoke-tests-container:
     name: Run Container Smoke Tests
     runs-on: ubuntu-24.04

--- a/pkg/certsuite/certsuite.go
+++ b/pkg/certsuite/certsuite.go
@@ -108,14 +108,14 @@ func Startup(initFlags bool) {
 
 	err := configuration.LoadEnvironmentVariables()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Could not load the environment variables, err: %v", err)
+		fmt.Fprintf(os.Stderr, "Could not load the environment variables, err: %v\n", err)
 		os.Exit(1)
 	}
 
 	logLevel := configuration.GetTestParameters().LogLevel
 	err = log.CreateGlobalLogFile(*flags.OutputDir, logLevel)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Could not create the log file, err: %v", err)
+		fmt.Fprintf(os.Stderr, "Could not create the log file, err: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -139,7 +139,7 @@ func Startup(initFlags bool) {
 func Shutdown() {
 	err := log.CloseGlobalLogFile()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Could not close the log file, err: %v", err)
+		fmt.Fprintf(os.Stderr, "Could not close the log file, err: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Also, create by default the output directory for the test results if it does not exists. Only applicable when the test suite is run with the certsuite command.