### PR TITLE
fix tnf_config.yaml directory typo batch script command

### DIFF
--- a/script/run-basic-batch-operators-test.sh
+++ b/script/run-basic-batch-operators-test.sh
@@ -627,7 +627,7 @@ while IFS=, read -r package_name catalog_index; do
 		certsuite run \
 		--kubeconfig=/usr/tnf/config/kubeconfig \
 		--preflight-dockerconfig=/usr/tnf/config/dockerconfig \
-		--config-file=/usr/tnf/config/tnf_config.yml \
+		--config-file=/usr/tnf/config/tnf_config.yaml \
 		--output-dir=/usr/tnf/output \
 		--label-filter=all >>"$LOG_FILE_PATH" 2>&1 || {
 		report_failure "$status" "$ns" "$package_name" "CNF suite exited with errors"


### PR DESCRIPTION
tnf_config file directory when executing command is miss matched with the one defined [here](https://github.com/test-network-function/cnf-certification-test/blob/7d772bb7c4e96795c85a50998e41a148a4c33b9e/script/run-basic-batch-operators-test.sh#L621)