### PR TITLE
Bump parser version to v0.4.7

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "partner_tag": "v5.2.1",
   "claimFormat": "v0.4.0",
-  "parserTag": "v0.4.6"
+  "parserTag": "v0.4.7"
 }


### PR DESCRIPTION
This is to pick up: https://github.com/test-network-function/parser/pull/48