### PR TITLE
Add 'new' image tag to push during CI runs

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -14,6 +14,7 @@ env:
   REGISTRY: quay.io
   REGISTRY_LOCAL: localhost
   CERTSUITE_IMAGE_NAME: testnetworkfunction/cnf-certification-test
+  CERTSUITE_IMAGE_NAME_NEW: testnetworkfunction/k8s-best-practices-certsuite
   CERTSUITE_IMAGE_TAG: unstable
   OCT_IMAGE_NAME: testnetworkfunction/oct
   OCT_IMAGE_TAG: latest
@@ -445,6 +446,7 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.CERTSUITE_IMAGE_NAME }}:${{ env.CERTSUITE_IMAGE_TAG }}
+            ${{ env.REGISTRY }}/${{ env.CERTSUITE_IMAGE_NAME_NEW }}:${{ env.CERTSUITE_IMAGE_TAG }}
       
       - name: (if on main and upstream) Send chat msg to dev team if failed to create container image.
         if: ${{ failure() && github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}

--- a/.github/workflows/qe-hosted.yml
+++ b/.github/workflows/qe-hosted.yml
@@ -37,7 +37,9 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          tags: quay.io/testnetworkfunction/cnf-certification-test:localtest
+          tags: |
+            quay.io/testnetworkfunction/cnf-certification-test:localtest
+            quay.io/testnetworkfunction/k8s-best-practices-certsuite:localtest
           outputs: type=docker,dest=/tmp/testimage.tar
       
       - name: Store image as artifact

--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -25,6 +25,7 @@ env:
   REGISTRY_LOCAL: localhost
   RELEASE_LEVEL: 4.12
   TNF_IMAGE_NAME: testnetworkfunction/cnf-certification-test
+  TNF_IMAGE_NAME_NEW: testnetworkfunction/k8s-best-practices-certsuite
   IMAGE_TAG: latest
   TNF_CONTAINER_CLIENT: docker
   TNF_NON_INTRUSIVE_ONLY: false
@@ -143,6 +144,8 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{env.TNF_IMAGE_NAME}}:${{ env.TNF_VERSION }}
             ${{ env.REGISTRY }}/${{env.TNF_IMAGE_NAME}}:${{ env.IMAGE_TAG }}
+            ${{ env.REGISTRY }}/${{env.TNF_IMAGE_NAME_NEW}}:${{ env.TNF_VERSION }}
+            ${{ env.REGISTRY }}/${{env.TNF_IMAGE_NAME_NEW}}:${{ env.IMAGE_TAG }}
 
       - name: If failed to create the image, send alert msg to dev team.
         if: ${{ failure() }}

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ GO_PACKAGES=$(shell go list ./... | grep -v vendor)
 REGISTRY_LOCAL?=localhost
 REGISTRY?=quay.io
 TNF_IMAGE_NAME?=testnetworkfunction/cnf-certification-test
+TNF_IMAGE_NAME_NEW?=testnetworkfunction/k8s-best-practices-certsuite
 IMAGE_TAG?=localtest
 .PHONY: all clean test build
 .PHONY: \
@@ -148,24 +149,9 @@ build-image-local:
 	docker build --pull --no-cache \
 		-t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
 		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
+		-t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME_NEW}:${IMAGE_TAG} \
+		-t ${REGISTRY}/${TNF_IMAGE_NAME_NEW}:${IMAGE_TAG} \
 		-f Dockerfile .
-
-build-image-local-x86:
-	docker build --pull --no-cache --platform linux/amd64 \
-		-t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-amd64 \
-		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-amd64 \
-		-f Dockerfile .
-
-build-image-local-arm:
-	docker build --pull --no-cache --platform linux/arm64 \
-		-t ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-arm64 \
-		-t ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-arm64 \
-		-f Dockerfile .
-
-create-manifest-local:
-	docker manifest create ${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG} \
-		${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-amd64 \
-		${REGISTRY}/${TNF_IMAGE_NAME}:${IMAGE_TAG}-linux-arm64
 
 results-html:
 	curl -s -O --output-dir internal/results/html ${RESULTS_HTML_URL}


### PR DESCRIPTION
While we are working towards renaming the test suite, the repo, and the image name, we should push the new image tag right along side of the old image tag so there is a period of backwards compatibility.

For this proof-of-concept, I chose to use `testnetworkfunction/k8s-best-practices-certsuite` as the name of the new image since it best matches the new best practices repository name: https://github.com/test-network-function/k8s-best-practices-guide

I created the repo in Quay: https://quay.io/repository/testnetworkfunction/k8s-best-practices-certsuite

Bonus: Remove unused Makefile paths.