### PR TITLE
Remove unnecessary kubeconfig check

### DIFF
--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -158,9 +158,6 @@ func GetClientsHolder(filenames ...string) *ClientsHolder {
 	if clientsHolder.ready {
 		return &clientsHolder
 	}
-	if len(filenames) == 0 {
-		log.Fatal("Please provide a valid Kubeconfig. Either set the KUBECONFIG environment variable or alternatively copy a kube config to $HOME/.kube/config")
-	}
 	clientsHolder, err := newClientsHolder(filenames...)
 	if err != nil {
 		log.Fatal("Failed to create k8s clients holder, err: %v", err)


### PR DESCRIPTION
In current state, it is not possible to run the suites from inside a cluster, without `kubeconfig` being specified (using `-k` flag), as the `KUBECONFIG` existence is checked before trying to create a client using an in cluster configuration.

The change in this PR allows the following flow (see [function](https://github.com/test-network-function/cnf-certification-test/blob/cb5fe52b41919f25ae5e14b49fcdb0d027eb4a32/internal/clientsholder/clientsholder.go#L215)):

- Try creating a client using in cluster configuration - if it worked, use it.
- If it didn't work see if there is a specified `KUBECONFIG` (through `-k` flag or default directory), if there is, use it.
- If there is no `KUBECONFIG` specified - return an error


