### PR TITLE
Remove result cast; -claim update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
-	github.com/test-network-function/test-network-function-claim v1.0.43
+	github.com/test-network-function/test-network-function-claim v1.0.44
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -441,8 +441,8 @@ github.com/test-network-function/oct v0.0.16 h1:03928xEEwYTVOx+NzSTO6yn1ZwJC0I6G
 github.com/test-network-function/oct v0.0.16/go.mod h1:fO+xvJYjjDOAX2xlmrhLF4UmVzMMxVGqurcAda+HkSs=
 github.com/test-network-function/privileged-daemonset v1.0.28 h1:37gCk/gC6Lq7MYFMcKDyFAl4xTKkXolg5Y0rDvkmYik=
 github.com/test-network-function/privileged-daemonset v1.0.28/go.mod h1:E9Y8UMf+Ey4RdEAAJH1OIUar7/9BLFtvGVJkqifIHfY=
-github.com/test-network-function/test-network-function-claim v1.0.43 h1:0wMSRCaXjatn8bEHUmXe/Cbg2+DM0I1KXjuG/tDIPZ4=
-github.com/test-network-function/test-network-function-claim v1.0.43/go.mod h1:qx39rLEBKV1Th5IcmaapgVpNbOtBYPpzvgg6Qw/hkxI=
+github.com/test-network-function/test-network-function-claim v1.0.44 h1:5zTSJxCuTkxIAMP8Otz1KQye0mF2CRTrikTUO2SUUoI=
+github.com/test-network-function/test-network-function-claim v1.0.44/go.mod h1:qx39rLEBKV1Th5IcmaapgVpNbOtBYPpzvgg6Qw/hkxI=
 github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinCts=
 github.com/vbatts/tar-split v0.11.5/go.mod h1:yZbwRsSeGjusneWgA781EKej9HF8vme8okylkAeNKLk=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/pkg/checksdb/checksdb.go
+++ b/pkg/checksdb/checksdb.go
@@ -138,13 +138,13 @@ func recordCheckResult(check *Check) {
 
 // GetReconciledResults is a function added to aggregate a Claim's results.  Due to the limitations of
 // test-network-function-claim's Go Client, results are generalized to map[string]interface{}.
-func GetReconciledResults() map[string]interface{} {
-	resultMap := make(map[string]interface{})
+func GetReconciledResults() map[string]claim.Result {
+	resultMap := make(map[string]claim.Result)
 	//nolint:gocritic
 	for key, val := range resultsDB {
 		// initializes the result map, if necessary
 		if _, ok := resultMap[key]; !ok {
-			resultMap[key] = make([]claim.Result, 0)
+			resultMap[key] = claim.Result{}
 		}
 
 		resultMap[key] = val

--- a/pkg/claimhelper/claimhelper_test.go
+++ b/pkg/claimhelper/claimhelper_test.go
@@ -28,7 +28,7 @@ import (
 func TestPopulateXMLFromClaim(t *testing.T) {
 	generateClaim := func(results map[string]claim.Result) claim.Claim {
 		c := claim.Claim{}
-		c.Results = make(map[string]interface{})
+		c.Results = make(map[string]claim.Result)
 
 		// Set the results if any
 		for k, v := range results {


### PR DESCRIPTION
Removes the need for the `interface` being re-casted into a `claim.Result`.

-claim repo has already been updated in: https://github.com/test-network-function/test-network-function-claim/pull/124