### PR TITLE
Makefile: use curl to get the parser webpage (results.html)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,9 @@ LINKER_TNF_RELEASE_FLAGS=-X github.com/test-network-function/cnf-certification-t
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/pkg/versions.GitRelease=${GIT_RELEASE}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/pkg/versions.GitPreviousRelease=${GIT_PREVIOUS_RELEASE}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/pkg/versions.ClaimFormatVersion=${CLAIM_FORMAT_VERSION}
-PARSER_RELEASE=$(shell jq .parserTag version.json)
 BASH_SCRIPTS=$(shell find . -name "*.sh" -not -path "./.git/*")
+PARSER_RELEASE=$(shell jq -r .parserTag version.json)
+RESULTS_HTML_URL=https://raw.githubusercontent.com/test-network-function/parser/${PARSER_RELEASE}/html/results.html
 
 all: build
 
@@ -62,7 +63,7 @@ build:
 		build-cnf-tests \
 		test
 
-build-certsuite-tool:
+build-certsuite-tool: results-html
 	PATH="${PATH}:${GOBIN}" go build -ldflags "${LINKER_TNF_RELEASE_FLAGS}" -o certsuite -v cmd/certsuite/main.go
 
 # Cleans up auto-generated and report files
@@ -175,7 +176,7 @@ create-manifest-local:
 		${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-arm64
 
 results-html:
-	script/get-results-html.sh ${PARSER_RELEASE}
+	curl -s -O --output-dir cnf-certification-test/results/html ${RESULTS_HTML_URL}
 
 check-results:
 	./certsuite check results

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ build:
 
 build-certsuite-tool: results-html
 	PATH="${PATH}:${GOBIN}" go build -ldflags "${LINKER_TNF_RELEASE_FLAGS}" -o certsuite -v cmd/certsuite/main.go
+	git restore cnf-certification-test/results/html/results.html
 
 # Cleans up auto-generated and report files
 clean:

--- a/cnf-certification-test/results/html/results.html
+++ b/cnf-certification-test/results/html/results.html
@@ -1,1 +1,0 @@
-This is a placeholder for the results.html file that will be downloaded from https://github.com/test-network-function/parser when this project is built

--- a/cnf-certification-test/results/html/results.html
+++ b/cnf-certification-test/results/html/results.html
@@ -1,0 +1,1 @@
+This is a placeholder for the results.html file that will be downloaded from https://github.com/test-network-function/parser when this project is built.

--- a/script/get-results-html.sh
+++ b/script/get-results-html.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -x
-git clone --depth=1 --branch="$1" "https://github.com/test-network-function/parser.git" temp-html
-cp temp-html/html/results.html cnf-certification-test/results/html/.
-rm -rf temp-html


### PR DESCRIPTION
It avoids the need to download the parser repo to just copy the results.html file. The script that to does this is also deleted.