### PR TITLE
Add scaling helper unit tests

### DIFF
--- a/tests/lifecycle/scaling/scaling_helper_test.go
+++ b/tests/lifecycle/scaling/scaling_helper_test.go
@@ -3,7 +3,11 @@ package scaling
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/cnf-certification-test/pkg/configuration"
+	scalingv1 "k8s.io/api/autoscaling/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestIsManaged(t *testing.T) {
@@ -49,4 +53,93 @@ func TestIsManaged(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetResourceHPA(t *testing.T) {
+	generateHPAList := func() []*scalingv1.HorizontalPodAutoscaler {
+		return []*scalingv1.HorizontalPodAutoscaler{
+			{
+				Spec: scalingv1.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: scalingv1.CrossVersionObjectReference{
+						Kind: "testKind",
+						Name: "testName",
+					},
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "testNamespace",
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		existsInList bool
+	}{
+		{
+			existsInList: true,
+		},
+		{
+			existsInList: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		if testCase.existsInList {
+			assert.NotNil(t, GetResourceHPA(generateHPAList(), "testName", "testNamespace", "testKind"))
+		} else {
+			assert.Nil(t, GetResourceHPA([]*scalingv1.HorizontalPodAutoscaler{}, "testName", "testNamespace", "testKind"))
+		}
+	}
+}
+
+func TestCheckOwnerReference(t *testing.T) {
+	generateOwnerReferences := func() []metav1.OwnerReference {
+		return []metav1.OwnerReference{
+			{
+				Kind: "testKind",
+			},
+		}
+	}
+
+	generateCrdFilter := func(scalable bool) []configuration.CrdFilter {
+		return []configuration.CrdFilter{
+			{
+				NameSuffix: "testSuffix",
+				Scalable:   scalable,
+			},
+		}
+	}
+
+	generateCrds := func() []*apiextv1.CustomResourceDefinition {
+		return []*apiextv1.CustomResourceDefinition{
+			{
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Names: apiextv1.CustomResourceDefinitionNames{
+						Kind: "testKind",
+					},
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testSuffix",
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		scalable bool
+	}{
+		{
+			scalable: true,
+		},
+		{
+			scalable: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.scalable, CheckOwnerReference(generateOwnerReferences(), generateCrdFilter(testCase.scalable), generateCrds()))
+	}
+
+	// Test case when owner reference is not found
+	assert.False(t, CheckOwnerReference([]metav1.OwnerReference{}, generateCrdFilter(true), generateCrds()))
 }


### PR DESCRIPTION
Brings this file's coverage to `100%`.  The overall `scaling` package only has 30.4% coverage at the time of this PR.