### PR TITLE
Adjust RHEL regex to support Beta versions

### DIFF
--- a/cnf-certification-test/platform/isredhat/isredhat.go
+++ b/cnf-certification-test/platform/isredhat/isredhat.go
@@ -28,7 +28,7 @@ const (
 	// NotRedHatBasedRegex is the expected output for a container that is not based on Red Hat technologies.
 	NotRedHatBasedRegex = `(?m)Unknown Base Image`
 	// VersionRegex is regular expression expected for a container based on Red Hat technologies.
-	VersionRegex = `(?m)Red Hat Enterprise Linux( Server)? release (\d+\.\d+) \(\w+\)`
+	VersionRegex = `(?m)Red Hat Enterprise Linux( Server)? release (\d+\.\d+)`
 )
 
 type BaseImageInfo struct {

--- a/cnf-certification-test/platform/isredhat/isredhat_test.go
+++ b/cnf-certification-test/platform/isredhat/isredhat_test.go
@@ -89,6 +89,13 @@ func TestTestContainerIsRedHatRelease(t *testing.T) {
 			expectedResult: true,
 			expectedErr:    nil,
 		},
+		{ // Test Case #5 - Beta version
+			resultStdOut:   "Red Hat Enterprise Linux release 8.5 Beta (Ootpa)",
+			resultStdErr:   "",
+			resultErr:      nil,
+			expectedResult: true,
+			expectedErr:    nil,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Support RHEL releases with "Beta" in the name like `Red Hat Enterprise Linux release 8.5 Beta (Ootpa)`