### PR TITLE
workflows: add new workflow to upload release assets

### DIFF
--- a/.github/workflows/upload-release-assets.yaml
+++ b/.github/workflows/upload-release-assets.yaml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 env:
-  CERTSUITE_X86_64_BIN: certsuite-"${GITHUB_REF}"-x86_64
-  CERTSUITE_ARM64_BIN: certsuite-"${GITHUB_REF}"-arm64
+  CERTSUITE_X86_64_BIN: certsuite-"${GITHUB_REF_NAME}"-x86_64
+  CERTSUITE_ARM64_BIN: certsuite-"${GITHUB_REF_NAME}"-arm64
 
 jobs:
   upload-release-assets:

--- a/.github/workflows/upload-release-assets.yaml
+++ b/.github/workflows/upload-release-assets.yaml
@@ -1,0 +1,46 @@
+name: Upload release assets 
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+env:
+  CERTSUITE_X86_64_BIN: certsuite-"${GITHUB_REF}"-x86_64
+  CERTSUITE_ARM64_BIN: certsuite-"${GITHUB_REF}"-arm64
+
+jobs:
+  upload-release-assets:
+    name: Updaload release assets
+    runs-on: ubuntu-22.04
+    steps:
+
+      - name: Set up Go 1.22
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version: 1.22.4
+
+      - name: Check out code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Build Certsuite binary (x86_64)
+        env:
+          SHELL: /bin/bash
+        run: |
+          make build
+          mv certsuite "${CERTSUITE_X86_64_BIN}"
+          tar -cvzf "${CERTSUITE_X86_64_BIN}".tar.gz "${CERTSUITE_X86_64_BIN}"
+
+      - name: Build Certsuite binary (ARM 64)
+        env:
+          SHELL: /bin/bash
+        run: |
+          make build-darwin-arm64
+          mv certsuite "${CERTSUITE_ARM64_BIN}"
+          tar -cvzf "${CERTSUITE_ARM64_BIN}".tar.gz "${CERTSUITE_ARM64_BIN}"
+
+      - name: Upload Certsuite binaries
+        env:
+          SHELL: /bin/bash
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload $GITHUB_REF "${CERTSUITE_X86_64_BIN}".tar.gz "${CERTSUITE_ARM64_BIN}".tar.gz

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ build-certsuite-tool: results-html
 	PATH="${PATH}:${GOBIN}" go build -ldflags "${LINKER_TNF_RELEASE_FLAGS}" -o certsuite -v cmd/certsuite/main.go
 	git restore cnf-certification-test/results/html/results.html
 
+build-darwin-arm64: results-html
+	PATH="${PATH}:${GOBIN}" GOOS=darwin GOARCH=arm64 go build -ldflags "${LINKER_TNF_RELEASE_FLAGS}" -o certsuite -v cmd/certsuite/main.go
+	git restore cnf-certification-test/results/html/results.html
+
 # Cleans up auto-generated and report files
 clean:
 	go clean && rm -f all-releases.txt cover.out claim.json cnf-certification-test/claim.json \


### PR DESCRIPTION
It builds and uploads the Certsuite binaries compressed in tar.gz for x86_64 and ARM 64.

build-depends: 31882

