### PR TITLE
Add 4.17 nightly YAML

### DIFF
--- a/.github/workflows/qe-ocp-417-intrusive.yaml
+++ b/.github/workflows/qe-ocp-417-intrusive.yaml
@@ -1,0 +1,117 @@
+name: QE OCP 4.17 Intrusive Testing
+
+on:
+  # pull_request:
+  #   branches: [ main ]
+  workflow_dispatch:
+  # Schedule a daily cron at 5 UTC
+  schedule:
+    - cron: '0 5 * * *'
+
+permissions:
+  contents: read
+
+env:
+  QE_REPO: test-network-function/cnfcert-tests-verification
+
+jobs:
+  pull-unstable-image:
+    runs-on: qe-ocp-417
+    env:
+      SHELL: /bin/bash
+      FORCE_DOWNLOAD_UNSTABLE: true
+    steps:
+      - name: Check out code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Clone the QE repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: ${{ env.QE_REPO }}
+          path: cnfcert-tests-verification
+
+      - name: Run the script to pull the unstable image
+        run: ./scripts/download-unstable.sh
+        working-directory: cnfcert-tests-verification
+
+  qe-ocp-417-intrusive-testing:
+    runs-on: qe-ocp-417
+    needs: pull-unstable-image
+    if: needs.pull-unstable-image.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix: 
+        # Add more suites if more intrusive tests are added to the QE repo
+        suite: [lifecycle]
+    env:
+      SHELL: /bin/bash
+      KUBECONFIG: '/home/labuser4/.kube/config'
+      PFLT_DOCKERCONFIG: '/home/labuser4/.docker/config'
+      TEST_TNF_IMAGE_NAME: quay.io/testnetworkfunction/cnf-certification-test
+      TEST_TNF_IMAGE_TAG: unstable
+      DOCKER_CONFIG_DIR: '/home/labuser4/.docker'
+      TNF_CONFIG_DIR: '/home/labuser4/tnf_config'
+      TNF_REPORT_DIR: '/home/labuser4/tnf_report'
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Run initial setup
+        uses: ./.github/actions/setup
+
+      - name: Show pods
+        run: oc get pods -A
+
+      - name: Clone the QE repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: ${{ env.QE_REPO }}
+          path: cnfcert-tests-verification
+
+      - name: Preemptively potential QE namespaces
+        run: ./scripts/delete-namespaces.sh
+        working-directory: cnfcert-tests-verification
+
+      - name: Preemptively delete contents of openshift-marketplace namespace
+        run: ./scripts/clean-marketplace.sh
+        working-directory: cnfcert-tests-verification
+
+      - name: Preemptively delete report and config folders
+        shell: bash
+        run: |
+          sudo rm -rf ${{env.TNF_CONFIG_DIR}}
+          sudo rm -rf ${{env.TNF_REPORT_DIR}}
+
+      - name: Run the tests (against image)
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          command: cd ${GITHUB_WORKSPACE}/cnfcert-tests-verification; FEATURES=${{matrix.suite}} TNF_REPO_PATH=${GITHUB_WORKSPACE} TNF_IMAGE=${{env.TEST_TNF_IMAGE_NAME}} TNF_IMAGE_TAG=${{env.TEST_TNF_IMAGE_TAG}} JOB_ID=${{github.run_id}} DISABLE_INTRUSIVE_TESTS=false ENABLE_PARALLEL=true ENABLE_FLAKY_RETRY=true make test-features
+
+      - name: Build the binary
+        run: make build-certsuite-tool
+
+      - name: Run the tests (against binary)
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          command: cd ${GITHUB_WORKSPACE}/cnfcert-tests-verification; FEATURES=${{matrix.suite}} TNF_REPO_PATH=${GITHUB_WORKSPACE} USE_BINARY=true JOB_ID=${{github.run_id}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=true ENABLE_FLAKY_RETRY=true make test-features
+
+      - name: (if on main and upstream) Send chat msg to dev team if failed to run QE tests
+        if: ${{ failure() && github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          JOB_RUN_ID: ${{ github.run_id }}
+          JOB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GITHUB_REPO: https://github.com/test-network-function/cnf-certification-test
+        run: |
+          curl -X POST --data "{
+              \"text\": \"🚨⚠️  Failed to run intrusive OCP 4.17 QE tests from commit \<$GITHUB_REPO/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<$GITHUB_REPO/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"
+          }" -H 'Content-type: application/json; charset=UTF-8' '${{ secrets.QE_NIGHTLY_WEBHOOK }}'

--- a/.github/workflows/qe-ocp-417.yaml
+++ b/.github/workflows/qe-ocp-417.yaml
@@ -1,0 +1,116 @@
+name: QE OCP 4.17 Testing
+
+on:
+  # pull_request:
+  #   branches: [ main ]
+  workflow_dispatch:
+  # Schedule a daily cron at midnight UTC
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: read
+
+env:
+  QE_REPO: test-network-function/cnfcert-tests-verification
+
+jobs:
+  pull-unstable-image:
+    runs-on: qe-ocp-417
+    env:
+      SHELL: /bin/bash
+      FORCE_DOWNLOAD_UNSTABLE: true
+    steps:
+      - name: Check out code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Clone the QE repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: ${{ env.QE_REPO }}
+          path: cnfcert-tests-verification
+
+      - name: Run the script to pull the unstable image
+        run: ./scripts/download-unstable.sh
+        working-directory: cnfcert-tests-verification
+
+  qe-ocp-417-testing:
+    runs-on: qe-ocp-417
+    needs: pull-unstable-image
+    if: needs.pull-unstable-image.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix: 
+        suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
+    env:
+      SHELL: /bin/bash
+      KUBECONFIG: '/home/labuser4/.kube/config'
+      PFLT_DOCKERCONFIG: '/home/labuser4/.docker/config'
+      TEST_TNF_IMAGE_NAME: quay.io/testnetworkfunction/cnf-certification-test
+      TEST_TNF_IMAGE_TAG: unstable
+      DOCKER_CONFIG_DIR: '/home/labuser4/.docker'
+      TNF_CONFIG_DIR: '/home/labuser4/tnf_config'
+      TNF_REPORT_DIR: '/home/labuser4/tnf_report'
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Run initial setup
+        uses: ./.github/actions/setup
+
+      - name: Show pods
+        run: oc get pods -A
+
+      - name: Clone the QE repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: ${{ env.QE_REPO }}
+          path: cnfcert-tests-verification
+
+      - name: Preemptively potential QE namespaces
+        run: ./scripts/delete-namespaces.sh
+        working-directory: cnfcert-tests-verification
+
+      - name: Preemptively delete contents of openshift-marketplace namespace
+        run: ./scripts/clean-marketplace.sh
+        working-directory: cnfcert-tests-verification
+
+      - name: Preemptively delete report and config folders
+        shell: bash
+        run: |
+          sudo rm -rf ${{env.TNF_CONFIG_DIR}}
+          sudo rm -rf ${{env.TNF_REPORT_DIR}}
+
+      - name: Run the tests (against image)
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          command: cd ${GITHUB_WORKSPACE}/cnfcert-tests-verification; FEATURES=${{matrix.suite}} TNF_REPO_PATH=${GITHUB_WORKSPACE} TNF_IMAGE=${{env.TEST_TNF_IMAGE_NAME}} TNF_IMAGE_TAG=${{env.TEST_TNF_IMAGE_TAG}} JOB_ID=${{github.run_id}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=true ENABLE_FLAKY_RETRY=true make test-features
+
+      - name: Build the binary
+        run: make build-certsuite-tool
+
+      - name: Run the tests (against binary)
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          command: cd ${GITHUB_WORKSPACE}/cnfcert-tests-verification; FEATURES=${{matrix.suite}} TNF_REPO_PATH=${GITHUB_WORKSPACE} USE_BINARY=true JOB_ID=${{github.run_id}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=true ENABLE_FLAKY_RETRY=true make test-features
+
+      - name: (if on main and upstream) Send chat msg to dev team if failed to run QE tests
+        if: ${{ failure() && github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          JOB_RUN_ID: ${{ github.run_id }}
+          JOB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GITHUB_REPO: https://github.com/test-network-function/cnf-certification-test
+        run: |
+          curl -X POST --data "{
+              \"text\": \"🚨⚠️  Failed to run non-intrusive OCP 4.17 QE tests from commit \<$GITHUB_REPO/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<$GITHUB_REPO/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"
+          }" -H 'Content-type: application/json; charset=UTF-8' '${{ secrets.QE_NIGHTLY_WEBHOOK }}'


### PR DESCRIPTION
Adds YAMLs for 4.17 OCP nightlies.

Related to: https://github.com/test-network-function/cnfcert-tests-verification/pull/818

https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/

This page lists a very early version of the 4.17 release which I deployed internally.