### PR TITLE
cmd/certsuite: add flags for selecting the TNF debug image

### DIFF
--- a/cmd/certsuite/run/run.go
+++ b/cmd/certsuite/run/run.go
@@ -37,6 +37,8 @@ func NewCommand() *cobra.Command {
 	runCmd.PersistentFlags().Bool("include-web-files", false, "Save web files in the configured output folder")
 	runCmd.PersistentFlags().Bool("enable-data-collection", false, "Allow sending test results to an external data collector")
 	runCmd.PersistentFlags().Bool("create-xml-junit-file", false, "Create a JUnit file with the test results")
+	runCmd.PersistentFlags().String("tnf-image-repository", "quay.io/testnetworkfunction", "The repository where TNF images are stored")
+	runCmd.PersistentFlags().String("tnf-debug-image", "debug-partner:5.1.0", "Name of the TNF debug image")
 
 	return runCmd
 }
@@ -60,6 +62,8 @@ func initFlags(arg interface{}) {
 	includeWebFiles, _ := cmd.Flags().GetBool("include-web-files")
 	dataCollection, _ := cmd.Flags().GetBool("enable-data-collection")
 	createXMLJUnitFile, _ := cmd.Flags().GetBool("create-xml-junit-file")
+	tnfImageRepo, _ := cmd.Flags().GetString("tnf-image-repository")
+	tnfDebugImage, _ := cmd.Flags().GetString("tnf-debug-image")
 
 	flags.OutputDir = &outputDir
 	flags.LabelsFlag = &labelFilter
@@ -81,6 +85,8 @@ func initFlags(arg interface{}) {
 	testParams.IncludeWebFilesInOutputFolder = includeWebFiles
 	testParams.EnableDataCollection = dataCollection
 	testParams.EnableXMLCreation = createXMLJUnitFile
+	testParams.TnfPartnerRepo = tnfImageRepo
+	testParams.SupportImage = tnfDebugImage
 }
 func runTestSuite(cmd *cobra.Command, _ []string) error {
 	certsuite.Startup(initFlags, cmd)

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -109,4 +109,6 @@ type TestParameters struct {
 	DaemonsetCPULim               string `default:"100m" split_words:"true"`
 	DaemonsetMemReq               string `default:"100M" split_words:"true"`
 	DaemonsetMemLim               string `default:"100M" split_words:"true"`
+	TnfPartnerRepo                string `split_words:"true" default:"quay.io/testnetworkfunction"`
+	SupportImage                  string `split_words:"true" default:"debug-partner:5.1.0"`
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -18,7 +18,6 @@ package provider
 
 import (
 	"context"
-	"os"
 	"regexp"
 	"time"
 
@@ -59,8 +58,6 @@ const (
 	rhcosName                        = "Red Hat Enterprise Linux CoreOS"
 	cscosName                        = "CentOS Stream CoreOS"
 	rhelName                         = "Red Hat Enterprise Linux"
-	tnfPartnerRepoDef                = "quay.io/testnetworkfunction"
-	supportImageDef                  = "debug-partner:5.1.0"
 )
 
 // Node's roles labels. Node is role R if it has **any** of the labels of each list.
@@ -177,24 +174,10 @@ var (
 	loaded = false
 )
 
-// Build image with version based on environment variables if provided, else use a default value
-func buildImageWithVersion() string {
-	tnfPartnerRepo := os.Getenv("TNF_PARTNER_REPO")
-	if tnfPartnerRepo == "" {
-		tnfPartnerRepo = tnfPartnerRepoDef
-	}
-	supportImage := os.Getenv("SUPPORT_IMAGE")
-	if supportImage == "" {
-		supportImage = supportImageDef
-	}
-
-	return tnfPartnerRepo + "/" + supportImage
-}
-
 func deployDaemonSet(namespace string) error {
 	k8sPrivilegedDs.SetDaemonSetClient(clientsholder.GetClientsHolder().K8sClient)
-	dsImage := buildImageWithVersion()
 
+	dsImage := env.variables.TnfPartnerRepo + "/" + env.variables.SupportImage
 	if k8sPrivilegedDs.IsDaemonSetReady(DaemonSetName, namespace, dsImage) {
 		return nil
 	}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -18,7 +18,6 @@ package provider
 
 import (
 	"errors"
-	"os"
 	"reflect"
 	"testing"
 
@@ -768,36 +767,6 @@ func TestGetRHELVersion(t *testing.T) {
 		result, err := node.GetRHELVersion()
 		assert.Equal(t, tc.expectedErr, err)
 		assert.Equal(t, tc.expectedOutput, result)
-	}
-}
-
-func TestBuildImageWithVersion(t *testing.T) {
-	testCases := []struct {
-		repoVar         string
-		supportImageVar string
-		expectedOutput  string
-	}{
-		{
-			repoVar:         "test1",
-			supportImageVar: "image1",
-			expectedOutput:  "test1/image1",
-		},
-		{
-			repoVar:         "",
-			supportImageVar: "",
-			expectedOutput:  "quay.io/testnetworkfunction/debug-partner:5.1.0",
-		},
-	}
-
-	defer func() {
-		os.Unsetenv("TNF_PARTNER_REPO")
-		os.Unsetenv("SUPPORT_IMAGE")
-	}()
-
-	for _, tc := range testCases {
-		os.Setenv("TNF_PARTNER_REPO", tc.repoVar)
-		os.Setenv("SUPPORT_IMAGE", tc.supportImageVar)
-		assert.Equal(t, tc.expectedOutput, buildImageWithVersion())
 	}
 }
 


### PR DESCRIPTION
This is the image used for the debug DaemonSet.

Also, keep the method to set the debug image using environment variables for compatibility with the old binary but save the variables into the "TestParameters" struct to have them grouped together with the rest of environment variables.