### PR TITLE
Mark read-only filesystem test as Optional

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -40,7 +40,7 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 
 |Mandatory|Optional|
 |---|---|
-|45|21|
+|44|22|
 
 ### Telco specific tests only: 27
 
@@ -1229,10 +1229,10 @@ Best Practice Reference|https://test-network-function.github.io/cnf-best-practic
 Exception Process|No exceptions
 Tags|common,operator
 |**Scenario**|**Optional/Mandatory**|
-|Extended|Mandatory|
-|Far-Edge|Mandatory|
-|Non-Telco|Mandatory|
-|Telco|Mandatory|
+|Extended|Optional|
+|Far-Edge|Optional|
+|Non-Telco|Optional|
+|Telco|Optional|
 
 #### operator-run-as-non-root
 

--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -991,10 +991,10 @@ that Node's kernel may not have the same hacks.'`,
 		TestOperatorReadOnlyFilesystemDocLink,
 		true,
 		map[string]string{
-			FarEdge:  Mandatory,
-			Telco:    Mandatory,
-			NonTelco: Mandatory,
-			Extended: Mandatory,
+			FarEdge:  Optional,
+			Telco:    Optional,
+			NonTelco: Optional,
+			Extended: Optional,
 		},
 		TagCommon)
 


### PR DESCRIPTION
Another option when compared to: #2244 

The best practices document mentions that pods should be `Leveraging read only root filesystem when possible.` 

https://test-network-function.github.io/cnf-best-practices-guide/#cnf-best-practices-cnf-security

So this makes it seem that we should mark this test as Optional instead of Mandatory.
