### PR TITLE
Enable OCP testing on PRs

### DIFF
--- a/.github/workflows/qe-ocp-pre-main.yaml
+++ b/.github/workflows/qe-ocp-pre-main.yaml
@@ -1,0 +1,90 @@
+name: OCP Pre-Main Testing
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+env:
+  QE_REPO: test-network-function/cnfcert-tests-verification
+  KUBECONFIG: /home/labuser3/.kube/config
+  PFLT_DOCKERCONFIG: '/home/labuser3/.docker/config'
+  TEST_TNF_IMAGE_NAME: quay.io/testnetworkfunction/cnf-certification-test
+  TEST_TNF_IMAGE_TAG: unstable
+  DOCKER_CONFIG_DIR: '/home/labuser3/.docker'
+  TNF_CONFIG_DIR: '/home/labuser3/tnf_config'
+  TNF_REPORT_DIR: '/home/labuser3/tnf_report'
+
+jobs:
+  pull-unstable-image:
+    runs-on: qe-ocp-416
+    env:
+      SHELL: /bin/bash
+      FORCE_DOWNLOAD_UNSTABLE: true
+    steps:
+      - name: Check out code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Clone the QE repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: ${{ env.QE_REPO }}
+          path: cnfcert-tests-verification
+
+      - name: Run the script to pull the unstable image
+        run: ./scripts/download-unstable.sh
+        working-directory: cnfcert-tests-verification
+
+  qe-ocp-testing:
+    runs-on: qe-ocp-416
+    needs: pull-unstable-image
+    if: needs.pull-unstable-image.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix: 
+        suite: [affiliatedcertification, operator]
+    env:
+      SHELL: /bin/bash
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Run initial setup
+        uses: ./.github/actions/setup
+
+      - name: Show pods
+        run: oc get pods -A
+
+      - name: Clone the QE repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: ${{ env.QE_REPO }}
+          path: cnfcert-tests-verification
+
+      - name: Preemptively potential QE namespaces
+        run: ./scripts/delete-namespaces.sh
+        working-directory: cnfcert-tests-verification
+
+      - name: Preemptively delete contents of openshift-marketplace namespace
+        run: ./scripts/clean-marketplace.sh
+        working-directory: cnfcert-tests-verification
+
+      - name: Preemptively delete report and config folders
+        shell: bash
+        run: |
+          sudo rm -rf ${{env.TNF_CONFIG_DIR}}
+          sudo rm -rf ${{env.TNF_REPORT_DIR}}
+
+      - name: Run the tests (against image)
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          command: cd ${GITHUB_WORKSPACE}/cnfcert-tests-verification; FEATURES=${{matrix.suite}} TNF_REPO_PATH=${GITHUB_WORKSPACE} TNF_IMAGE=${{env.TEST_TNF_IMAGE_NAME}} TNF_IMAGE_TAG=${{env.TEST_TNF_IMAGE_TAG}} JOB_ID=${{github.run_id}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=true ENABLE_FLAKY_RETRY=true make test-features


### PR DESCRIPTION
Enable both the `operator` and `affiliatedcertification` suites on PRs.  Targeting 4.16 off the bat.