### PR TITLE
configure : Test operator labels in tnf_config yaml

### DIFF
--- a/cnf-certification-test/tnf_config.yml
+++ b/cnf-certification-test/tnf_config.yml
@@ -5,17 +5,18 @@ podsUnderTestLabels:
 operatorsUnderTestLabels:
   - "test-network-function.com/operator:target"
   - "test-network-function.com/operator1:new"
+  - "cnf/test:cr-scale-operator"
 targetCrdFilters:
   - nameSuffix: "group1.test.com"
     scalable: false
   - nameSuffix: "test-network-function.com"
     scalable: false
-  - nameSuffix: "tutorial.my.domain"
-    scalable: true 
+  - nameSuffix: "memcacheds.cache.example.com"
+    scalable: true
 managedDeployments:
-  - name: jack
+  - name: memcached-sample
 managedStatefulsets:
-  - name: jack
+  - name: memcached-sample
 acceptedKernelTaints:
   - module: vboxsf
   - module: vboxguest

--- a/expected_results.yaml
+++ b/expected_results.yaml
@@ -29,6 +29,7 @@ testCases:
     - lifecycle-affinity-required-pods
     - lifecycle-container-poststart
     - lifecycle-container-prestop
+    - lifecycle-crd-scaling
     - lifecycle-deployment-scaling
     - lifecycle-image-pull-policy
     - lifecycle-liveness-probe
@@ -73,7 +74,6 @@ testCases:
     - affiliated-certification-helm-version
     - affiliated-certification-helmchart-is-certified
     - lifecycle-cpu-isolation
-    - lifecycle-crd-scaling
     - lifecycle-statefulset-scaling
     - lifecycle-storage-provisioner
     - networking-dpdk-cpu-pinning-exec-probe


### PR DESCRIPTION
https://issues.redhat.com/browse/CNFCERT-990

This PR makes the lifecycle-cr-scaling test cases as PASSED from skipped as the tnf_config is configured to use the the deployed test operator (cr-scale-operator) and run this test case.