### PR TITLE
Switch RHCOS job back to 22.04

### DIFF
--- a/.github/workflows/update-rhcos-mapping.yml
+++ b/.github/workflows/update-rhcos-mapping.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write  # for peter-evans/create-pull-request to create branch
       pull-requests: write  # for peter-evans/create-pull-request to create a PR
     name: Update offline mapping of RHCOS to OCP version
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     env:
       SHELL: /bin/bash        
 


### PR DESCRIPTION
Looks like the `oc` client isn't preloaded into ubuntu-24.04.