### PR TITLE
Change debug-partner to k8s-best-practices-debug

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -18,6 +18,8 @@ env:
   CERTSUITE_IMAGE_TAG: unstable
   OCT_IMAGE_NAME: testnetworkfunction/oct
   OCT_IMAGE_TAG: latest
+  DEBUG_IMAGE_NAME: testnetworkfunction/k8s-best-practices-debug
+  DEBUG_IMAGE_TAG: v0.0.2
   CERTSUITE_CONFIG_DIR: /tmp/certsuite/config
   CERTSUITE_OUTPUT_DIR: /tmp/certsuite/output
   SMOKE_TESTS_LOG_LEVEL: debug
@@ -156,8 +158,22 @@ jobs:
               exit 1
           fi
 
+  precheck-images:
+    name: Precheck Images
+    runs-on: ubuntu-22.04
+    env:
+      SHELL: /bin/bash
+    steps:
+      - name: Pull the images to verify they exist
+        run: |
+          docker pull ${REGISTRY}/${CERTSUITE_IMAGE_NAME}:${CERTSUITE_IMAGE_TAG}
+          docker pull ${REGISTRY}/${OCT_IMAGE_NAME}:${OCT_IMAGE_TAG}
+          docker pull ${REGISTRY}/${DEBUG_IMAGE_NAME}:${DEBUG_IMAGE_TAG}
+
   smoke-tests-local:
     name: Run Local Smoke Tests
+    needs: precheck-images
+    if: needs.precheck-images.result == 'success'
     runs-on: ubuntu-22.04
     env:
       SHELL: /bin/bash
@@ -251,6 +267,8 @@ jobs:
 
   smoke-tests-container:
     name: Run Container Smoke Tests
+    needs: precheck-images
+    if: needs.precheck-images.result == 'success'
     runs-on: ubuntu-22.04
     env:
       SHELL: /bin/bash

--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -87,7 +87,7 @@ jobs:
           echo "debug_version_number=$VERSION_FROM_FILE_DEBUG" >> $GITHUB_OUTPUT
         id: set_debug_version
         env:
-          VERSION_FROM_FILE_DEBUG: ${{ fromJSON(steps.get_version_json_file.outputs.json).debug_tag }}
+          VERSION_FROM_FILE_DEBUG: ${{ fromJSON(steps.get_version_json_file.outputs.json).debugTag }}
 
       - name: Update env variables
         run: |
@@ -107,7 +107,7 @@ jobs:
       - name: Check whether the version tag exists on remote
         run: git ls-remote --exit-code ${{ env.DEBUG_IMAGE_SRC_URL }} refs/tags/$DEBUG_IMAGE_VERSION
 
-      - name: (if debug_tag is missing) Display debug message
+      - name: (if debugTag is missing) Display debug message
         if: ${{ failure() }}
         run: echo "Tag '$DEBUG_IMAGE_VERSION' does not exist on remote $DEBUG_IMAGE_SRC_URL"
 

--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -33,8 +33,8 @@ env:
   TNF_CONFIG_DIR: /tmp/tnf/config
   TNF_OUTPUT_DIR: /tmp/tnf/output
   TNF_SRC_URL: 'https://github.com/${{ github.repository }}'
-  PARTNER_REPO: test-network-function/cnf-certification-test-partner
-  PARTNER_SRC_URL: 'https://github.com/${PARTNER_REPO}'
+  DEBUG_REPO: test-network-function/k8s-best-practices-debug
+  DEBUG_SRC_URL: 'https://github.com/${DEBUG_REPO}'
   TESTING_CMD_PARAMS: '-n host -i ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${IMAGE_TAG} -t ${TNF_CONFIG_DIR} -o ${TNF_OUTPUT_DIR}'
   ON_DEMAND_DEBUG_PODS: false
 
@@ -48,7 +48,7 @@ jobs:
       PFLT_DOCKERCONFIG: '/home/runner/.docker/config'
       CURRENT_VERSION_GENERIC_BRANCH: main
       TNF_VERSION: ""
-      PARTNER_VERSION: ""
+      DEBUG_VERSION: ""
     steps:
 
       - name: Write temporary docker file
@@ -83,21 +83,21 @@ jobs:
         run: echo "json=$(cat version.json | tr -d '[:space:]')" >> $GITHUB_OUTPUT
         id: get_version_json_file
 
-      - name: Get the partner version number from file
+      - name: Get the debug version number from file
         run: |
-          echo Partner version tag: $VERSION_FROM_FILE_PARTNER
-          echo "partner_version_number=$VERSION_FROM_FILE_PARTNER" >> $GITHUB_OUTPUT
-        id: set_partner_version
+          echo Debug version tag: $VERSION_FROM_FILE_DEBUG
+          echo "debug_version_number=$VERSION_FROM_FILE_DEBUG" >> $GITHUB_OUTPUT
+        id: set_debug_version
         env:
-          VERSION_FROM_FILE_PARTNER: ${{ fromJSON(steps.get_version_json_file.outputs.json).partner_tag }}
+          VERSION_FROM_FILE_DEBUG: ${{ fromJSON(steps.get_version_json_file.outputs.json).debug_tag }}
 
       - name: Update env variables
         run: |
           echo "TNF_VERSION=${{ steps.set_tnf_version.outputs.version_number }}" >> $GITHUB_ENV
-          echo "PARTNER_VERSION=${{ steps.set_partner_version.outputs.partner_version_number }}" >> $GITHUB_ENV
+          echo "DEBUG_VERSION=${{ steps.set_debug_version.outputs.debug_version_number }}" >> $GITHUB_ENV
 
       - name: Ensure $TNF_VERSION and $IMAGE_TAG are set
-        run: '[[ -n "$TNF_VERSION" ]] && [[ -n "$IMAGE_TAG" ]] && [[ -n "$PARTNER_VERSION" ]]'
+        run: '[[ -n "$TNF_VERSION" ]] && [[ -n "$IMAGE_TAG" ]] && [[ -n "$DEBUG_VERSION" ]]'
 
       - name: Check whether the version tag exists on remote
         run: git ls-remote --exit-code $TNF_SRC_URL refs/tags/$TNF_VERSION
@@ -107,11 +107,11 @@ jobs:
         run: echo "Tag '$TNF_VERSION' does not exist on remote $TNF_SRC_URL"
 
       - name: Check whether the version tag exists on remote
-        run: git ls-remote --exit-code ${{ env.PARTNER_SRC_URL }} refs/tags/$PARTNER_VERSION
+        run: git ls-remote --exit-code ${{ env.DEBUG_SRC_URL }} refs/tags/$DEBUG_VERSION
 
-      - name: (if partner_tag is missing) Display debug message
+      - name: (if debug_tag is missing) Display debug message
         if: ${{ failure() }}
-        run: echo "Tag '$PARTNER_VERSION' does not exist on remote $PARTNER_SRC_URL"
+        run: echo "Tag '$DEBUG_VERSION' does not exist on remote $DEBUG_SRC_URL"
 
       - name: Checkout the version tag
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -33,10 +33,8 @@ env:
   TNF_CONFIG_DIR: /tmp/tnf/config
   TNF_OUTPUT_DIR: /tmp/tnf/output
   TNF_SRC_URL: 'https://github.com/${{ github.repository }}'
-  DEBUG_REPO: test-network-function/k8s-best-practices-debug
-  DEBUG_SRC_URL: 'https://github.com/${DEBUG_REPO}'
-  TESTING_CMD_PARAMS: '-n host -i ${REGISTRY_LOCAL}/${TNF_IMAGE_NAME}:${IMAGE_TAG} -t ${TNF_CONFIG_DIR} -o ${TNF_OUTPUT_DIR}'
-  ON_DEMAND_DEBUG_PODS: false
+  DEBUG_IMAGE_REPO: test-network-function/k8s-best-practices-debug
+  DEBUG_IMAGE_SRC_URL: 'https://github.com/${DEBUG_IMAGE_REPO}'
 
 jobs:
   test-and-push-tnf-image-main:
@@ -48,7 +46,7 @@ jobs:
       PFLT_DOCKERCONFIG: '/home/runner/.docker/config'
       CURRENT_VERSION_GENERIC_BRANCH: main
       TNF_VERSION: ""
-      DEBUG_VERSION: ""
+      DEBUG_IMAGE_VERSION: ""
     steps:
 
       - name: Write temporary docker file
@@ -94,10 +92,10 @@ jobs:
       - name: Update env variables
         run: |
           echo "TNF_VERSION=${{ steps.set_tnf_version.outputs.version_number }}" >> $GITHUB_ENV
-          echo "DEBUG_VERSION=${{ steps.set_debug_version.outputs.debug_version_number }}" >> $GITHUB_ENV
+          echo "DEBUG_IMAGE_VERSION=${{ steps.set_debug_version.outputs.debug_version_number }}" >> $GITHUB_ENV
 
       - name: Ensure $TNF_VERSION and $IMAGE_TAG are set
-        run: '[[ -n "$TNF_VERSION" ]] && [[ -n "$IMAGE_TAG" ]] && [[ -n "$DEBUG_VERSION" ]]'
+        run: '[[ -n "$TNF_VERSION" ]] && [[ -n "$IMAGE_TAG" ]] && [[ -n "$DEBUG_IMAGE_VERSION" ]]'
 
       - name: Check whether the version tag exists on remote
         run: git ls-remote --exit-code $TNF_SRC_URL refs/tags/$TNF_VERSION
@@ -107,11 +105,11 @@ jobs:
         run: echo "Tag '$TNF_VERSION' does not exist on remote $TNF_SRC_URL"
 
       - name: Check whether the version tag exists on remote
-        run: git ls-remote --exit-code ${{ env.DEBUG_SRC_URL }} refs/tags/$DEBUG_VERSION
+        run: git ls-remote --exit-code ${{ env.DEBUG_IMAGE_SRC_URL }} refs/tags/$DEBUG_IMAGE_VERSION
 
       - name: (if debug_tag is missing) Display debug message
         if: ${{ failure() }}
-        run: echo "Tag '$DEBUG_VERSION' does not exist on remote $DEBUG_SRC_URL"
+        run: echo "Tag '$DEBUG_IMAGE_VERSION' does not exist on remote $DEBUG_IMAGE_SRC_URL"
 
       - name: Checkout the version tag
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/cmd/certsuite/run/run.go
+++ b/cmd/certsuite/run/run.go
@@ -40,7 +40,7 @@ func NewCommand() *cobra.Command {
 	runCmd.PersistentFlags().Bool("enable-data-collection", false, "Allow sending test results to an external data collector")
 	runCmd.PersistentFlags().Bool("create-xml-junit-file", false, "Create a JUnit file with the test results")
 	runCmd.PersistentFlags().String("tnf-image-repository", "quay.io/testnetworkfunction", "The repository where TNF images are stored")
-	runCmd.PersistentFlags().String("tnf-debug-image", "debug-partner:5.2.1", "Name of the TNF debug image")
+	runCmd.PersistentFlags().String("tnf-debug-image", "k8s-best-practices-debug:v0.0.1", "Name of the k8s-best-practices-debug image")
 	runCmd.PersistentFlags().String("daemonset-cpu-req", "100m", "CPU request for the debug DaemonSet container")
 	runCmd.PersistentFlags().String("daemonset-cpu-lim", "100m", "CPU limit for the debug DaemonSet container")
 	runCmd.PersistentFlags().String("daemonset-mem-req", "100M", "Memory request for the debug DaemonSet container")

--- a/cmd/certsuite/run/run.go
+++ b/cmd/certsuite/run/run.go
@@ -40,7 +40,7 @@ func NewCommand() *cobra.Command {
 	runCmd.PersistentFlags().Bool("enable-data-collection", false, "Allow sending test results to an external data collector")
 	runCmd.PersistentFlags().Bool("create-xml-junit-file", false, "Create a JUnit file with the test results")
 	runCmd.PersistentFlags().String("tnf-image-repository", "quay.io/testnetworkfunction", "The repository where TNF images are stored")
-	runCmd.PersistentFlags().String("tnf-debug-image", "k8s-best-practices-debug:v0.0.1", "Name of the k8s-best-practices-debug image")
+	runCmd.PersistentFlags().String("tnf-debug-image", "k8s-best-practices-debug:v0.0.2", "Name of the k8s-best-practices-debug image")
 	runCmd.PersistentFlags().String("daemonset-cpu-req", "100m", "CPU request for the debug DaemonSet container")
 	runCmd.PersistentFlags().String("daemonset-cpu-lim", "100m", "CPU limit for the debug DaemonSet container")
 	runCmd.PersistentFlags().String("daemonset-mem-req", "100M", "Memory request for the debug DaemonSet container")

--- a/docs/runtime-env.md
+++ b/docs/runtime-env.md
@@ -63,4 +63,4 @@ See more about this variable [here](https://github.com/redhat-openshift-ecosyste
 against a private container registry that has self-signed certificates.
 
 Note that you can also specify the debug pod image to use with `SUPPORT_IMAGE`
-environment variable, default to `k8s-best-practices-debug:v0.0.1`.
+environment variable, default to `k8s-best-practices-debug:v0.0.2`.

--- a/docs/runtime-env.md
+++ b/docs/runtime-env.md
@@ -62,17 +62,5 @@ See more about this variable [here](https://github.com/redhat-openshift-ecosyste
 `TNF_ALLOW_PREFLIGHT_INSECURE` (default: false) is required set to `true` if you are running
 against a private container registry that has self-signed certificates.
 
-## Disconnected environment
-
-In a disconnected environment, only specific versions of images are mirrored to
-the local repo. For those environments, the partner pod image
-`quay.io/testnetworkfunction/cnf-test-partner` and debug pod image
-`quay.io/testnetworkfunction/debug-partner` should be mirrored and
-`TNF_PARTNER_REPO` should be set to the local repo, e.g.:
-
-```shell
-export TNF_PARTNER_REPO=registry.dfwt5g.lab:5000/testnetworkfunction
-```
-
 Note that you can also specify the debug pod image to use with `SUPPORT_IMAGE`
-environment variable, default to `debug-partner:5.2.1`.
+environment variable, default to `k8s-best-practices-debug:v0.0.1`.

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "partner_tag": "v5.2.1",
+  "debug_tag": "v0.0.1",
   "claimFormat": "v0.4.0",
   "parserTag": "v0.4.7"
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "debug_tag": "v0.0.1",
+  "debugTag": "v0.0.1",
   "claimFormat": "v0.4.0",
   "parserTag": "v0.4.7"
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "debugTag": "v0.0.1",
+  "debugTag": "v0.0.2",
   "claimFormat": "v0.4.0",
   "parserTag": "v0.4.7"
 }


### PR DESCRIPTION
https://quay.io/repository/testnetworkfunction/k8s-best-practices-debug?tab=tags

https://github.com/test-network-function/k8s-best-practices-debug 

Instead of building and pushing the `debug` image from the `cnf-certification-test-partner` repo, we decided to de-couple the `debug` image from the complexity of the partner repo and just build it separately.

Changes to the partner repo (which is primarily used for the CI-related tasks) shouldn't affect the debug image (and versioning scheme) going forward.