### PR TITLE
Adjust 'access-control-namespace' test to be Optional

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -40,7 +40,7 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 
 |Mandatory|Optional|
 |---|---|
-|46|20|
+|45|21|
 
 ### Telco specific tests only: 27
 
@@ -145,10 +145,10 @@ Best Practice Reference|https://test-network-function.github.io/cnf-best-practic
 Exception Process|No exceptions
 Tags|common,access-control
 |**Scenario**|**Optional/Mandatory**|
-|Extended|Mandatory|
-|Far-Edge|Mandatory|
-|Non-Telco|Mandatory|
-|Telco|Mandatory|
+|Extended|Optional|
+|Far-Edge|Optional|
+|Non-Telco|Optional|
+|Telco|Optional|
 
 #### access-control-namespace-resource-quota
 

--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -813,10 +813,10 @@ tag. (2) It does not have any of the following prefixes: default, openshift-, is
 		TestNamespaceBestPracticesIdentifierDocLink,
 		true,
 		map[string]string{
-			FarEdge:  Mandatory,
-			Telco:    Mandatory,
-			NonTelco: Mandatory,
-			Extended: Mandatory,
+			FarEdge:  Optional,
+			Telco:    Optional,
+			NonTelco: Optional,
+			Extended: Optional,
 		},
 		TagCommon)
 


### PR DESCRIPTION
Changing the `access-control-namespace` test to be `Optional` instead of `Mandatory`.

Related links:
- https://test-network-function.github.io/cnf-best-practices-guide/
- https://github.com/test-network-function/test-network-function/commit/4c2f48dde4ad12207986864859c9018c40f3dbad 

For future reference, we decided to change this to optional instead of just removing the `openshift-` prefix from the list because we wanted future visibility into potential failures/problems if a partner somehow uses one of these namespaces.