### PR TITLE
cmd/certsuite: add new "certsuite info" command to display Catalog info

### DIFF
--- a/cmd/certsuite/info/info.go
+++ b/cmd/certsuite/info/info.go
@@ -9,6 +9,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/identifiers"
 	"github.com/test-network-function/cnf-certification-test/internal/cli"
 	"github.com/test-network-function/test-network-function-claim/pkg/claim"
+	"golang.org/x/term"
 )
 
 var (
@@ -19,7 +20,7 @@ var (
 	}
 )
 
-func showInfo(cmd *cobra.Command, _ []string) error {
+func showInfo(cmd *cobra.Command, _ []string) error { //nolint:funlen
 	testCaseFlag, _ := cmd.Flags().GetString("test-case")
 
 	var testCase claim.TestCaseDescription
@@ -34,15 +35,27 @@ func showInfo(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("no test case found matching name %q", testCaseFlag)
 	}
 
-	const lineMaxWidth = 120
+	// Adjust text box line width
+	const linePadding = 4
+	lineMaxWidth := 120
+	if term.IsTerminal(0) {
+		width, _, err := term.GetSize(0)
+		fmt.Println("Term Width: ", width)
+		if err != nil {
+			return fmt.Errorf("could not get terminal size, err: %v", err)
+		}
+		if width < lineMaxWidth+linePadding {
+			lineMaxWidth = width - linePadding
+		}
+	}
 
 	// Test case identifier
-	border := strings.Repeat("-", lineMaxWidth+4) //nolint:mnd // magic number
+	border := strings.Repeat("-", lineMaxWidth+linePadding)
 	fmt.Println(border)
 	fmt.Printf("| %s |\n", cli.LineColor(cli.LineAlignCenter(testCase.Identifier.Id, lineMaxWidth), cli.Cyan))
 
 	// Description
-	border = strings.Repeat("-", lineMaxWidth+4) //nolint:mnd // magic number
+	border = strings.Repeat("-", lineMaxWidth+linePadding)
 	fmt.Println(border)
 	fmt.Printf("| %s |\n", cli.LineColor(cli.LineAlignCenter("DESCRIPTION", lineMaxWidth), cli.Green))
 	fmt.Println(border)

--- a/cmd/certsuite/info/info.go
+++ b/cmd/certsuite/info/info.go
@@ -2,6 +2,7 @@ package info
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -22,9 +23,9 @@ func showInfo(cmd *cobra.Command, _ []string) error {
 	testCaseFlag, _ := cmd.Flags().GetString("test-case")
 
 	var testCase claim.TestCaseDescription
-	for _, tc := range identifiers.Catalog {
-		if tc.Identifier.Id == testCaseFlag {
-			testCase = tc
+	for id := range identifiers.Catalog {
+		if id.Id == testCaseFlag {
+			testCase = identifiers.Catalog[id]
 			break
 		}
 	}
@@ -36,12 +37,12 @@ func showInfo(cmd *cobra.Command, _ []string) error {
 	const lineMaxWidth = 120
 
 	// Test case identifier
-	border := strings.Repeat("-", lineMaxWidth+4)
+	border := strings.Repeat("-", lineMaxWidth+4) //nolint:mnd // magic number
 	fmt.Println(border)
 	fmt.Printf("| %s |\n", cli.LineColor(cli.LineAlignCenter(testCase.Identifier.Id, lineMaxWidth), cli.Cyan))
 
 	// Description
-	border = strings.Repeat("-", lineMaxWidth+4)
+	border = strings.Repeat("-", lineMaxWidth+4) //nolint:mnd // magic number
 	fmt.Println(border)
 	fmt.Printf("| %s |\n", cli.LineColor(cli.LineAlignCenter("DESCRIPTION", lineMaxWidth), cli.Green))
 	fmt.Println(border)
@@ -79,6 +80,10 @@ func showInfo(cmd *cobra.Command, _ []string) error {
 
 func NewCommand() *cobra.Command {
 	infoCmd.PersistentFlags().StringP("test-case", "t", "", "The test case to display information about")
-	infoCmd.MarkPersistentFlagRequired("test-case")
+	err := infoCmd.MarkPersistentFlagRequired("test-case")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not mark persistent flag \"test-case\" as required, err: %v", err)
+		return nil
+	}
 	return infoCmd
 }

--- a/cmd/certsuite/info/info.go
+++ b/cmd/certsuite/info/info.go
@@ -1,0 +1,84 @@
+package info
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/identifiers"
+	"github.com/test-network-function/cnf-certification-test/internal/cli"
+	"github.com/test-network-function/test-network-function-claim/pkg/claim"
+)
+
+var (
+	infoCmd = &cobra.Command{
+		Use:   "info",
+		Short: "Displays information from the test catalog",
+		RunE:  showInfo,
+	}
+)
+
+func showInfo(cmd *cobra.Command, _ []string) error {
+	testCaseFlag, _ := cmd.Flags().GetString("test-case")
+
+	var testCase claim.TestCaseDescription
+	for _, tc := range identifiers.Catalog {
+		if tc.Identifier.Id == testCaseFlag {
+			testCase = tc
+			break
+		}
+	}
+
+	if testCase.Identifier.Id == "" {
+		return fmt.Errorf("no test case found matching name %q", testCaseFlag)
+	}
+
+	const lineMaxWidth = 120
+
+	// Test case identifier
+	border := strings.Repeat("-", lineMaxWidth+4)
+	fmt.Println(border)
+	fmt.Printf("| %s |\n", cli.LineColor(cli.LineAlignCenter(testCase.Identifier.Id, lineMaxWidth), cli.Cyan))
+
+	// Description
+	border = strings.Repeat("-", lineMaxWidth+4)
+	fmt.Println(border)
+	fmt.Printf("| %s |\n", cli.LineColor(cli.LineAlignCenter("DESCRIPTION", lineMaxWidth), cli.Green))
+	fmt.Println(border)
+	for _, line := range cli.WrapLines(testCase.Description, lineMaxWidth) {
+		fmt.Printf("| %s |\n", cli.LineAlignLeft(line, lineMaxWidth))
+	}
+
+	// Remediation
+	fmt.Println(border)
+	fmt.Printf("| %s |\n", cli.LineColor(cli.LineAlignCenter("REMEDIATION", lineMaxWidth), cli.Green))
+	fmt.Println(border)
+	for _, line := range cli.WrapLines(testCase.Remediation, lineMaxWidth) {
+		fmt.Printf("| %s |\n", cli.LineAlignLeft(line, lineMaxWidth))
+	}
+
+	// Exceptions
+	fmt.Println(border)
+	fmt.Printf("| %s |\n", cli.LineColor(cli.LineAlignCenter("EXCEPTIONS", lineMaxWidth), cli.Green))
+	fmt.Println(border)
+	for _, line := range cli.WrapLines(testCase.ExceptionProcess, lineMaxWidth) {
+		fmt.Printf("| %s |\n", cli.LineAlignLeft(line, lineMaxWidth))
+	}
+
+	// Best Practices reference
+	fmt.Println(border)
+	fmt.Printf("| %s |\n", cli.LineColor(cli.LineAlignCenter("BEST PRACTICES REFERENCE", lineMaxWidth), cli.Green))
+	fmt.Println(border)
+	for _, line := range cli.WrapLines(testCase.BestPracticeReference, lineMaxWidth) {
+		fmt.Printf("| %s |\n", cli.LineAlignLeft(line, lineMaxWidth))
+	}
+	fmt.Println(border)
+
+	return nil
+}
+
+func NewCommand() *cobra.Command {
+	infoCmd.PersistentFlags().StringP("test-case", "t", "", "The test case to display information about")
+	infoCmd.MarkPersistentFlagRequired("test-case")
+	return infoCmd
+}

--- a/cmd/certsuite/main.go
+++ b/cmd/certsuite/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/cmd/certsuite/check"
 	"github.com/test-network-function/cnf-certification-test/cmd/certsuite/claim"
 	"github.com/test-network-function/cnf-certification-test/cmd/certsuite/generate"
+	"github.com/test-network-function/cnf-certification-test/cmd/certsuite/info"
 	"github.com/test-network-function/cnf-certification-test/cmd/certsuite/run"
 	"github.com/test-network-function/cnf-certification-test/cmd/certsuite/version"
 )
@@ -25,6 +26,7 @@ func main() {
 	rootCmd.AddCommand(generate.NewCommand())
 	rootCmd.AddCommand(check.NewCommand())
 	rootCmd.AddCommand(run.NewCommand())
+	rootCmd.AddCommand(info.NewCommand())
 	rootCmd.AddCommand(version.NewCommand())
 
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/certsuite/version/version.go
+++ b/cmd/certsuite/version/version.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	runCmd = &cobra.Command{
+	versionCmd = &cobra.Command{
 		Use:   "version",
 		Short: "Show the Red Hat Best Practices Test Suite for Kubernetes version",
 		RunE:  showVersion,
@@ -23,5 +23,5 @@ func showVersion(cmd *cobra.Command, _ []string) error {
 }
 
 func NewCommand() *cobra.Command {
-	return runCmd
+	return versionCmd
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -258,7 +258,7 @@ func LineAlignLeft(s string, w int) string {
 }
 
 func LineAlignCenter(s string, w int) string {
-	return fmt.Sprintf("%[1]*s", -w, fmt.Sprintf("%[1]*s", (w+len(s))/2, s))
+	return fmt.Sprintf("%[1]*s", -w, fmt.Sprintf("%[1]*s", (w+len(s))/2, s)) //nolint:mnd // magic number
 }
 
 func LineColor(s, color string) string {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -225,3 +225,42 @@ func PrintCheckErrored(checkName string) {
 
 	fmt.Print(ClearLineCode + "[ " + CheckResultTagError + " ] " + checkName + "\n")
 }
+
+func WrapLines(text string, maxWidth int) []string {
+	lines := strings.Split(text, "\n")
+	wrappedLines := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if len(line) <= maxWidth {
+			wrappedLines = append(wrappedLines, line)
+			continue
+		}
+
+		// Break lines longer than maxWidth
+		words := strings.Fields(line)
+		currentLine := words[0]
+		for _, word := range words[1:] {
+			if len(currentLine)+len(word)+1 <= maxWidth {
+				currentLine += " " + word
+			} else {
+				wrappedLines = append(wrappedLines, currentLine)
+				currentLine = word
+			}
+		}
+
+		wrappedLines = append(wrappedLines, currentLine)
+	}
+
+	return wrappedLines
+}
+
+func LineAlignLeft(s string, w int) string {
+	return fmt.Sprintf("%[1]*s", -w, s)
+}
+
+func LineAlignCenter(s string, w int) string {
+	return fmt.Sprintf("%[1]*s", -w, fmt.Sprintf("%[1]*s", (w+len(s))/2, s))
+}
+
+func LineColor(s, color string) string {
+	return color + s + Reset
+}


### PR DESCRIPTION
At the moment only the "--test-case/-t" flag is supported to show the information available in the Catalog for a particular test case.