### PR TITLE
Bug fix: adjust OCP beta slice

### DIFF
--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -588,10 +588,10 @@ func testNodeOperatingSystemStatus(check *checksdb.Check, env *provider.TestEnvi
 		// Control plane nodes must be RHCOS (also CentOS Stream starting in OCP 4.13)
 		// Per the release notes from OCP documentation:
 		// "You must use RHCOS machines for the control plane, and you can use either RHCOS or RHEL for compute machines."
-		if node.IsMasterNode() && !node.IsRHCOS() && !node.IsCSCOS() {
-			check.LogError("Master node %q has been found to be running an incompatible operating system %q", nodeName, node.Data.Status.NodeInfo.OSImage)
+		if node.IsControlPlaneNode() && !node.IsRHCOS() && !node.IsCSCOS() {
+			check.LogError("Control plane node %q has been found to be running an incompatible operating system %q", nodeName, node.Data.Status.NodeInfo.OSImage)
 			failedControlPlaneNodes = append(failedControlPlaneNodes, nodeName)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNodeReportObject(nodeName, "Master node has been found to be running an incompatible OS", false).AddField(testhelper.OSImage, node.Data.Status.NodeInfo.OSImage))
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNodeReportObject(nodeName, "Control plane node has been found to be running an incompatible OS", false).AddField(testhelper.OSImage, node.Data.Status.NodeInfo.OSImage))
 			continue
 		}
 

--- a/pkg/compatibility/compatibility.go
+++ b/pkg/compatibility/compatibility.go
@@ -50,7 +50,7 @@ type VersionInfo struct {
 }
 
 var (
-	ocpBetaVersions   = []string{"4.13", "4.14"}
+	ocpBetaVersions   = []string{"4.13", "4.14", "4.15", "4.16", "4.17"}
 	ocpLifeCycleDates = map[string]VersionInfo{
 		// TODO: Adjust all of these periodically to make sure they are up to date with the lifecycle
 		// update documentation.

--- a/pkg/compatibility/compatibility_test.go
+++ b/pkg/compatibility/compatibility_test.go
@@ -184,6 +184,11 @@ func TestIsRHCOSCompatible(t *testing.T) {
 			testMachineVersion: "4.13.0-rc.2",
 			expectedOutput:     true,
 		},
+		{
+			testOCPVersion:     "4.16.0-rc.1",
+			testMachineVersion: "4.16.0-rc.1",
+			expectedOutput:     true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/provider/nodes.go
+++ b/pkg/provider/nodes.go
@@ -47,7 +47,7 @@ func (node *Node) IsWorkerNode() bool {
 	return false
 }
 
-func (node *Node) IsMasterNode() bool {
+func (node *Node) IsControlPlaneNode() bool {
 	for nodeLabel := range node.Data.Labels {
 		if stringhelper.StringInSlice(MasterLabels, nodeLabel, true) {
 			return true

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -530,7 +530,7 @@ func (env *TestEnvironment) GetWorkerCount() int {
 func (env *TestEnvironment) GetMasterCount() int {
 	masterCount := 0
 	for _, e := range env.Nodes {
-		if e.IsMasterNode() {
+		if e.IsControlPlaneNode() {
 			masterCount++
 		}
 	}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -395,7 +395,7 @@ func TestIsWorkerNode(t *testing.T) {
 	}
 }
 
-func TestIsMasterNode(t *testing.T) {
+func TestIsControlPlaneNode(t *testing.T) {
 	testCases := []struct {
 		node           *corev1.Node
 		expectedResult bool
@@ -490,7 +490,7 @@ func TestIsMasterNode(t *testing.T) {
 
 	for _, tc := range testCases {
 		node := Node{Data: tc.node}
-		assert.Equal(t, tc.expectedResult, node.IsMasterNode())
+		assert.Equal(t, tc.expectedResult, node.IsControlPlaneNode())
 	}
 }
 


### PR DESCRIPTION
The `ocpBetaVersions` slice was only containing entries for 4.13 and 4.14.  I added more entries for 4.15, 4.16, and 4.17 and I also added a unit test for the version that @ramperher reported as failing.

Bonus, I changed the strings that report "master" nodes to "control plane" nodes.