### PR TITLE
Remove some dependencies from the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,9 +82,9 @@ RUN make build-certsuite-tool \
 # Switch contexts back to the root CERTSUITE directory
 WORKDIR ${CERTSUITE_DIR}
 
-# Remove most of the build artefacts
+# Remove most of the build artifacts
 RUN \
-	dnf remove --assumeyes --disableplugin=subscription-manager gcc git wget \
+	dnf remove --assumeyes --disableplugin=subscription-manager git wget \
 	&& dnf clean all --assumeyes --disableplugin=subscription-manager \
 	&& rm -rf ${CERTSUITE_SRC_DIR} \
 	&& rm -rf ${TEMP_DIR} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,7 @@ RUN \
 	mkdir ${CERTSUITE_DIR} \
 	&& dnf update --assumeyes --disableplugin=subscription-manager \
 	&& dnf install --assumeyes --disableplugin=subscription-manager \
-		gcc \
 		git \
-		jq \
 		cmake \
 		wget \
 	&& dnf clean all --assumeyes --disableplugin=subscription-manager \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # There are four main groups of operations provided by this Makefile: build,
 # clean, run and tasks.
 #
-# Build operations will create artefacts from code. This includes things such
+# Build operations will create artifacts from code. This includes things such
 # as binaries, mock files, or catalogs of CNF tests.
 #
 # Clean operations remove the results of the build tasks, or other files not


### PR DESCRIPTION
Seeing if things break if I remove these dependencies.

Follow up, it looks we can safely remove the `jq` and `gcc` deps.