### PR TITLE
Remove operator read-only filesystem test

### DIFF
--- a/expected_results.yaml
+++ b/expected_results.yaml
@@ -71,7 +71,6 @@ testCases:
   fail:
     - access-control-security-context # test pod does not meet the security requirements
     - affiliated-certification-container-is-certified-digest # test container image is not certified
-    - operator-read-only-file-system
     - operator-run-as-non-root
   skip:
     - access-control-sys-ptrace-capability

--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -982,22 +982,6 @@ that Node's kernel may not have the same hacks.'`,
 		},
 		TagCommon)
 
-	TestOperatorReadOnlyFilesystem = AddCatalogEntry(
-		"read-only-file-system",
-		common.OperatorTestKey,
-		`Tests that check that the pods have the read-only root filesystem setting enabled.`,
-		OperatorReadOnlyFilesystem,
-		NoExceptions,
-		TestOperatorReadOnlyFilesystemDocLink,
-		true,
-		map[string]string{
-			FarEdge:  Optional,
-			Telco:    Optional,
-			NonTelco: Optional,
-			Extended: Optional,
-		},
-		TagCommon)
-
 	TestOperatorCrdVersioningIdentifier = AddCatalogEntry(
 		"crd-versioning",
 		common.OperatorTestKey,

--- a/tests/identifiers/remediation.go
+++ b/tests/identifiers/remediation.go
@@ -89,8 +89,6 @@ const (
 
 	OperatorAutomountTokens = `Ensure that the pods have the automount service account token disabled.`
 
-	OperatorReadOnlyFilesystem = `Ensure that the pods have the read-only root filesystem setting enabled.`
-
 	OperatorCrdVersioningRemediation = `Ensure that the Operator CRD has a valid version.`
 
 	OperatorSingleCrdOwnerRemediation = `Ensure that a CRD is owned by only one Operator`


### PR DESCRIPTION
The `operator-sdk` does not set this value by default and if it is turned on, it causes a loop in operator controller pods.  Thanks to @ramperher for the analysis of the test case.