### PR TITLE
feat : Add helper function to get all operator pods

### DIFF
--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -34,6 +34,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/internal/crclient"
 	"github.com/test-network-function/cnf-certification-test/internal/log"
 	"github.com/test-network-function/cnf-certification-test/pkg/checksdb"
+	"github.com/test-network-function/cnf-certification-test/pkg/podhelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
 	"github.com/test-network-function/cnf-certification-test/pkg/stringhelper"
 	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
@@ -685,7 +686,7 @@ func isInstallModeMultiNamespace(installModes []v1alpha1.InstallMode) bool {
 //   - bool: true if one of the passed topOwners is a CSV that is installed by a cluster-wide operator, otherwise return false
 //   - name string : the name of the matching object, if found.
 //   - aNamespace string : the namespace of the matching object, if found.
-func ownedByClusterWideOperator(topOwners map[string]provider.TopOwner, env *provider.TestEnvironment) (aNamespace, name string, found bool) {
+func ownedByClusterWideOperator(topOwners map[string]podhelper.TopOwner, env *provider.TestEnvironment) (aNamespace, name string, found bool) {
 	for _, owner := range topOwners {
 		if isCSVAndClusterWide(owner.Namespace, owner.Name, env) {
 			return owner.Namespace, owner.Name, true

--- a/cnf-certification-test/lifecycle/podsets/podsets_test.go
+++ b/cnf-certification-test/lifecycle/podsets/podsets_test.go
@@ -23,14 +23,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
-	v1app "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestIsDeploymentReady(t *testing.T) {
 	type dpStatus struct {
-		condition   v1app.DeploymentConditionType
+		condition   appsv1.DeploymentConditionType
 		replicas    int32
 		ready       int32
 		available   int32
@@ -38,18 +38,18 @@ func TestIsDeploymentReady(t *testing.T) {
 		updated     int32
 	}
 	m := map[dpStatus]bool{
-		{v1app.DeploymentReplicaFailure, 10, 9, 10, 0, 0}: false,
-		{v1app.DeploymentAvailable, 10, 9, 9, 0, 10}:      false,
-		{v1app.DeploymentAvailable, 10, 10, 10, 1, 10}:    false,
-		{v1app.DeploymentAvailable, 10, 1, 10, 0, 10}:     false,
-		{v1app.DeploymentAvailable, 10, 10, 10, 0, 9}:     false,
-		{v1app.DeploymentAvailable, 10, 10, 10, 0, 10}:    true,
+		{appsv1.DeploymentReplicaFailure, 10, 9, 10, 0, 0}: false,
+		{appsv1.DeploymentAvailable, 10, 9, 9, 0, 10}:      false,
+		{appsv1.DeploymentAvailable, 10, 10, 10, 1, 10}:    false,
+		{appsv1.DeploymentAvailable, 10, 1, 10, 0, 10}:     false,
+		{appsv1.DeploymentAvailable, 10, 10, 10, 0, 9}:     false,
+		{appsv1.DeploymentAvailable, 10, 10, 10, 0, 10}:    true,
 	}
 	for key, v := range m {
 		dp := provider.Deployment{
-			Deployment: &v1app.Deployment{
-				Status: v1app.DeploymentStatus{
-					Conditions: []v1app.DeploymentCondition{
+			Deployment: &appsv1.Deployment{
+				Status: appsv1.DeploymentStatus{
+					Conditions: []appsv1.DeploymentCondition{
 						{
 							Type: key.condition,
 						},
@@ -59,7 +59,7 @@ func TestIsDeploymentReady(t *testing.T) {
 					UnavailableReplicas: key.unavailable,
 					UpdatedReplicas:     key.updated,
 				},
-				Spec: v1app.DeploymentSpec{
+				Spec: appsv1.DeploymentSpec{
 					Replicas: &key.replicas,
 				},
 			},
@@ -87,11 +87,11 @@ func TestIsStatefulSetReady(t *testing.T) {
 	}
 	for k, v := range m {
 		ss := provider.StatefulSet{
-			StatefulSet: &v1app.StatefulSet{
-				Spec: v1app.StatefulSetSpec{
+			StatefulSet: &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
 					Replicas: &k.replicas,
 				},
-				Status: v1app.StatefulSetStatus{
+				Status: appsv1.StatefulSetStatus{
 					ReadyReplicas:     k.ready,
 					AvailableReplicas: k.available,
 					UpdatedReplicas:   k.updated,

--- a/cnf-certification-test/lifecycle/scaling/deployment_scaling_test.go
+++ b/cnf-certification-test/lifecycle/scaling/deployment_scaling_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/internal/log"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
-	v1app "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	v1autoscaling "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,13 +37,13 @@ import (
 )
 
 func TestScaleDeploymentFunc(t *testing.T) {
-	generateDeployment := func(name string, replicas *int32) *v1app.Deployment {
-		return &v1app.Deployment{
+	generateDeployment := func(name string, replicas *int32) *appsv1.Deployment {
+		return &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: "namespace1",
 			},
-			Spec: v1app.DeploymentSpec{
+			Spec: appsv1.DeploymentSpec{
 				Replicas: replicas,
 			},
 		}
@@ -93,13 +93,13 @@ func TestScaleDeploymentFunc(t *testing.T) {
 }
 
 func TestScaleHpaDeploymentFunc(t *testing.T) {
-	generateDeployment := func(name string, replicas *int32) *v1app.Deployment {
-		return &v1app.Deployment{
+	generateDeployment := func(name string, replicas *int32) *appsv1.Deployment {
+		return &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: "namespace1",
 			},
-			Spec: v1app.DeploymentSpec{
+			Spec: appsv1.DeploymentSpec{
 				Replicas: replicas,
 			},
 		}
@@ -283,15 +283,15 @@ func TestScaleDeploymentHelper(t *testing.T) {
 		// Create a spoofed deployment to pass to the clientsholder.
 		// This is only needed because the podsets.WaitForDeploymentSetReady function
 		// utilizes the clientsholder straight from the function to retrieve the latest information.
-		dep := &v1app.Deployment{
+		dep := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dp1",
 				Namespace: "ns1",
 			},
-			Status: v1app.DeploymentStatus{
-				Conditions: []v1app.DeploymentCondition{
+			Status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
 					{
-						Type: v1app.DeploymentAvailable,
+						Type: appsv1.DeploymentAvailable,
 					},
 				},
 				Replicas:          1,

--- a/cnf-certification-test/lifecycle/scaling/statefulset_scaling.go
+++ b/cnf-certification-test/lifecycle/scaling/statefulset_scaling.go
@@ -26,7 +26,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/internal/log"
 
-	v1app "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	v1autoscaling "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 
@@ -36,7 +36,7 @@ import (
 	hps "k8s.io/client-go/kubernetes/typed/autoscaling/v1"
 )
 
-func TestScaleStatefulSet(statefulset *v1app.StatefulSet, timeout time.Duration, logger *log.Logger) bool {
+func TestScaleStatefulSet(statefulset *appsv1.StatefulSet, timeout time.Duration, logger *log.Logger) bool {
 	clients := clientsholder.GetClientsHolder()
 	name, namespace := statefulset.Name, statefulset.Namespace
 	ssClients := clients.K8sClient.AppsV1().StatefulSets(namespace)
@@ -79,7 +79,7 @@ func TestScaleStatefulSet(statefulset *v1app.StatefulSet, timeout time.Duration,
 	return true
 }
 
-func scaleStateFulsetHelper(clients *clientsholder.ClientsHolder, ssClient v1.StatefulSetInterface, statefulset *v1app.StatefulSet, replicas int32, timeout time.Duration, logger *log.Logger) bool {
+func scaleStateFulsetHelper(clients *clientsholder.ClientsHolder, ssClient v1.StatefulSetInterface, statefulset *appsv1.StatefulSet, replicas int32, timeout time.Duration, logger *log.Logger) bool {
 	name := statefulset.Name
 	namespace := statefulset.Namespace
 
@@ -110,7 +110,7 @@ func scaleStateFulsetHelper(clients *clientsholder.ClientsHolder, ssClient v1.St
 	return true
 }
 
-func TestScaleHpaStatefulSet(statefulset *v1app.StatefulSet, hpa *v1autoscaling.HorizontalPodAutoscaler, timeout time.Duration, logger *log.Logger) bool {
+func TestScaleHpaStatefulSet(statefulset *appsv1.StatefulSet, hpa *v1autoscaling.HorizontalPodAutoscaler, timeout time.Duration, logger *log.Logger) bool {
 	clients := clientsholder.GetClientsHolder()
 	hpaName := hpa.Name
 	name, namespace := statefulset.Name, statefulset.Namespace

--- a/pkg/autodiscover/constants.go
+++ b/pkg/autodiscover/constants.go
@@ -16,6 +16,7 @@
 package autodiscover
 
 const (
-	debugHelperPodsLabelName  = "test-network-function.com/app"
-	debugHelperPodsLabelValue = "tnf-debug"
+	debugHelperPodsLabelName      = "test-network-function.com/app"
+	debugHelperPodsLabelValue     = "tnf-debug"
+	podNameWithNamespaceFormatStr = "%s, ns=%s"
 )

--- a/pkg/podhelper/podhelper.go
+++ b/pkg/podhelper/podhelper.go
@@ -1,0 +1,76 @@
+package podhelper
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+// Structure to describe a top owner of a pod
+type TopOwner struct {
+	Kind      string
+	Name      string
+	Namespace string
+}
+
+// Get the list of top owners of pods
+func GetPodTopOwner(podNamespace string, podOwnerReferences []metav1.OwnerReference) (topOwners map[string]TopOwner, err error) {
+	topOwners = make(map[string]TopOwner)
+	err = followOwnerReferences(clientsholder.GetClientsHolder().GroupResources, clientsholder.GetClientsHolder().DynamicClient, topOwners, podNamespace, podOwnerReferences)
+	if err != nil {
+		return topOwners, fmt.Errorf("could not get top owners, err=%s", err)
+	}
+	return topOwners, nil
+}
+
+// Recursively follow the ownership tree to find the top owners
+func followOwnerReferences(resourceList []*metav1.APIResourceList, dynamicClient dynamic.Interface, topOwners map[string]TopOwner, namespace string, ownerRefs []metav1.OwnerReference) (err error) {
+	for _, ownerRef := range ownerRefs {
+		// Get group resource version
+		gvr := getResourceSchema(resourceList, ownerRef.APIVersion, ownerRef.Kind)
+		// Get the owner resources
+		resource, err := dynamicClient.Resource(gvr).Namespace(namespace).Get(context.Background(), ownerRef.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("could not get object indicated by owner references")
+		}
+		// Get owner references of the unstructured object
+		ownerReferences := resource.GetOwnerReferences()
+		if err != nil {
+			return fmt.Errorf("error getting owner references. err= %s", err)
+		}
+		// if no owner references, we have reached the top record it
+		if len(ownerReferences) == 0 {
+			topOwners[ownerRef.Name] = TopOwner{Kind: ownerRef.Kind, Name: ownerRef.Name, Namespace: namespace}
+		}
+		// if not continue following other branches
+		err = followOwnerReferences(resourceList, dynamicClient, topOwners, namespace, ownerReferences)
+		if err != nil {
+			return fmt.Errorf("error following owners")
+		}
+	}
+	return nil
+}
+
+// Get the Group Version Resource based on APIVersion and kind
+func getResourceSchema(resourceList []*metav1.APIResourceList, apiVersion, kind string) (gvr schema.GroupVersionResource) {
+	const groupVersionComponentsNumber = 2
+	for _, gr := range resourceList {
+		for i := 0; i < len(gr.APIResources); i++ {
+			if gr.APIResources[i].Kind == kind && gr.GroupVersion == apiVersion {
+				groupSplit := strings.Split(gr.GroupVersion, "/")
+				if len(groupSplit) == groupVersionComponentsNumber {
+					gvr.Group = groupSplit[0]
+					gvr.Version = groupSplit[1]
+					gvr.Resource = gr.APIResources[i].Name
+				}
+				return gvr
+			}
+		}
+	}
+	return gvr
+}

--- a/pkg/podhelper/podhelper_test.go
+++ b/pkg/podhelper/podhelper_test.go
@@ -1,0 +1,92 @@
+package podhelper
+
+import (
+	"reflect"
+	"testing"
+
+	olmv1Alpha "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	v1app "k8s.io/api/apps/v1"
+
+	k8sDynamicFake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func Test_followOwnerReferences(t *testing.T) {
+	type args struct {
+		topOwners map[string]TopOwner
+		namespace string
+		ownerRefs []metav1.OwnerReference
+	}
+
+	csv1 := &olmv1Alpha.ClusterServiceVersion{
+		TypeMeta: metav1.TypeMeta{Kind: "ClusterServiceVersion", APIVersion: "operators.coreos.com/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "csv1",
+			Namespace:       "ns1",
+			OwnerReferences: []metav1.OwnerReference{},
+		},
+	}
+	dep1 := &v1app.Deployment{
+		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "dep1",
+			Namespace:       "ns1",
+			OwnerReferences: []metav1.OwnerReference{{APIVersion: "operators.coreos.com/v1alpha1", Kind: "ClusterServiceVersion", Name: "csv1"}},
+		},
+	}
+	rep1 := &v1app.ReplicaSet{
+		TypeMeta: metav1.TypeMeta{Kind: "ReplicaSet", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "rep1",
+			Namespace:       "ns1",
+			OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "dep1"}},
+		},
+	}
+
+	resourceList := []*metav1.APIResourceList{
+		{GroupVersion: "operators.coreos.com/v1alpha1", APIResources: []metav1.APIResource{{Name: "clusterserviceversions", Kind: "ClusterServiceVersion"}}},
+		{GroupVersion: "apps/v1", APIResources: []metav1.APIResource{{Name: "deployments", Kind: "Deployment"}}},
+		{GroupVersion: "apps/v1", APIResources: []metav1.APIResource{{Name: "replicasets", Kind: "ReplicaSet"}}},
+		{GroupVersion: "apps/v1", APIResources: []metav1.APIResource{{Name: "pods", Kind: "Pod"}}},
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "test1",
+			args: args{topOwners: map[string]TopOwner{"csv1": {Namespace: "ns1", Kind: "ClusterServiceVersion", Name: "csv1"}},
+				namespace: "ns1",
+				ownerRefs: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "rep1"}},
+			},
+		},
+	}
+
+	// Spoof the get and update functions
+	client := k8sDynamicFake.NewSimpleDynamicClient(runtime.NewScheme(), rep1, dep1, csv1)
+	client.Fake.AddReactor("get", "ClusterServiceVersion", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, csv1, nil
+	})
+	client.Fake.AddReactor("get", "Deployment", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, dep1, nil
+	})
+	client.Fake.AddReactor("get", "ReplicaSet", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, rep1, nil
+	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotResults := map[string]TopOwner{}
+			if err := followOwnerReferences(resourceList, client, gotResults, tt.args.namespace, tt.args.ownerRefs); (err != nil) != tt.wantErr {
+				t.Errorf("followOwnerReferences() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(gotResults, tt.args.topOwners) {
+				t.Errorf("followOwnerReferences() = %v, want %v", gotResults, tt.args.topOwners)
+			}
+		})
+	}
+}

--- a/pkg/podhelper/podhelper_test.go
+++ b/pkg/podhelper/podhelper_test.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	v1app "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 
 	k8sDynamicFake "k8s.io/client-go/dynamic/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -29,7 +29,7 @@ func Test_followOwnerReferences(t *testing.T) {
 			OwnerReferences: []metav1.OwnerReference{},
 		},
 	}
-	dep1 := &v1app.Deployment{
+	dep1 := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "dep1",
@@ -37,7 +37,7 @@ func Test_followOwnerReferences(t *testing.T) {
 			OwnerReferences: []metav1.OwnerReference{{APIVersion: "operators.coreos.com/v1alpha1", Kind: "ClusterServiceVersion", Name: "csv1"}},
 		},
 	}
-	rep1 := &v1app.ReplicaSet{
+	rep1 := &appsv1.ReplicaSet{
 		TypeMeta: metav1.TypeMeta{Kind: "ReplicaSet", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "rep1",

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -25,11 +25,10 @@ import (
 
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/internal/log"
+	"github.com/test-network-function/cnf-certification-test/pkg/podhelper"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
 )
 
 const (
@@ -406,65 +405,6 @@ func (p *Pod) IsRunAsUserID(uid int64) bool {
 }
 
 // Get the list of top owners of pods
-func (p *Pod) GetTopOwner() (topOwners map[string]TopOwner, err error) {
-	topOwners = make(map[string]TopOwner)
-	err = followOwnerReferences(clientsholder.GetClientsHolder().GroupResources, clientsholder.GetClientsHolder().DynamicClient, topOwners, p.Namespace, p.OwnerReferences)
-	if err != nil {
-		return topOwners, fmt.Errorf("could not get top owners, err=%s", err)
-	}
-	return topOwners, nil
-}
-
-// Structure to describe a top owner of a pod
-type TopOwner struct {
-	Kind      string
-	Name      string
-	Namespace string
-}
-
-// Recursively follow the ownership tree to find the top owners
-func followOwnerReferences(resourceList []*metav1.APIResourceList, dynamicClient dynamic.Interface, topOwners map[string]TopOwner, namespace string, ownerRefs []metav1.OwnerReference) (err error) {
-	for _, ownerRef := range ownerRefs {
-		// Get group resource version
-		gvr := getResourceSchema(resourceList, ownerRef.APIVersion, ownerRef.Kind)
-		// Get the owner resources
-		resource, err := dynamicClient.Resource(gvr).Namespace(namespace).Get(context.Background(), ownerRef.Name, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("could not get object indicated by owner references")
-		}
-		// Get owner references of the unstructured object
-		ownerReferences := resource.GetOwnerReferences()
-		if err != nil {
-			return fmt.Errorf("error getting owner references. err= %s", err)
-		}
-		// if no owner references, we have reached the top record it
-		if len(ownerReferences) == 0 {
-			topOwners[ownerRef.Name] = TopOwner{Kind: ownerRef.Kind, Name: ownerRef.Name, Namespace: namespace}
-		}
-		// if not continue following other branches
-		err = followOwnerReferences(resourceList, dynamicClient, topOwners, namespace, ownerReferences)
-		if err != nil {
-			return fmt.Errorf("error following owners")
-		}
-	}
-	return nil
-}
-
-// Get the Group Version Resource based on APIVersion and kind
-func getResourceSchema(resourceList []*metav1.APIResourceList, apiVersion, kind string) (gvr schema.GroupVersionResource) {
-	const groupVersionComponentsNumber = 2
-	for _, gr := range resourceList {
-		for i := 0; i < len(gr.APIResources); i++ {
-			if gr.APIResources[i].Kind == kind && gr.GroupVersion == apiVersion {
-				groupSplit := strings.Split(gr.GroupVersion, "/")
-				if len(groupSplit) == groupVersionComponentsNumber {
-					gvr.Group = groupSplit[0]
-					gvr.Version = groupSplit[1]
-					gvr.Resource = gr.APIResources[i].Name
-				}
-				return gvr
-			}
-		}
-	}
-	return gvr
+func (p *Pod) GetTopOwner() (topOwners map[string]podhelper.TopOwner, err error) {
+	return podhelper.GetPodTopOwner(p.Namespace, p.OwnerReferences)
 }

--- a/pkg/provider/pods_test.go
+++ b/pkg/provider/pods_test.go
@@ -18,23 +18,18 @@ package provider
 
 import (
 	"errors"
-	"reflect"
 	"strings"
 	"testing"
 
-	olmv1Alpha "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
 	"github.com/test-network-function/cnf-certification-test/internal/log"
-	v1app "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	k8sDynamicFake "k8s.io/client-go/dynamic/fake"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
-	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestPod_CheckResourceOnly2MiHugePages(t *testing.T) {
@@ -520,82 +515,5 @@ func TestIsRunAsUserID(t *testing.T) {
 
 	for _, tc := range testCases {
 		assert.Equal(t, tc.expectedOutput, tc.testPod.IsRunAsUserID(tc.testUID))
-	}
-}
-
-func Test_followOwnerReferences(t *testing.T) {
-	type args struct {
-		topOwners map[string]TopOwner
-		namespace string
-		ownerRefs []metav1.OwnerReference
-	}
-
-	csv1 := &olmv1Alpha.ClusterServiceVersion{
-		TypeMeta: metav1.TypeMeta{Kind: "ClusterServiceVersion", APIVersion: "operators.coreos.com/v1alpha1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            "csv1",
-			Namespace:       "ns1",
-			OwnerReferences: []metav1.OwnerReference{},
-		},
-	}
-	dep1 := &v1app.Deployment{
-		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            "dep1",
-			Namespace:       "ns1",
-			OwnerReferences: []metav1.OwnerReference{{APIVersion: "operators.coreos.com/v1alpha1", Kind: "ClusterServiceVersion", Name: "csv1"}},
-		},
-	}
-	rep1 := &v1app.ReplicaSet{
-		TypeMeta: metav1.TypeMeta{Kind: "ReplicaSet", APIVersion: "apps/v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            "rep1",
-			Namespace:       "ns1",
-			OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "dep1"}},
-		},
-	}
-
-	resourceList := []*metav1.APIResourceList{
-		{GroupVersion: "operators.coreos.com/v1alpha1", APIResources: []metav1.APIResource{{Name: "clusterserviceversions", Kind: "ClusterServiceVersion"}}},
-		{GroupVersion: "apps/v1", APIResources: []metav1.APIResource{{Name: "deployments", Kind: "Deployment"}}},
-		{GroupVersion: "apps/v1", APIResources: []metav1.APIResource{{Name: "replicasets", Kind: "ReplicaSet"}}},
-		{GroupVersion: "apps/v1", APIResources: []metav1.APIResource{{Name: "pods", Kind: "Pod"}}},
-	}
-
-	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
-	}{
-		{
-			name: "test1",
-			args: args{topOwners: map[string]TopOwner{"csv1": {Namespace: "ns1", Kind: "ClusterServiceVersion", Name: "csv1"}},
-				namespace: "ns1",
-				ownerRefs: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "rep1"}},
-			},
-		},
-	}
-
-	// Spoof the get and update functions
-	client := k8sDynamicFake.NewSimpleDynamicClient(runtime.NewScheme(), rep1, dep1, csv1)
-	client.Fake.AddReactor("get", "ClusterServiceVersion", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, csv1, nil
-	})
-	client.Fake.AddReactor("get", "Deployment", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, dep1, nil
-	})
-	client.Fake.AddReactor("get", "ReplicaSet", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, rep1, nil
-	})
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotResults := map[string]TopOwner{}
-			if err := followOwnerReferences(resourceList, client, gotResults, tt.args.namespace, tt.args.ownerRefs); (err != nil) != tt.wantErr {
-				t.Errorf("followOwnerReferences() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if !reflect.DeepEqual(gotResults, tt.args.topOwners) {
-				t.Errorf("followOwnerReferences() = %v, want %v", gotResults, tt.args.topOwners)
-			}
-		})
 	}
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -72,9 +72,10 @@ type TestEnvironment struct { // rename this with testTarget
 	AbnormalEvents []*Event
 
 	// Pod Groupings
-	Pods      []*Pod                 `json:"testPods"`
-	DebugPods map[string]*corev1.Pod // map from nodename to debugPod
-	AllPods   []*Pod                 `json:"AllPods"`
+	Pods            []*Pod                 `json:"testPods"`
+	DebugPods       map[string]*corev1.Pod // map from nodename to debugPod
+	AllPods         []*Pod                 `json:"AllPods"`
+	AllOperatorPods []*Pod                 `json:"AllOperatorPods"`
 
 	// Deployment Groupings
 	Deployments []*Deployment `json:"testDeployments"`
@@ -255,6 +256,12 @@ func buildTestEnvironment() { //nolint:funlen
 	for i := 0; i < len(data.DebugPods); i++ {
 		nodeName := data.DebugPods[i].Spec.NodeName
 		env.DebugPods[nodeName] = &data.DebugPods[i]
+	}
+
+	pods = data.AllOperatorPods
+	for i := 0; i < len(pods); i++ {
+		aNewPod := NewPod(&pods[i])
+		env.AllOperatorPods = append(env.AllOperatorPods, &aNewPod)
 	}
 
 	env.OCPStatus = data.OCPStatus

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -75,7 +75,7 @@ type TestEnvironment struct { // rename this with testTarget
 	Pods            []*Pod                 `json:"testPods"`
 	DebugPods       map[string]*corev1.Pod // map from nodename to debugPod
 	AllPods         []*Pod                 `json:"AllPods"`
-	AllOperatorPods map[string][]*Pod      `json:"AllOperatorPods"`
+	CSVToPodListMap map[string][]*Pod      `json:"CSVToPodListMap"`
 
 	// Deployment Groupings
 	Deployments []*Deployment `json:"testDeployments"`
@@ -258,14 +258,14 @@ func buildTestEnvironment() { //nolint:funlen
 		env.DebugPods[nodeName] = &data.DebugPods[i]
 	}
 
-	env.AllOperatorPods = make(map[string][]*Pod)
-	for k, podList := range data.AllOperatorPods {
+	env.CSVToPodListMap = make(map[string][]*Pod)
+	for k, podList := range data.CSVToPodListMap {
 		var pods []*Pod
 		for i := 0; i < len(podList); i++ {
 			aNewPod := NewPod(podList[i])
 			pods = append(pods, &aNewPod)
 		}
-		env.AllOperatorPods[k] = pods
+		env.CSVToPodListMap[k] = pods
 	}
 
 	env.OCPStatus = data.OCPStatus

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -75,7 +75,7 @@ type TestEnvironment struct { // rename this with testTarget
 	Pods            []*Pod                 `json:"testPods"`
 	DebugPods       map[string]*corev1.Pod // map from nodename to debugPod
 	AllPods         []*Pod                 `json:"AllPods"`
-	AllOperatorPods []*Pod                 `json:"AllOperatorPods"`
+	AllOperatorPods map[string][]*Pod      `json:"AllOperatorPods"`
 
 	// Deployment Groupings
 	Deployments []*Deployment `json:"testDeployments"`
@@ -258,10 +258,14 @@ func buildTestEnvironment() { //nolint:funlen
 		env.DebugPods[nodeName] = &data.DebugPods[i]
 	}
 
-	pods = data.AllOperatorPods
-	for i := 0; i < len(pods); i++ {
-		aNewPod := NewPod(&pods[i])
-		env.AllOperatorPods = append(env.AllOperatorPods, &aNewPod)
+	env.AllOperatorPods = make(map[string][]*Pod)
+	for k, podList := range data.AllOperatorPods {
+		var pods []*Pod
+		for i := 0; i < len(podList); i++ {
+			aNewPod := NewPod(podList[i])
+			pods = append(pods, &aNewPod)
+		}
+		env.AllOperatorPods[k] = pods
 	}
 
 	env.OCPStatus = data.OCPStatus


### PR DESCRIPTION
**Issue** [JIRA Link](https://issues.redhat.com/browse/CNFCERT-885)

**Includes**
- Logic to get all pods managed by the operators under test from the namespaces mentioned through `targetNamespaces` in CSV. The client code gets this from `env.AllOperatorPods` 
- Refactoring of the retrieval of owner references code (moved from `provider` to `podhelper`

**NOTE** 
To be used in [this PR](https://github.com/test-network-function/cnf-certification-test/pull/1967)