### PR TITLE
Parse flags after env vars to override them if required

### DIFF
--- a/cmd/certsuite/run/run.go
+++ b/cmd/certsuite/run/run.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/test-network-function/cnf-certification-test/internal/log"
 	"github.com/test-network-function/cnf-certification-test/pkg/certsuite"
+	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
 	"github.com/test-network-function/cnf-certification-test/pkg/flags"
 )
 
@@ -30,7 +31,9 @@ func NewCommand() *cobra.Command {
 	return runCmd
 }
 
-func initFlags(cmd *cobra.Command) {
+func initFlags(arg interface{}) {
+	cmd := arg.(*cobra.Command)
+
 	outputDir, _ := cmd.Flags().GetString("output-dir")
 	labelFilter, _ := cmd.Flags().GetString("label-filter")
 	timeout, _ := cmd.Flags().GetString("timeout")
@@ -44,11 +47,13 @@ func initFlags(cmd *cobra.Command) {
 	flags.ListFlag = &list
 	flags.ServerModeFlag = &serverMode
 	flags.ConfigurationFile = configFile
+
+	// Override env vars
+	testParams := configuration.GetTestParameters()
+	testParams.ConfigurationPath = configFile
 }
 func runTestSuite(cmd *cobra.Command, _ []string) error {
-	initFlags(cmd)
-
-	certsuite.Startup(false)
+	certsuite.Startup(initFlags, cmd)
 	defer certsuite.Shutdown()
 
 	err := certsuite.Run(*flags.LabelsFlag, *flags.OutputDir)

--- a/cnf-certification-test/results/html/results.html
+++ b/cnf-certification-test/results/html/results.html
@@ -1,1 +1,230 @@
-This is a placeholder for the results.html file that will be downloaded from https://github.com/test-network-function/parser when this project is built
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>CNF Certification Test Parser</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="shortcut icon"
+        type="image/svg+xml"
+        sizes="any"
+        href="https://ux.redhat.com/assets/logo-red-hat.svg">
+        <link rel="shortcut icon" href="/assets/logo-red-hat.svg">
+        <link rel="preconnect" href="https://ga.jspm.io">
+        <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link rel="stylesheet" href="https://ux.redhat.com/assets/packages/@rhds/elements/elements/rh-footer/rh-footer-lightdom.css">
+  <script type="importmap">
+    {
+      "imports": {
+        "@rhds/elements/": "https://ga.jspm.io/npm:@rhds/elements@1.2.0/elements/",
+        "@rhds/elements/lib/": "https://ga.jspm.io/npm:@rhds/elements@1.2.0/elements/lib/",
+        "@patternfly/elements/": "https://ga.jspm.io/npm:@patternfly/elements@2.4.0/"
+      },
+      "scopes": {
+        "https://ga.jspm.io/": {
+          "@lit/reactive-element": "https://ga.jspm.io/npm:@lit/reactive-element@1.6.3/reactive-element.js",
+          "@lit/reactive-element/decorators/": "https://ga.jspm.io/npm:@lit/reactive-element@1.6.3/decorators/",
+          "@patternfly/elements/": "https://ga.jspm.io/npm:@patternfly/elements@2.4.0/",
+          "@patternfly/pfe-core": "https://ga.jspm.io/npm:@patternfly/pfe-core@2.4.1/core.js",
+          "@patternfly/pfe-core/": "https://ga.jspm.io/npm:@patternfly/pfe-core@2.4.1/",
+          "@rhds/tokens/media.js": "https://ga.jspm.io/npm:@rhds/tokens@1.1.2/js/media.js",
+          "lit": "https://ga.jspm.io/npm:lit@2.8.0/index.js",
+          "lit-element/lit-element.js": "https://ga.jspm.io/npm:lit-element@3.3.3/lit-element.js",
+          "lit-html": "https://ga.jspm.io/npm:lit-html@2.8.0/lit-html.js",
+          "lit-html/": "https://ga.jspm.io/npm:lit-html@2.8.0/",
+          "lit/": "https://ga.jspm.io/npm:lit@2.8.0/",
+          "tslib": "https://ga.jspm.io/npm:tslib@2.6.2/tslib.es6.mjs"
+        },
+        "https://ga.jspm.io/npm:@patternfly/elements@2.4.0/": {
+          "lit": "https://ga.jspm.io/npm:lit@2.6.1/index.js",
+          "lit/": "https://ga.jspm.io/npm:lit@2.6.1/"
+        }
+      }
+    }
+  </script>
+  <script type="module">
+    // import design system element definitions,
+    // which auto-register their tagnames once executed
+    import '@rhds/elements/rh-button/rh-button.js';
+    import '@rhds/elements/rh-dialog/rh-dialog.js';
+    import '@rhds/elements/rh-footer/rh-footer-universal.js';
+    import '@patternfly/elements/pf-text-input/pf-text-input.js';
+    import '@rhds/elements/rh-tabs/rh-tabs.js';
+    import '@rhds/elements/rh-accordion/rh-accordion.js';
+    import '@rhds/elements/rh-table/rh-table.js';
+    import 'https://jspm.dev/@rhds/elements/rh-tag/rh-tag.js'
+</script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" integrity="sha256-2TnSHycBDAm2wpZmgdi0z81kykGPJAkiUY+Wf97RbvY=" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://getbootstrap.com/docs/5.3/assets/css/docs.css" integrity="sha256-NMC47kc7OBPhLkw/Q1Vxza+y2Nr9LkHyFuBnnNjFPwI=" crossorigin="anonymous">
+  <link rel="stylesheet"
+    href="https://ux.redhat.com/assets/packages/@rhds/elements/elements/rh-table/rh-table-lightdom.css">  <style>@keyframes anim-minus{to{transform:rotate(90deg)}}body,html{font-family:var(--rh-font-family-body-text, RedHatText, "Red Hat Text", "Noto Sans Arabic", "Noto Sans Hebrew", Helvetica, Arial, sans-serif);margin:0;padding:0;height:100%}progress{height:20px;width:0%}h1{font-size:var(--rh-font-size-heading-2xl, 3rem);margin:0}datalist,main{display:flex;flex-direction:column}main{grid-area:main;margin:var(--rh-space-xl, 10px);gap:var(--rh-space-lg, 16px);flex-flow:row wrap;margin-block:10px;margin-inline:20px}[data-demo],form{display:contents}fieldset{display:grid;flex:1 1 100%}label{font-weight:var(--rh-font-weight-heading-bold, 700);margin-block-end:var(--rh-space-sm, 6px)}body{color:var(--rh-color-text-primary-on-light, #151515);background-color:var(--rh-color-surface-lightest, #fff);display:grid;grid-template-areas:"header""progress""main""footer"}body.dark{color:var(--rh-color-text-primary-on-dark, #fff);background-color:var(--rh-color-surface-darkest, #151515)}section{padding:16px}form h2,rh-tabs{width:100%}form output{text-transform:capitalize}datalist{justify-content:space-between;writing-mode:vertical-lr}datalist,input{width:200px}option{padding:0}a{color:var(--rh-color-interactive-blue-darker, #06c)}input[type=checkbox],label,ul li a,ul li span{display:inline-block}ul li a{border-radius:50%;color:#000;height:1.5em;left:-1.5em;line-height:1.5em;text-align:center;text-decoration:none;width:1.5em}a:hover{color:var(--rh-color-interactive-blue-darkest, #004080)}a:visited{color:var(--rh-color-interactive-purple-darker, #6753ac)}.dark a{color:var(--rh-color-interactive-blue-lighter, #73bcf7)}ul li a:active{top:1px}.dark a:hover{color:var(--rh-color-interactive-blue-lightest, #bee1f4)}.dark a:visited{color:var(--rh-color-interactive-purple-lighter, #a18fff)}ul li{border-bottom-left-radius:.75em;border-top-left-radius:.75em;margin:2px 0;position:relative}#config-table li,#nodes-table li,ul{list-style:none}rh-accordion-header rh-tag{margin-inline-start:var(--rh-space-md, 8px)}.tag-header,header,progress{display:flex;align-items:center}.tag-header{gap:var(--rh-space-lg, 16px)}tblack{font-size:17px}input.larger-checkbox{width:17px;height:17px}ul{padding-left:1.75em}svg{pointer-events:none}ul li a.minus{animation-name:anim-minus;animation-duration:.1s;animation-fill-mode:forwards}ul li span{margin:.25em .5em}.top-right{font-size:small;position:fixed;right:1em;top:1em}div.mb-3{display:grid;grid-template-areas:"inputs-header filters-header outputs-header""inputs filters outputs";gap:10px;margin-left:auto;margin-right:0;margin-top:10px}#inputs{grid-area:inputs}#filters{grid-area:filters;gap:5px}#outputs{grid-area:outputs;gap:10px}div.inputs-header{grid-area:inputs-header}div.filters-header{grid-area:filters-header;gap:5px}div.outputs-header{grid-area:outputs-header;gap:10px}header{background:var(--rh-color-surface-darkest, #151515);color:var(--rh-color-text-primary-on-dark, #fff);padding-inline:var(--rh-space-xl, 24px);gap:var(--rh-space-xl, 24px)}div.progress{height:20px;width:100%;grid-area:progress}rh-tabs{min-height:1200px}rh-footer-universal{grid-area:footer;margin-block-start:auto}div.float-right{float:right}.flow-column,.flow-row{display:flex;flex-direction:column;justify-content:flex-start}.flow-row{flex-direction:row;gap:var(--rh-space-xl, 24px)}#mandatory-checkbox,#optional-checkbox{width:20px;margin-right:0;margin-left:auto}.read-only{pointer-events:none;opacity:.5}.test-header{font-size:25px;line-height:25px;font-weight:400}.test-section{font-size:20px;line-height:20px;font-weight:700}.test-subsection{font-size:15px;line-height:15px;font-weight:700}</style>
+  <script src="https://cdn.jsdelivr.net/npm/dayjs@1.10.4/dayjs.min.js" integrity="sha256-NTsR4SOm3YHfJrmrmvBtEYqfQ6jQ5yvEKMhgQe3DIl0=" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dayjs@1.10.4/plugin/duration.js" integrity="sha256-pqOo8IK7KpViodnVHibVieA1r77f96mxs6Ssu9SDTAo=" crossorigin="anonymous"></script>  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.0/jquery.min.js" integrity="sha256-2Pmvv0kuTBOenSvLm6bvfBSSHrUJ+3A7x6P5Ebd07/g=" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha256-0upsHgyryiDRjpJLJaHNAYfDi6fDP2CrBuGwQCubzbU=" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/ansi_up@5.1.0/ansi_up.js" integrity="sha256-tarXJ7M5ReiY9qzPiDQdY5EZcrMil9PaXwnVbAgWbo8=" crossorigin="anonymous"></script>
+  <script>const expectedClaimVersion="v0.4.0";let claimGlobal,feedbackGlobal,isResultTabActive=!1,uuidNode=1;function selectScenarioHandler(){!0===isResultTabActive&&refreshResultsTabContent()}function refreshResultsTabContent(){hideAllResultsTabObjects(),enableFiltersResults(),isResultTabActive=!0;const e=document.getElementById("selectScenarioComboBox");"all"===e.options[e.selectedIndex].value?(showAll(),disableCheckboxOnShowAll()):(enableCheckbox(),document.getElementById("results-table").setAttribute("hidden","hidden"),enableFiltersResults(),document.getElementById("optional-checkbox").removeAttribute("hidden"),document.getElementById("myCheck-mandatory").removeAttribute("hidden")),makeResultsTableVisible("optional"),makeResultsTableVisible("mandatory")}function makeResultsTableVisible(e){const t=document.getElementById(e+"-checkbox"),n=document.getElementById("selectScenarioComboBox"),l=n.options[n.selectedIndex].value;"faredge"===l&&(!0===t.checked?document.getElementById(e+"-far-edge-table").removeAttribute("hidden"):document.getElementById(e+"-far-edge-table").setAttribute("hidden","hidden")),"telco"===l&&(!0===t.checked?document.getElementById(e+"-telco-table").removeAttribute("hidden"):document.getElementById(e+"-telco-table").setAttribute("hidden","hidden")),"nontelco"===l&&(!0===t.checked?document.getElementById(e+"-non-telco-table").removeAttribute("hidden"):document.getElementById(e+"-non-telco-table").setAttribute("hidden","hidden")),"extended"===l&&(!0===t.checked?document.getElementById(e+"-extended-table").removeAttribute("hidden"):document.getElementById(e+"-extended-table").setAttribute("hidden","hidden"))}function filterTestCasesBasedOnStateHandler(e,t,n,l){const o=document.getElementById("filter-"+l+"-"+n+"-"+t),a=o.checked;a?o.setAttribute("checked",""):o.removeAttribute("checked");const s=e.replace(/#/g,""),d=document.getElementById(s).getElementsByTagName("rh-accordion-header");for(let e=0;e<d.length;e++){const t=d[e];t.getAttribute("data-id")===n&&(!0===a?t.removeAttribute("hidden"):t.setAttribute("hidden","hidden"))}}function showAll(){document.getElementById("mandatory-far-edge-table").setAttribute("hidden","hidden"),document.getElementById("mandatory-telco-table").setAttribute("hidden","hidden"),document.getElementById("mandatory-non-telco-table").setAttribute("hidden","hidden"),document.getElementById("mandatory-extended-table").setAttribute("hidden","hidden"),document.getElementById("optional-far-edge-table").setAttribute("hidden","hidden"),document.getElementById("optional-telco-table").setAttribute("hidden","hidden"),document.getElementById("optional-non-telco-table").setAttribute("hidden","hidden"),document.getElementById("optional-extended-table").setAttribute("hidden","hidden"),document.getElementById("results-table").removeAttribute("hidden")}function disableFiltersResults(){document.getElementById("filters").classList.add("read-only"),document.getElementById("outputs").classList.add("read-only"),document.getElementById("downloadjsonHandler").setAttribute("disabled",""),document.getElementById("download").setAttribute("disabled","")}function enableFiltersResults(){document.getElementById("filters").classList.remove("read-only"),document.getElementById("outputs").classList.remove("read-only"),document.getElementById("downloadjsonHandler").removeAttribute("disabled"),document.getElementById("download").removeAttribute("disabled")}function disableCheckboxOnShowAll(){document.getElementById("mandatoryChecked").classList.add("read-only"),document.getElementById("optionalChecked").classList.add("read-only")}function enableCheckbox(){document.getElementById("mandatoryChecked").classList.remove("read-only"),document.getElementById("optionalChecked").classList.remove("read-only")}function hideAllResultsTabObjects(){isResultTabActive=!1,document.getElementById("progress-bar").setAttribute("hidden","hidden"),document.getElementById("mandatory-far-edge-table").setAttribute("hidden","hidden"),document.getElementById("mandatory-non-telco-table").setAttribute("hidden","hidden"),document.getElementById("mandatory-extended-table").setAttribute("hidden","hidden"),document.getElementById("mandatory-telco-table").setAttribute("hidden","hidden"),document.getElementById("optional-far-edge-table").setAttribute("hidden","hidden"),document.getElementById("optional-non-telco-table").setAttribute("hidden","hidden"),document.getElementById("optional-extended-table").setAttribute("hidden","hidden"),disableFiltersResults()}function fillVersionsElement(e,t){$(t).empty(),$('<colgroup><col><col></colgroup><thead><tr><th scope="col" data-label="Component">Component</th><th scope="col" data-label="Version">Version</th></tr></thead><tbody>').appendTo($(t));for(const n in e)$('<tr><td data-label="Component"><b>'+n+'</b></td><td data-label="Version">'+e[n]+"</td></tr>").appendTo($(t));$("</tbody>").appendTo($(t))}function getClaimVersion(e){const t=e.claimFormat;if(void 0===t)return"nil - claimFormat version not present in claim file";const n=t.match(/(v[0-9]\.[0-9]\.[0-9])/);return null!==n&&n.length>1?n[1]:"nil - claimFormat version is not in a valid format, check claim file"}function fillMetadata(e,t){$(t).empty(),$("<tbody>").appendTo($(t));for(const n in e)$("<tr><td><b>"+n+"</b></td><td>"+e[n]+"</td></tr>").appendTo($(t));$("</tbody>").appendTo($(t))}$(document).ready((function(){"undefined"!=typeof initialjson&&(claimGlobal=initialjson),"undefined"!=typeof feedback&&(feedbackGlobal=feedback);const e=window.location.search,t=new URLSearchParams(e),n=t.get("claimfile"),l=t.get("feedback");console.log("claimfile via url:",n),console.log("feedbackfile via url:",l),fetchRenderClaimFile(n),fetchRenderFeedbackFile(l),void 0!==claimGlobal&&renderResultsWithModal();document.getElementById("feedbackFile").addEventListener("change",(function(){const e=this.files;if(e.length){const t=new FileReader;t.addEventListener("load",(e=>{fillFeedback(JSON.parse(t.result))})),t.readAsText(e[0])}this.value=null}),!1);document.getElementById("formFile").addEventListener("change",handleFiles,!1)}));const tableNameMap={faredge:"Far-Edge",telco:"Telco",nontelco:"Non-Telco",extended:"Extended",all:"All"};function getTestCaseStats(e,t){let n=0,l=0,o=0,a=0,s=0,d=0,i=0,r=0,c=0;for(const m in e){const u=e[m];let h=u.categoryClassification.FarEdge;"telco"===t&&(h=u.categoryClassification.Telco),"nontelco"===t&&(h=u.categoryClassification.NonTelco),"extended"===t&&(h=u.categoryClassification.Extended),"passed"===u.state?"Mandatory"===h||"all"===t?(n++,l++):d++:"skipped"===u.state?"Mandatory"===h||"all"===t?(n++,o++):i++:"failed"===u.state?"Mandatory"===h||"all"===t?(n++,a++):r++:"aborted"===u.state&&("Mandatory"===h||"all"===t?(n++,s++):c++)}return{testsTotal:n,testsPassed:l,testsSkipped:o,testsFailed:a,testsAborted:s,testsPassedOptional:d,testsSkippedOptional:i,testsFailedOptional:r,testsAbortedOptional:c}}function generateTestCasesStatsElement(e,t,n,l,o,a,s,d,i){let r="";return r="all"===t?'<thead><tr><th style="width:15%" scope="col">Test summary ('+tableNameMap[t]+')</th><th scope="col">Test feedback</th></tr></thead><tbody>':'<thead><tr><th style="width:15%" scope="col">'+n+" Test  summary ("+tableNameMap[t]+')</th><th scope="col">Test feedback</th></tr></thead><tbody>',r+='<tr><td class="align-top"><b><tblack>Total:</tblack></b><tblack> '+o+'</tblack><br><rh-tag color="green"> Passed </rh-tag></b> <tblack>'+a+"</tblack> ",r+='<input type="checkbox" class="larger-checkbox" id="filter-'+n+"-passed-"+t+'" checked onclick="filterTestCasesBasedOnStateHandler(\''+e+"','"+t+"', 'passed','"+n+"' )\" >",r+='<br><b><rh-tag color="gray"> Skipped </rh-tag></b> <tblack>'+s+"</tblack> ",r+='<input type="checkbox" class="larger-checkbox" id="filter-'+n+"-skipped-"+t+'" checked onclick="filterTestCasesBasedOnStateHandler(\''+e+"','"+t+"', 'skipped', '"+n+"' )\" >",r+='<br><b><rh-tag color="red"> Failed </rh-tag></b> <tblack>'+d+"</tblack> ",r+='<input type="checkbox" class="larger-checkbox" id="filter-'+n+"-failed-"+t+'" checked onclick="filterTestCasesBasedOnStateHandler(\''+e+"','"+t+"', 'failed', '"+n+"' )\" >",r+='<br><b><rh-tag color="purple"> Aborted </rh-tag></b> <tblack>'+i+"</tblack> ",r+='<input type="checkbox" class="larger-checkbox" id="filter-'+n+"-aborted-"+t+'" checked onclick="filterTestCasesBasedOnStateHandler(\''+e+"','"+t+"', 'aborted', '"+n+"' )\" >",r+="</td><td>",r+='<rh-accordion class="rh-accordion" id="results-accordion">',r}function generateTestcaseSingleResultElement(e,t,n,l){const o=new AnsiUp;let a="";const s=e.state;let d="";"passed"===s?d='<rh-tag color="green">Passed</rh-tag></div>':"skipped"===s?d='<rh-tag color="gray">Skipped</rh-tag></div>':"aborted"===s?d='<rh-tag color="purple">Aborted</rh-tag></div>':(d='<rh-tag color="red">Failed</rh-tag></div>',"Optional"===l&&"all"!==t||(d='<rh-tag color="red">failed</rh-tag></div>'));const i="collapse"+n,r="heading"+n;a+='<rh-accordion-header id="'+r+'" data-id="'+s+'" data-bs-target="#'+i+'" aria-expanded="true"><div class=tag-header><h1 class="test-header">'+e.testID.id+d+"</h1></rh-accordion-header>",a+='<rh-accordion-panel id="'+i+'"aria-labelledby="'+r+">",a+='<div class="table-responsive">',a+='<h1 class="test-section">Results</h1>',a+='<table id="myTable-'+e.testID.id+'" class="table table-bordered"><thead><tr>',a+="<th>Test ID</th>",a+='<th class="th-lg">Test Text</th>',a+="<th>Duration</th>",a+="<th>State</th>",a+="<th>Test output</th>",a+="</tr></thead><tbody>",dayjs.extend(window.dayjs_plugin_duration);const c=dayjs.duration(e.duration/1e6).format("D[d] H[h] m[m] s[s] SSS[ms]");let m="";"skipped"===e.state&&(m=e.skipReason,""===m&&(m="Test case skipped by configuration"),m=" ( "+m+" )"),a+='<tr><td  style="white-space: nowrap;">'+e.testID.id+"</td>",a+='<td class="th-lg">'+e.catalogInfo.description.replace(/\n/g,"<br>")+"</td>",a+="<td>"+c+"</td>",a+="<td><b>"+e.state+"</b>"+m+"</td>",a+="<td>"+o.ansi_to_html(e.capturedTestOutput).replace(/\n/g,"<br>")+"</td></tr>";const u=NonCompliantReasonTextToJson(e.checkDetails),h=CompliantReasonTextToJson(e.checkDetails);return a+="</tbody></table></div>",a+='<h1 class="test-section">Feedback</h1><label>Write your feedback for '+e.testID.id+" test case</label>",a+='<textarea style="width: 100%; margin: 0 auto;" rows = "5" id="source-'+t+"-"+e.testID.id+'" type="text"></textarea>',a+='<h1 class="test-section">Non-Compliant objects</h1>',a+=createReasonTableAllTypes(u),a+='<h1 class="test-section">Compliant objects</h1>',a+=createReasonTableAllTypes(h),a+="</rh-accordion-panel>",a}function fillResults(e,t,n,l){const o=Object.entries(e).sort((function(e,t){const n=e[1].testID.id+e[1].state,l=t[1].testID.id+t[1].state;return n.localeCompare(l)})),a=Object.fromEntries(o),s=getTestCaseStats(e,l);let d=generateTestCasesStatsElement(t,l,"mandatory","tred",s.testsTotal,s.testsPassed,s.testsSkipped,s.testsFailed,s.testsAborted),i=generateTestCasesStatsElement(n,l,"optional","ty",s.testsTotal,s.testsPassedOptional,s.testsSkippedOptional,s.testsFailedOptional,s.testsAbortedOptional),r=1;for(const t in a){const n=e[t];let o=n.categoryClassification.FarEdge;"telco"===l&&(o=n.categoryClassification.Telco),"nontelco"===l&&(o=n.categoryClassification.NonTelco),"extended"===l&&(o=n.categoryClassification.Extended),r+=1;const a=generateTestcaseSingleResultElement(n,l,r,o);"Mandatory"===o||"all"===l?d+=a:i+=a}d+="</rh-accordion></td></tr></tbody>",i+="</rh-accordion></td></tr></tbody>",$(d).appendTo($(t)),"all"!==l&&$(i).appendTo($(n))}function fillFeedback(e){for(const t in e){const n=document.getElementById(t);null!==n&&(n.textContent=n.value,n.textContent=e[t],n.value=e[t])}}function saveTextAreaContent(e){const t=document.getElementById("selectScenarioComboBox"),n="source-"+t.options[t.selectedIndex].value+"-"+e;console.log(n);const l=document.getElementById(n).value;document.getElementById(n).textContent=l}function handleFiles(){const e=this.files;if(e.length){const t=new FileReader;t.addEventListener("load",(e=>{claimGlobal=JSON.parse(t.result),renderResultsWithModal()})),t.readAsText(e[0])}}function renderResultsWithModal(){const e=getClaimVersion(claimGlobal.claim.versions),t=document.getElementById("modalBody");if(expectedClaimVersion!==e){$("#staticBackdrop").modal("show"),t.textContent="Unsupported claim format. Expecting: "+expectedClaimVersion+" but got: "+e;document.getElementById("continueLoadingClaim").addEventListener("click",renderResults)}else renderResults()}function fetchRenderClaimFile(e){null!==e&&fetch(e).then((e=>{if(!e.ok)throw new Error(`HTTP error, status = ${e.status}`);return e.json()})).then((e=>{claimGlobal=e,renderResultsWithModal()})).catch((e=>{console.log(`Error: ${e.message}`)}))}function fetchRenderFeedbackFile(e){null!==e&&fetch(e).then((e=>{if(!e.ok)throw new Error(`HTTP error, status = ${e.status}`);return e.json()})).then((e=>{feedbackGlobal=e,renderResultsWithModal()})).catch((e=>{console.log(`Error: ${e.message}`)}))}function renderResults(){if(void 0!==claimGlobal){let e=formatForFastTreeview(0,claimGlobal.claim.configurations,[]);addOrphans(e.objectArray,"#config-table"),e=formatForFastTreeview(0,claimGlobal.claim.nodes,[]),addOrphans(e.objectArray,"#nodes-table"),fillMetadata(claimGlobal.claim.metadata,"#metadata-table"),fillVersionsElement(claimGlobal.claim.versions,"#versions-table"),fillResults(claimGlobal.claim.results,"#results-table","#optional-","all"),fillResults(claimGlobal.claim.results,"#mandatory-far-edge-table","#optional-far-edge-table","faredge"),fillResults(claimGlobal.claim.results,"#mandatory-telco-table","#optional-telco-table","telco"),fillResults(claimGlobal.claim.results,"#mandatory-non-telco-table","#optional-non-telco-table","nontelco"),fillResults(claimGlobal.claim.results,"#mandatory-extended-table","#optional-extended-table","extended"),void 0!==feedbackGlobal&&fillFeedback(feedbackGlobal)}}function linkToStyle(e){const t=[],n=e.sheet;let l;try{l=n.cssRules||n.rules}catch(e){return console.log(e),null}for(let e=0;e<l.length;++e){const n=l[e];".collapse:not(.show)"!==l[e].selectorText&&t.push(n.cssText)}const o=document.createElement("style");return o.type="text/css",o.appendChild(document.createTextNode(t.join("\r\n"))),o}function getHtmlResults(){let e=document.getElementById("selectScenarioComboBox");const t=document.implementation.createHTMLDocument(),n=t.head,l=t.body,o=t.createElement("script");o.type="text/javascript",o.textContent="\n  function filterTestCasesBasedOnStateHandler(tableId, tableName, state, mandatoryOptional) { // eslint-disable-line no-unused-vars\n    const checkBox = document.getElementById('filter-' + mandatoryOptional + '-' + state + '-' + tableName)\n    const show = checkBox.checked\n    if (show) {\n      checkBox.setAttribute('checked', '')\n    } else {\n      checkBox.removeAttribute('checked')\n    }\n    const tableIdClean = tableId.replace(/#/g, '')\n    const table = document.getElementById(tableIdClean)\n    const elements = table.getElementsByTagName('rh-accordion-header')\n    for (let i = 0; i < elements.length; i++) {\n      const element = elements[i]\n      const id = element.getAttribute('data-id')\n      if (id === state) {\n        if (show === true) {\n          element.removeAttribute('hidden')\n        } else {\n          element.setAttribute('hidden', 'hidden')\n        }\n      }\n    }\n  }\n";const a=document.createElement("script");a.type="importmap",a.textContent=' {\n      "imports": {\n        "@rhds/elements/": "https://ga.jspm.io/npm:@rhds/elements@1.2.0/elements/",\n        "@rhds/elements/lib/": "https://ga.jspm.io/npm:@rhds/elements@1.2.0/elements/lib/",\n        "@patternfly/elements/": "https://ga.jspm.io/npm:@patternfly/elements@2.4.0/"\n      },\n      "scopes": {\n        "https://ga.jspm.io/": {\n          "@lit/reactive-element": "https://ga.jspm.io/npm:@lit/reactive-element@1.6.3/reactive-element.js",\n          "@lit/reactive-element/decorators/": "https://ga.jspm.io/npm:@lit/reactive-element@1.6.3/decorators/",\n          "@patternfly/elements/": "https://ga.jspm.io/npm:@patternfly/elements@2.4.0/",\n          "@patternfly/pfe-core": "https://ga.jspm.io/npm:@patternfly/pfe-core@2.4.1/core.js",\n          "@patternfly/pfe-core/": "https://ga.jspm.io/npm:@patternfly/pfe-core@2.4.1/",\n          "@rhds/tokens/media.js": "https://ga.jspm.io/npm:@rhds/tokens@1.1.2/js/media.js",\n          "lit": "https://ga.jspm.io/npm:lit@2.8.0/index.js",\n          "lit-element/lit-element.js": "https://ga.jspm.io/npm:lit-element@3.3.3/lit-element.js",\n          "lit-html": "https://ga.jspm.io/npm:lit-html@2.8.0/lit-html.js",\n          "lit-html/": "https://ga.jspm.io/npm:lit-html@2.8.0/",\n          "lit/": "https://ga.jspm.io/npm:lit@2.8.0/",\n          "tslib": "https://ga.jspm.io/npm:tslib@2.6.2/tslib.es6.mjs"\n        },\n        "https://ga.jspm.io/npm:@patternfly/elements@2.4.0/": {\n          "lit": "https://ga.jspm.io/npm:lit@2.6.1/index.js",\n          "lit/": "https://ga.jspm.io/npm:lit@2.6.1/"\n        }\n      }\n    }\n',t.head.appendChild(a),t.head.appendChild(o);const s=document.createElement("script");s.type="module",s.textContent=" \n  // import design system element definitions,\n  // which auto-register their tagnames once executed\n  import '@rhds/elements/rh-button/rh-button.js';\n  import '@rhds/elements/rh-dialog/rh-dialog.js';\n  import '@rhds/elements/rh-footer/rh-footer-universal.js';\n  import '@rhds/elements/rh-footer/rh-footer-universal.js';\n  import '@patternfly/elements/pf-text-input/pf-text-input.js';\n  import '@rhds/elements/rh-tabs/rh-tabs.js';\n  import '@rhds/elements/rh-accordion/rh-accordion.js';\n  import 'https://jspm.dev/@rhds/elements/rh-tag/rh-tag.js'\n  <\/script>\n",t.head.appendChild(s),e=document.getElementById("selectScenarioComboBox"),insertResults(l,"mandatory"),"all"!==e.value&&insertResults(l,"optional"),document.querySelectorAll("link[rel='stylesheet']").forEach((function(e){const t=linkToStyle(e);null!==t&&n.insertBefore(t,n.firstChild)})),document.querySelectorAll("style").forEach((function(e){const t=e.cloneNode(!0);n.insertBefore(t,n.firstChild)}));return t.querySelectorAll("textarea").forEach((e=>{e.readOnly=!0})),t.documentElement.outerHTML}function downloadjsonHandler(){const e={},t=["all","telco","nontelco","extended","faredge"];for(const n in claimGlobal.claim.results)for(let l=0;l<t.length;l++){const o="source-"+t[l]+"-"+n,a=document.getElementById(o);null!==a&&(e[o]=a.value)}const n=document.createElement("a");n.setAttribute("href","data:text/json;charset=utf-8,"+encodeURIComponent(JSON.stringify(e))),n.setAttribute("download","feedback.json"),n.style.display="none",document.body.appendChild(n),n.click(),document.body.removeChild(n)}function download(){for(const e in claimGlobal.claim.results)saveTextAreaContent(e);const e=document.createElement("a");e.setAttribute("href","data:text/html;charset=UTF-8,"+encodeURIComponent(getHtmlResults())),e.setAttribute("download","results-feedback"),e.style.display="none",document.body.appendChild(e),e.click(),document.body.removeChild(e)}function insertResults(e,t){const n=document.getElementById(t+"-checkbox"),l=document.getElementById("selectScenarioComboBox").value;let o=document.getElementById("results-table");"faredge"===l&&!0===n.checked&&(o=document.getElementById(t+"-far-edge-table")),"telco"===l&&!0===n.checked&&(o=document.getElementById(t+"-telco-table")),"nontelco"===l&&!0===n.checked&&(o=document.getElementById(t+"-non-telco-table")),"extended"===l&&!0===n.checked&&(o=document.getElementById(t+"-extended-table"));const a=o.cloneNode(!0);e.appendChild(a)}function NonCompliantReasonTextToJson(e){const t=/NonCompliantObjectsOut":(\[.*])/.exec(e);let n;if(t){const e=t[1];n=JSON.parse(e)}return n}function CompliantReasonTextToJson(e){const t=/"CompliantObjectsOut":(\[.*]),"NonCompliantObjectsOut"/.exec(e);let n;if(t){const e=t[1];n=JSON.parse(e)}return n}function createTypeList(e){const t=new Map;return void 0===e||e.forEach((function(e){t.set(e.ObjectType,!0)})),t}function createReasonTableAllTypes(e){const t=createTypeList(e);let n="";return t.forEach((function(t,l){n+='<h3 class="test-subsection"> Type: '+l+"</h3>",n+='<div class="table-responsive">',n+=createReasonTableOneType(e,l),n+="</div>"})),n}function createReasonTableOneType(e,t){if(void 0===e)return"";const n=document.createElement("table");n.setAttribute("border","1"),n.setAttribute("class","table table-striped");let l=!0;const o=document.createElement("tbody");return e.forEach((function(e){if(e.ObjectType!==t)return;if(l){const t=document.createElement("thead"),o=document.createElement("tr");null!==e.ObjectFieldsKeys&&Object.values(e.ObjectFieldsKeys).forEach((function(e){const t=document.createElement("th");t.textContent=e,o.appendChild(t)})),t.appendChild(o),n.appendChild(t),l=!1}const a=document.createElement("tr");null!==e.ObjectFieldsValues&&Object.values(e.ObjectFieldsValues).forEach((function(e){const t=document.createElement("td");t.textContent=e,a.appendChild(t)})),o.appendChild(a)})),n.appendChild(o),n.outerHTML}function isStringInt(e){return/^\d+$/.test(e)}function formatForFastTreeview(e,t,n){let l="",o="";for(const a in t){if(null===t[a]||"managedFields"===a)continue;"name"===a.toLowerCase()&&(l=t[a]),"namespace"===a.toLowerCase()&&(o=t[a]);const s=uuidNode++;if(Array.isArray(t[a])||"[object Object]"===t[a].toString()){const d=formatForFastTreeview(s,t[a],n),i=d.name,r=d.namespace;""!==i&&(l=i,o=r);let c=a;isStringInt(a)&&""!==l&&(c="ns:"+o+" name:"+l,l="",o=""),n.push({id:s.toString(),name:c,parent:e.toString()})}else n.push({id:s.toString(),name:a+" : "+t[a],parent:e.toString()})}return{objectArray:n,name:l,namespace:o}}function orphans(e){return e.filter((function(e){return"0"===e.parent}))}function hasChildren(e,t){return e.some((function(e){return e.parent===t}))}function getChildren(e,t){return e.filter((function(e){return e.parent===t}))}function generateListItem(e,t){const n=document.createElement("li");if(n.id="item-"+t.id,hasChildren(e,t.id)){const t=document.createElement("a");t.href="#",t.innerHTML='\n    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16" part="svg"><path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"></path>\n    </svg>',t.title="hold shift to expand sub tree",t.addEventListener("click",expand.bind(null,e),{once:!0}),t.classList.add("plus"),n.appendChild(t)}const l=document.createElement("span");return l.textContent=t.name,n.appendChild(l),n}function expand(e,t){t.preventDefault(),t.stopPropagation();const n=t.target,l=n.parentElement,o=l.id.replace("item-",""),a=getChildren(e,o).map(generateListItem.bind(null,e)),s=document.createElement("ul");if(a.forEach((function(e){s.appendChild(e)})),l.appendChild(s),n.classList.remove("plus"),n.classList.add("minus"),n.innerHTML='    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16" part="svg">\n  <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"></path>\n</svg>',n.addEventListener("click",collapse.bind(null,e),{once:!0}),t.shiftKey){const t=countChildren(e,o,0);console.log(t),initProgressBar(),expandAll({value:s},t,{value:2})}}function collapse(e,t){t.preventDefault(),t.stopPropagation();const n=t.target,l=n.parentElement,o=l.querySelector("ul");l.removeChild(o),n.classList.remove("minus"),n.classList.add("plus"),n.addEventListener("click",expand.bind(null,e),{once:!0})}function addOrphans(e,t){const n=document.querySelector(t),l=orphans(e);if(l.length){const t=l.map(generateListItem.bind(null,e)),o=document.createElement("ul");t.forEach((function(e){o.appendChild(e)})),n.appendChild(o)}}function expandAll(e,t,n){if(isAnchorElement(e.value)){const t=new MouseEvent("click",{bubbles:!0,cancelable:!0,view:window});e.value.dispatchEvent(t)}n.value++;updateProgressBar(100*n.value/t),e.value.children.length>0&&setTimeout((function(){for(let l=0;l<e.value.children.length;l++){expandAll({value:e.value.children[l]},t,n)}}),0)}function isAnchorElement(e){return e instanceof HTMLAnchorElement}function countChildren(e,t,n){const l=getChildren(e,t);return n++,l.length>0&&(n+=2),l.forEach((function(t){n=countChildren(e,t.id,n)+1})),n}function updateProgressBar(e){const t=document.querySelector(".progress-bar"),n=t.style.width.replace(/%/g,"");e>=parseInt(n)+2&&(t.style.width=e.toString()+"%")}function initProgressBar(){document.getElementById("progress-bar").removeAttribute("hidden");document.querySelector(".progress-bar").style.width="0%"}</script>
+  <script async src="https://ga.jspm.io/npm:es-module-shims@1.7.2/dist/es-module-shims.js"></script>
+  <script type="module">
+      import 'element-internals-polyfill';
+  </script>
+</head>
+
+<body >
+  <header>
+    <img alt="Red Hat"
+         src="https://static.redhat.com/libs/redhat/brand-assets/2/corp/logo--on-dark.svg"
+         width="100"
+         height="30">
+         <h3>CNF Certification Test Parser</h3>
+         <div class="mb-3">
+          <h4 class="inputs-header">Upload file</h4>
+          <div id="inputs" class="flow-column">
+          <input class="form-control" type="file" id="formFile">
+         </div>
+
+          <h4 class="filters-header">Scenario</h4>
+          <div class="flow-column read-only" id="filters">
+
+            <select name="class" id="selectScenarioComboBox" onchange="selectScenarioHandler()">
+              <option value="all"> All</option>
+              <option value="faredge"> Far-Edge</option>
+              <option value="telco"> Telco</option>
+              <option value="nontelco"> Non-Telco</option>
+              <option value="extended"> Extended</option>
+            </select>
+
+          <div class="flow-row" id="mandatoryChecked">
+           <label id="myCheck-mandatory" for="mandatory-checkbox" >Show Mandatory</label>
+           <input type="checkbox" id="mandatory-checkbox" data-bs-target="#results" checked
+             onclick="makeResultsTableVisible('mandatory')" >
+            </div>
+            <div class="flow-row" id="optionalChecked">
+           <label id="myCheck-result" for="optional-checkbox" >Show Optional</label>
+           <input type="checkbox" id="optional-checkbox" data-bs-target="#results" 
+             onclick="makeResultsTableVisible('optional')" >
+            </div>
+         </div>
+
+          <h4 class="outputs-header">Results</h4>
+          <div class="flow-column  read-only" id="outputs">
+          <p id="UploadFeedback">
+            Upload Feedback File: <input type="file" id="feedbackFile">
+          </p>
+          <rh-button  id="download" type="button"  onclick="download()" disabled>Download
+            Results</rh-button >
+            <rh-button  id="downloadjsonHandler" type="button" onclick="downloadjsonHandler()"
+            disabled>Download Feedback as a JSON file</rh-button >
+        </div>
+        </div>
+      </header>
+      <main>
+  <div class="progress" id="progress-bar">
+    <progress  class="progress-bar" aria-label="progress" aria-valuenow="0" aria-valuemin="0" 
+    aria-valuemax="100" ></progress>
+  </div>
+  <rh-tabs>
+    <rh-tab slot="tab" onclick="hideAllResultsTabObjects()">Configuration</rh-tab>
+    <rh-tab-panel id="config" >
+    <rh-table>
+      <div id="config-table"></div>
+    </rh-table>
+  </rh-tab-panel>
+    <rh-tab slot="tab"  onclick="hideAllResultsTabObjects()">Metadata</rh-tab>
+    <rh-tab-panel id="metadata">
+      <rh-table>
+        <table id="metadata-table">
+        </table>
+      </rh-table>
+    </rh-tab-panel>
+    <rh-tab slot="tab"  onclick="hideAllResultsTabObjects()" >Nodes</rh-tab>
+    <rh-tab-panel id="nodes">
+      <rh-table>
+        <div id="nodes-table"></div>
+      </rh-table>
+    </rh-tab-panel>
+    <rh-tab slot="tab" onclick="refreshResultsTabContent()">Results</rh-tab>
+    <rh-tab-panel  id="results">
+      <rh-table>
+        <table class="table" id="results-table" hidden>
+        </table>
+        <table class="table" id="mandatory-far-edge-table" hidden>
+        </table>
+        <table class="table" id="optional-far-edge-table" hidden>
+        </table>
+        <table class="table" id="mandatory-telco-table" hidden>
+        </table>
+        <table class="table" id="optional-telco-table" hidden>
+        </table>
+        <table class="table" id="mandatory-non-telco-table" hidden>
+        </table>
+        <table class="table" id="optional-non-telco-table" hidden>
+        </table>
+        <table class="table" id="mandatory-extended-table" hidden>
+        </table>
+        <table class="table" id="optional-extended-table" hidden>
+        </table>
+      </rh-table>
+    </rh-tab-panel>
+    <rh-tab slot="tab"  onclick="hideAllResultsTabObjects()" >Versions</rh-tab>
+    <rh-tab-panel id="versions">
+      <rh-table>
+        <table id="versions-table">
+        </table>
+      </rh-table>
+    </rh-tab-panel>
+  </rh-tabs>
+
+  <!-- Modal -->
+  <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1"
+    aria-labelledby="staticBackdropLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="staticBackdropLabel">Warning</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body" id="modalBody">
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Stop Loading</button>
+          <button type="button" id="continueLoadingClaim" data-bs-dismiss="modal"
+            class="btn btn-primary">Continue</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+        </main>
+            <!-- Universal Footer -->
+    <rh-footer-universal>
+      <h3 slot="links-primary" data-analytics-text="Red Hat legal and privacy links" hidden>Red Hat legal and privacy links</h3>
+      <ul slot="links-primary" data-analytics-region="page-footer-bottom-primary">
+        <li><a href="https://redhat.com/en/about/company" data-analytics-category="Footer|Corporate" data-analytics-text="About Red Hat">About Red Hat</a></li>
+        <li><a href="https://redhat.com/en/jobs" data-analytics-category="Footer|Corporate" data-analytics-text="Jobs">Jobs</a></li>
+        <li><a href="https://redhat.com/en/events" data-analytics-category="Footer|Corporate" data-analytics-text="Events">Events</a></li>
+        <li><a href="https://redhat.com/en/about/office-locations" data-analytics-category="Footer|Corporate" data-analytics-text="Locations">Locations</a></li>
+        <li><a href="https://redhat.com/en/contact" data-analytics-category="Footer|Corporate" data-analytics-text="Contact Red Hat">Contact Red Hat</a></li>
+        <li><a href="https://redhat.com/en/blog" data-analytics-category="Footer|Corporate" data-analytics-text="Red Hat Blog">Red Hat Blog</a></li>
+        <li><a href="https://redhat.com/en/about/our-culture/diversity-equity-inclusion" data-analytics-category="Footer|Corporate" data-analytics-text="Diversity equity and inclusion">Diversity, equity, and inclusion</a></li>
+        <li><a href="https://coolstuff.redhat.com/" data-analytics-category="Footer|Corporate" data-analytics-text="Cool Stuff Store">Cool Stuff Store</a></li>
+        <li><a href="https://www.redhat.com/en/summit" data-analytics-category="Footer|Corporate" data-analytics-text="Red Hat Summit">Red Hat Summit</a></li>
+      </ul>
+      <rh-footer-copyright slot="links-secondary">© 2022 Red Hat, Inc.</rh-footer-copyright>
+      <h3 slot="links-secondary" data-analytics-text="Red Hat legal and privacy links" hidden>Red Hat legal and privacy links</h3>
+      <ul slot="links-secondary" data-analytics-region="page-footer-bottom-secondary">
+        <li><a href="https://redhat.com/en/about/privacy-policy" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Privacy statement">Privacy statement</a></li>
+        <li><a href="https://redhat.com/en/about/terms-use" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Terms of use">Terms of use</a></li>
+        <li><a href="https://redhat.com/en/about/all-policies-guidelines" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="All policies and guidelines">All policies and guidelines</a></li>
+        <li><a href="https://redhat.com/en/about/digital-accessibility" data-analytics-category="Footer|Red Hat legal and privacy links" data-analytics-text="Digital accessibility" class="active">Digital accessibility</a></li>
+        <!-- If your website supports trustarc include this item to add Cookie Preferences to your site. -->
+        <!-- <li><span id="teconsent"> </span></li> -->
+      </ul>
+    </rh-footer-universal>
+  <!-- This will load the initial JSON file, if present. It may fail. -->
+  <script src="./claimjson.js"></script>
+  <script src="./feedback.js"></script>
+
+
+</body>
+
+</html>

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 )
 
 func main() {
-	certsuite.Startup(true)
+	certsuite.Startup(flags.InitFlags, nil)
 	defer certsuite.Shutdown()
 
 	if *flags.ServerModeFlag {

--- a/pkg/certsuite/certsuite.go
+++ b/pkg/certsuite/certsuite.go
@@ -101,16 +101,14 @@ func processFlags() {
 	}
 }
 
-func Startup(initFlags bool) {
-	if initFlags {
-		flags.InitFlags()
-	}
-
+func Startup(initFlags func(interface{}), arg interface{}) {
 	err := configuration.LoadEnvironmentVariables()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not load the environment variables, err: %v", err)
 		os.Exit(1)
 	}
+
+	initFlags(arg)
 
 	logLevel := configuration.GetTestParameters().LogLevel
 	err = log.CreateGlobalLogFile(*flags.OutputDir, logLevel)

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -57,7 +57,7 @@ var (
 	ConfigurationFile string
 )
 
-func InitFlags() {
+func InitFlags(arg interface{}) {
 	OutputDir = flag.String(outputDirFlagKey, defaultOutputDir,
 		"the directory where the output artifacts will be placed")
 	LabelsFlag = flag.String(labelsFlagName, labelsFlagDefaultValue, labelsFlagUsage)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -34,7 +34,6 @@ import (
 	"github.com/test-network-function/cnf-certification-test/internal/log"
 	"github.com/test-network-function/cnf-certification-test/pkg/autodiscover"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
-	"github.com/test-network-function/cnf-certification-test/pkg/flags"
 	k8sPrivilegedDs "github.com/test-network-function/privileged-daemonset"
 	"helm.sh/helm/v3/pkg/release"
 	scalingv1 "k8s.io/api/autoscaling/v1"
@@ -225,9 +224,6 @@ func buildTestEnvironment() { //nolint:funlen
 	env = TestEnvironment{}
 
 	env.variables = *configuration.GetTestParameters()
-	if flags.ConfigurationFile != "" {
-		env.variables.ConfigurationPath = flags.ConfigurationFile
-	}
 	config, err := configuration.LoadConfiguration(env.variables.ConfigurationPath)
 	if err != nil {
 		log.Fatal("Cannot load configuration file: %v", err)


### PR DESCRIPTION
To support the transition from the standard test suite binary to the test suite run as a "certsuite run" subcommand the precedence of flags needs to be higher than that of the env vars, as flags will be the main mechanism for passing options to the test suite.

As no new flags will be added to the old flag library, it's necessary to leave the env vars but override them when the test suite it run with the "certsuite" command.