### PR TITLE
cmd/certsuite: add new command to show the version

### DIFF
--- a/cmd/certsuite/main.go
+++ b/cmd/certsuite/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/cmd/certsuite/claim"
 	"github.com/test-network-function/cnf-certification-test/cmd/certsuite/generate"
 	"github.com/test-network-function/cnf-certification-test/cmd/certsuite/run"
+	"github.com/test-network-function/cnf-certification-test/cmd/certsuite/version"
 )
 
 var (
@@ -24,6 +25,7 @@ func main() {
 	rootCmd.AddCommand(generate.NewCommand())
 	rootCmd.AddCommand(check.NewCommand())
 	rootCmd.AddCommand(run.NewCommand())
+	rootCmd.AddCommand(version.NewCommand())
 
 	if err := rootCmd.Execute(); err != nil {
 		log.Error("%v", err)

--- a/cmd/certsuite/version/version.go
+++ b/cmd/certsuite/version/version.go
@@ -1,0 +1,27 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/test-network-function/cnf-certification-test/pkg/versions"
+)
+
+var (
+	runCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Show the Red Hat Best Practices Test Suite for Kubernetes version",
+		RunE:  showVersion,
+	}
+)
+
+func showVersion(cmd *cobra.Command, _ []string) error {
+	fmt.Printf("Certsuite version: %s\n", versions.GitVersion())
+	fmt.Printf("Claim file version: %s\n", versions.ClaimFormatVersion)
+
+	return nil
+}
+
+func NewCommand() *cobra.Command {
+	return runCmd
+}


### PR DESCRIPTION
It displays the Certsuite version as well as the Claim file version.