### PR TITLE
log: rename global log file

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -321,7 +321,7 @@ jobs:
         run: ./certsuite run --label-filter="${SMOKE_TESTS_LABELS_FILTER}" --output-dir="certsuite-out" --log-level=${TNF_SMOKE_TESTS_LOG_LEVEL}
 
       - name: 'Check the smoke test results (run with the certsuite cmd) against the expected results template'
-        run: ./certsuite check results --log-file="certsuite-out/cnf-certsuite.log"
+        run: ./certsuite check results --log-file="certsuite-out/certsuite.log"
 
       - name: 'Test: Run preflight specific test suite with the certsuite command'
         run: ./certsuite run --label-filter="preflight" --log-level=${TNF_SMOKE_TESTS_LOG_LEVEL}
@@ -488,7 +488,7 @@ jobs:
         run: make build-certsuite-tool
 
       - name: Check the smoke test results against the expected results template
-        run: ./certsuite check results --log-file="${TNF_OUTPUT_DIR}"/cnf-certsuite.log
+        run: ./certsuite check results --log-file="${TNF_OUTPUT_DIR}"/certsuite.log
 
       - name: 'Test: Run Preflight Specific Smoke Tests in a TNF container'
         run: TNF_LOG_LEVEL=${TNF_SMOKE_TESTS_LOG_LEVEL} ./run-tnf-container.sh ${{ env.TESTING_CMD_PARAMS }} -l "preflight"
@@ -510,7 +510,7 @@ jobs:
             --label-filter="${SMOKE_TESTS_LABELS_FILTER}"
 
       - name: Check the smoke test results (run with the certsuite cmd) against the expected results template
-        run: ./certsuite check results --log-file="${TNF_CERTSUITE_CMD_OUTPUT_DIR}"/cnf-certsuite.log
+        run: ./certsuite check results --log-file="${TNF_CERTSUITE_CMD_OUTPUT_DIR}"/certsuite.log
 
       - name: 'Test: Run Preflight Specific Smoke Tests in a TNF container with the certsuite command'
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 bin/
 catalog.json
 claim.json
-cnf-certification-test/cnf-certsuite.log
+cnf-certification-test/certsuite.log
 .idea
 vendor
 *.test

--- a/cmd/certsuite/check/results/results.go
+++ b/cmd/certsuite/check/results/results.go
@@ -203,7 +203,7 @@ func generateTemplateFile(resultsDB map[string]string) error {
 
 func NewCommand() *cobra.Command {
 	checkResultsCmd.PersistentFlags().String("template", "expected_results.yaml", "reference YAML template with the expected results")
-	checkResultsCmd.PersistentFlags().String("log-file", "cnf-certification-test/cnf-certsuite.log", "log file of the CERTSUITE execution")
+	checkResultsCmd.PersistentFlags().String("log-file", "cnf-certification-test/certsuite.log", "log file of the CERTSUITE execution")
 	checkResultsCmd.PersistentFlags().Bool("generate-template", false, "generate a reference YAML template from the log file")
 
 	checkResultsCmd.MarkFlagsMutuallyExclusive("template", "generate-template")

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ The purpose of the tests and the framework is to test the interaction of the wor
 
 **Features**
 
-* The test suite generates a report (`claim.json`) and saves the test execution log (`cnf-certsuite.log`) in a configurable output directory.
+* The test suite generates a report (`claim.json`) and saves the test execution log (`certsuite.log`) in a configurable output directory.
 
 * The catalog of the existing test cases and test building blocks are available in [CATALOG.md](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md)
 

--- a/docs/test-container.md
+++ b/docs/test-container.md
@@ -38,7 +38,7 @@ In order to get the required information, the test suite does not `ssh` into nod
 **Required arguments**
 
 * `-t` to provide the path of the local directory that contains tnf config files
-* `-o` to provide the path of the local directory where test results (claim.json), the execution logs (cnf-certsuite.log), and the results artifacts file (results.tar.gz) will be available from after the container exits.
+* `-o` to provide the path of the local directory where test results (claim.json), the execution logs (certsuite.log), and the results artifacts file (results.tar.gz) will be available from after the container exits.
 
 !!! warning
 

--- a/docs/test-output.md
+++ b/docs/test-output.md
@@ -48,7 +48,7 @@ For more details on the contents of the claim file
 
 ## Execution logs
 
-The test suite also saves a copy of the execution logs at [test output directory]/cnf-certsuite.log
+The test suite also saves a copy of the execution logs at [test output directory]/certsuite.log
 
 ## Results artifacts zip file
 

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	LogFileName        = "cnf-certsuite.log"
+	LogFileName        = "certsuite.log"
 	LogFilePermissions = 0o644
 )
 

--- a/run-basic-batch-operators-test.sh
+++ b/run-basic-batch-operators-test.sh
@@ -522,7 +522,7 @@ while IFS=, read -r package_name catalog; do
 
 		# Add log link
 		echo ", log: "
-		echo '<a href="/'"$REPORT_FOLDER_RELATIVE"'/'"$package_name"'/cnf-certsuite.log">'"link"'</a>'
+		echo '<a href="/'"$REPORT_FOLDER_RELATIVE"'/'"$package_name"'/certsuite.log">'"link"'</a>'
 
 		# Add tnf_config link
 		echo ", tnf_config: "


### PR DESCRIPTION
From "cnf-certsuite.log" to "certsuite.log" to be in line with the recent renaming of the test suite.