### PR TITLE
tests/observability: fix observability-pod-disruption-budged test case

### DIFF
--- a/tests/observability/suite.go
+++ b/tests/observability/suite.go
@@ -27,11 +27,13 @@ import (
 	pdbv1 "github.com/test-network-function/cnf-certification-test/tests/observability/pdb"
 
 	"github.com/test-network-function/cnf-certification-test/internal/clientsholder"
+	"github.com/test-network-function/cnf-certification-test/internal/datautil"
 	"github.com/test-network-function/cnf-certification-test/internal/log"
 	"github.com/test-network-function/cnf-certification-test/pkg/checksdb"
 	"github.com/test-network-function/cnf-certification-test/pkg/provider"
 	"github.com/test-network-function/cnf-certification-test/pkg/testhelper"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -193,22 +195,29 @@ func testPodDisruptionBudgets(check *checksdb.Check, env *provider.TestEnvironme
 		check.LogInfo("Testing Deployment %q", d.ToString())
 		pdbFound := false
 		for pdbIndex := range env.PodDisruptionBudgets {
-			for k, v := range d.Spec.Template.Labels {
-				if env.PodDisruptionBudgets[pdbIndex].Spec.Selector.MatchLabels[k] == v {
-					pdbFound = true
-					if ok, err := pdbv1.CheckPDBIsValid(&env.PodDisruptionBudgets[pdbIndex], d.Spec.Replicas); !ok {
-						check.LogError("PDB %q is not valid for Deployment %q, err: %v", env.PodDisruptionBudgets[pdbIndex].Name, d.Name, err)
-						nonCompliantObjects = append(nonCompliantObjects, testhelper.NewReportObject(fmt.Sprintf("Invalid PodDisruptionBudget config: %v", err), testhelper.DeploymentType, false).
-							AddField(testhelper.DeploymentName, d.Name).
-							AddField(testhelper.Namespace, d.Namespace).
-							AddField(testhelper.PodDisruptionBudgetReference, env.PodDisruptionBudgets[pdbIndex].Name))
-					} else {
-						check.LogInfo("PDB %q is valid for Deployment: %q", env.PodDisruptionBudgets[pdbIndex].Name, d.Name)
-						compliantObjects = append(compliantObjects, testhelper.NewReportObject("Deployment: references PodDisruptionBudget", testhelper.DeploymentType, true).
-							AddField(testhelper.DeploymentName, d.Name).
-							AddField(testhelper.Namespace, d.Namespace).
-							AddField(testhelper.PodDisruptionBudgetReference, env.PodDisruptionBudgets[pdbIndex].Name))
-					}
+			pdb := &env.PodDisruptionBudgets[pdbIndex]
+			if pdb.Namespace != d.Namespace {
+				continue
+			}
+			pdbSelectorMap, err := metav1.LabelSelectorAsMap(pdb.Spec.Selector)
+			if err != nil {
+				check.LogError("Could not convert the PDB %q selector to a map, err: %v", pdb.Name, err)
+				continue
+			}
+			if pdbSelectorMap != nil && datautil.IsMapSubset(d.Spec.Template.Labels, pdbSelectorMap) {
+				pdbFound = true
+				if ok, err := pdbv1.CheckPDBIsValid(pdb, d.Spec.Replicas); !ok {
+					check.LogError("PDB %q is not valid for Deployment %q, err: %v", pdb.Name, d.Name, err)
+					nonCompliantObjects = append(nonCompliantObjects, testhelper.NewReportObject(fmt.Sprintf("Invalid PodDisruptionBudget config: %v", err), testhelper.DeploymentType, false).
+						AddField(testhelper.DeploymentName, d.Name).
+						AddField(testhelper.Namespace, d.Namespace).
+						AddField(testhelper.PodDisruptionBudgetReference, pdb.Name))
+				} else {
+					check.LogInfo("PDB %q is valid for Deployment: %q", pdb.Name, d.Name)
+					compliantObjects = append(compliantObjects, testhelper.NewReportObject("Deployment: references PodDisruptionBudget", testhelper.DeploymentType, true).
+						AddField(testhelper.DeploymentName, d.Name).
+						AddField(testhelper.Namespace, d.Namespace).
+						AddField(testhelper.PodDisruptionBudgetReference, pdb.Name))
 				}
 			}
 		}
@@ -224,22 +233,28 @@ func testPodDisruptionBudgets(check *checksdb.Check, env *provider.TestEnvironme
 		check.LogInfo("Testing StatefulSet %q", s.ToString())
 		pdbFound := false
 		for pdbIndex := range env.PodDisruptionBudgets {
-			for k, v := range s.Spec.Template.Labels {
-				if env.PodDisruptionBudgets[pdbIndex].Spec.Selector.MatchLabels[k] == v {
-					pdbFound = true
-					if ok, err := pdbv1.CheckPDBIsValid(&env.PodDisruptionBudgets[pdbIndex], s.Spec.Replicas); !ok {
-						check.LogError("PDB %q is not valid for StatefulSet %q, err: %v", env.PodDisruptionBudgets[pdbIndex].Name, s.Name, err)
-						nonCompliantObjects = append(nonCompliantObjects, testhelper.NewReportObject(fmt.Sprintf("Invalid PodDisruptionBudget config: %v", err), testhelper.StatefulSetType, false).
-							AddField(testhelper.StatefulSetName, s.Name).
-							AddField(testhelper.Namespace, s.Namespace).
-							AddField(testhelper.PodDisruptionBudgetReference, env.PodDisruptionBudgets[pdbIndex].Name))
-					} else {
-						check.LogInfo("PDB %q is valid for StatefulSet: %q", env.PodDisruptionBudgets[pdbIndex].Name, s.Name)
-						compliantObjects = append(compliantObjects, testhelper.NewReportObject("StatefulSet: references PodDisruptionBudget", testhelper.StatefulSetType, true).
-							AddField(testhelper.StatefulSetName, s.Name).
-							AddField(testhelper.Namespace, s.Namespace).
-							AddField(testhelper.PodDisruptionBudgetReference, env.PodDisruptionBudgets[pdbIndex].Name))
-					}
+			pdb := &env.PodDisruptionBudgets[pdbIndex]
+			if pdb.Namespace != s.Namespace {
+				continue
+			}
+			pdbSelectorMap, err := metav1.LabelSelectorAsMap(pdb.Spec.Selector)
+			if err != nil {
+				check.LogError("Could not convert the PDB %q selector to a map, err: %v", pdb.Name, err)
+			}
+			if pdbSelectorMap != nil && datautil.IsMapSubset(s.Spec.Template.Labels, pdbSelectorMap) {
+				pdbFound = true
+				if ok, err := pdbv1.CheckPDBIsValid(pdb, s.Spec.Replicas); !ok {
+					check.LogError("PDB %q is not valid for StatefulSet %q, err: %v", pdb.Name, s.Name, err)
+					nonCompliantObjects = append(nonCompliantObjects, testhelper.NewReportObject(fmt.Sprintf("Invalid PodDisruptionBudget config: %v", err), testhelper.StatefulSetType, false).
+						AddField(testhelper.StatefulSetName, s.Name).
+						AddField(testhelper.Namespace, s.Namespace).
+						AddField(testhelper.PodDisruptionBudgetReference, pdb.Name))
+				} else {
+					check.LogInfo("PDB %q is valid for StatefulSet: %q", pdb.Name, s.Name)
+					compliantObjects = append(compliantObjects, testhelper.NewReportObject("StatefulSet: references PodDisruptionBudget", testhelper.StatefulSetType, true).
+						AddField(testhelper.StatefulSetName, s.Name).
+						AddField(testhelper.Namespace, s.Namespace).
+						AddField(testhelper.PodDisruptionBudgetReference, pdb.Name))
 				}
 			}
 		}


### PR DESCRIPTION
Use all the labels defined in the PDB's selector "MatchLabels" fields to match workloads, as the Kubernetes documentation specifies that those labels should be ANDed.

Also, take into account the "MatchExpressions" field of the selector when it can be properly converted to a map.