### PR TITLE
cmd/certsuite: move the "list" flag from "run" to "info"

### DIFF
--- a/cmd/certsuite/main_test.go
+++ b/cmd/certsuite/main_test.go
@@ -5,7 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/cnf-certification-test/cmd/certsuite/info"
+	"github.com/test-network-function/cnf-certification-test/cmd/certsuite/version"
 	"github.com/test-network-function/cnf-certification-test/pkg/versions"
 )
 
@@ -20,7 +23,7 @@ func TestCertsuiteVersionCmd(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	cmd := newRootCmd()
+	cmd := createCommand(version.NewCommand())
 	cmd.SetArgs([]string{
 		"version",
 	})
@@ -42,7 +45,7 @@ func TestCertsuiteInfoCmd(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	cmd := newRootCmd()
+	cmd := createCommand(info.NewCommand())
 	cmd.SetArgs([]string{
 		"info",
 		"--test-label=observability",
@@ -66,4 +69,14 @@ func TestCertsuiteInfoCmd(t *testing.T) {
 ------------------------------------------------------------
 `
 	assert.Equal(t, expectedOutput, string(out))
+}
+
+func createCommand(cmd *cobra.Command) *cobra.Command {
+	rootCmd := cobra.Command{
+		Use:   "certsuite",
+		Short: "A CLI tool for the Red Hat Best Practices Test Suite for Kubernetes.",
+	}
+	rootCmd.AddCommand(cmd)
+
+	return &rootCmd
 }

--- a/cmd/certsuite/main_test.go
+++ b/cmd/certsuite/main_test.go
@@ -32,6 +32,38 @@ func TestCertsuiteVersionCmd(t *testing.T) {
 	os.Stdout = savedStdout
 
 	// Check the result
-	const expectedOut = "Certsuite version: v0.0.0 (aaabbbccc)\nClaim file version: v0.0.0\n"
-	assert.Equal(t, expectedOut, string(out))
+	const expectedOutput = "Certsuite version: v0.0.0 (aaabbbccc)\nClaim file version: v0.0.0\n"
+	assert.Equal(t, expectedOutput, string(out))
+}
+
+func TestCertsuiteInfoCmd(t *testing.T) {
+	// Run the command
+	savedStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"info",
+		"--test-label=observability",
+		"--list",
+	})
+	err := cmd.Execute()
+	assert.Nil(t, err)
+
+	w.Close()
+	out, _ := io.ReadAll(r)
+	os.Stdout = savedStdout
+
+	// Check the result
+	const expectedOutput = `------------------------------------------------------------
+|                   TEST CASE SELECTION                    |
+------------------------------------------------------------
+| observability-container-logging                          |
+| observability-crd-status                                 |
+| observability-termination-policy                         |
+| observability-pod-disruption-budget                      |
+------------------------------------------------------------
+`
+	assert.Equal(t, expectedOutput, string(out))
 }

--- a/cmd/certsuite/run/run.go
+++ b/cmd/certsuite/run/run.go
@@ -29,7 +29,6 @@ func NewCommand() *cobra.Command {
 	runCmd.PersistentFlags().String("timeout", timeoutFlagDefaultvalue.String(), "Time allowed for the test suite execution to complete (e.g. --timeout 30m  or -timeout 1h30m)")
 	runCmd.PersistentFlags().StringP("config-file", "c", "config/tnf_config.yml", "The workload configuration file")
 	runCmd.PersistentFlags().StringP("kubeconfig", "k", "", "The target cluster's Kubeconfig file")
-	runCmd.PersistentFlags().Bool("list", false, "Shows all the available checks/tests (can be filtered with --label-filter)")
 	runCmd.PersistentFlags().Bool("server-mode", false, "Run the certsuite in web server mode")
 	runCmd.PersistentFlags().Bool("omit-artifacts-zip-file", false, "Prevents the creation of a zip file with the result artifacts")
 	runCmd.PersistentFlags().String("log-level", "debug", "Sets the log level")
@@ -56,7 +55,6 @@ func initTestParamsFromFlags(cmd *cobra.Command) error {
 	// Fetch test params from flags
 	testParams.OutputDir, _ = cmd.Flags().GetString("output-dir")
 	testParams.LabelsFilter, _ = cmd.Flags().GetString("label-filter")
-	testParams.ListOnly, _ = cmd.Flags().GetBool("list")
 	testParams.ServerMode, _ = cmd.Flags().GetBool("server-mode")
 	testParams.ConfigFile, _ = cmd.Flags().GetString("config-file")
 	testParams.Kubeconfig, _ = cmd.Flags().GetString("kubeconfig")

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -159,16 +159,6 @@ func PrintResultsTable(results map[string][]int) {
 	fmt.Printf("\n")
 }
 
-func PrintChecksList(checkIDs []string) {
-	fmt.Println("------------------------------------------------------------")
-	fmt.Println("|                   TEST CASE SELECTION                    |")
-	fmt.Println("------------------------------------------------------------")
-	for _, checkID := range checkIDs {
-		fmt.Printf("| %-56s |\n", checkID)
-	}
-	fmt.Println("------------------------------------------------------------")
-}
-
 func stopCheckLineGoroutine() {
 	if stopChan == nil {
 		// This may happen for checks that were skipped if no compliant nor non-compliant objects found.

--- a/pkg/certsuite/certsuite.go
+++ b/pkg/certsuite/certsuite.go
@@ -29,7 +29,7 @@ import (
 	"github.com/test-network-function/cnf-certification-test/tests/preflight"
 )
 
-func LoadChecksDB(labelsExpr string) {
+func LoadInternalChecksDB() {
 	accesscontrol.LoadChecks()
 	certification.LoadChecks()
 	lifecycle.LoadChecks()
@@ -39,6 +39,10 @@ func LoadChecksDB(labelsExpr string) {
 	performance.LoadChecks()
 	platform.LoadChecks()
 	operator.LoadChecks()
+}
+
+func LoadChecksDB(labelsExpr string) {
+	LoadInternalChecksDB()
 
 	if preflight.ShouldRun(labelsExpr) {
 		preflight.LoadChecks()
@@ -99,18 +103,7 @@ func Startup() {
 	_ = clientsholder.GetClientsHolder(getK8sClientsConfigFileNames()...)
 	LoadChecksDB(testParams.LabelsFilter)
 
-	// If the list flag is passed, print the checks filtered with --labels and leave
-	if testParams.ListOnly {
-		checksIDs, err := checksdb.FilterCheckIDs()
-		if err != nil {
-			log.Fatal("Could not list test cases, err: %v", err)
-		} else {
-			cli.PrintChecksList(checksIDs)
-			os.Exit(0)
-		}
-	}
-
-	log.Info("CERTSUITE Version: %v", versions.GitVersion())
+	log.Info("Certsuite Version: %v", versions.GitVersion())
 	log.Info("Claim Format Version: %s", versions.ClaimFormatVersion)
 	log.Info("Labels filter: %v", testParams.LabelsFilter)
 	log.Info("Log level: %s", strings.ToUpper(testParams.LogLevel))
@@ -119,7 +112,7 @@ func Startup() {
 
 	cli.PrintBanner()
 
-	fmt.Printf("CERTSUITE version: %s\n", versions.GitVersion())
+	fmt.Printf("Certsuite version: %s\n", versions.GitVersion())
 	fmt.Printf("Claim file version: %s\n", versions.ClaimFormatVersion)
 	fmt.Printf("Checks filter: %s\n", testParams.LabelsFilter)
 	fmt.Printf("Output folder: %s\n", testParams.OutputDir)

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -115,6 +115,5 @@ type TestParameters struct {
 	EnableDataCollection          bool
 	EnableXMLCreation             bool
 	ServerMode                    bool
-	ListOnly                      bool
 	Timeout                       time.Duration
 }


### PR DESCRIPTION
As the "info" command already gets detailed Catalog information, it looks more convenient to integrate the functionality for listing test cases in it.

Also adds a new unit test for the "list" flag as part of the "info" command.