### PR TITLE
Add option to sanitize claim file result output

### DIFF
--- a/cmd/certsuite/run/run.go
+++ b/cmd/certsuite/run/run.go
@@ -45,6 +45,7 @@ func NewCommand() *cobra.Command {
 	runCmd.PersistentFlags().String("daemonset-cpu-lim", "100m", "CPU limit for the debug DaemonSet container")
 	runCmd.PersistentFlags().String("daemonset-mem-req", "100M", "Memory request for the debug DaemonSet container")
 	runCmd.PersistentFlags().String("daemonset-mem-lim", "100M", "Memory limit for the debug DaemonSet container")
+	runCmd.PersistentFlags().Bool("sanitize-claim", false, "Sanitize the claim.json file before sending it to the collector")
 
 	return runCmd
 }
@@ -73,6 +74,7 @@ func initTestParamsFromFlags(cmd *cobra.Command) error {
 	testParams.DaemonsetCPULim, _ = cmd.Flags().GetString("daemonset-cpu-lim")
 	testParams.DaemonsetMemReq, _ = cmd.Flags().GetString("daemonset-mem-req")
 	testParams.DaemonsetMemLim, _ = cmd.Flags().GetString("daemonset-mem-lim")
+	testParams.SanitizeClaim, _ = cmd.Flags().GetBool("sanitize-claim")
 	timeoutStr, _ := cmd.Flags().GetString("timeout")
 
 	// Check if the output directory exists and, if not, create it

--- a/pkg/certsuite/certsuite.go
+++ b/pkg/certsuite/certsuite.go
@@ -167,11 +167,19 @@ func Run(labelsFilter, outputFolder string) error {
 		claimBuilder.ToJUnitXML(junitOutputFileName, startTime, endTime)
 	}
 
+	if configuration.GetTestParameters().SanitizeClaim {
+		claimOutputFile, err = claimhelper.SanitizeClaimFile(claimOutputFile, configuration.GetTestParameters().LabelsFilter)
+		if err != nil {
+			log.Error("Failed to sanitize claim file: %v", err)
+		}
+	}
+
 	// Send claim file to the collector if specified by env var
 	if configuration.GetTestParameters().EnableDataCollection {
 		if env.CollectorAppEndpoint == "" {
 			env.CollectorAppEndpoint = collectorAppURL
 		}
+
 		err = collector.SendClaimFileToCollector(env.CollectorAppEndpoint, claimOutputFile, env.ExecutedBy, env.PartnerName, env.CollectorAppPassword)
 		if err != nil {
 			log.Error("Failed to send post request to the collector: %v", err)

--- a/pkg/checksdb/checksdb.go
+++ b/pkg/checksdb/checksdb.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/test-network-function/cnf-certification-test/internal/cli"
 	"github.com/test-network-function/cnf-certification-test/internal/log"
+	"github.com/test-network-function/cnf-certification-test/pkg/labels"
 	"github.com/test-network-function/cnf-certification-test/pkg/stringhelper"
 	"github.com/test-network-function/cnf-certification-test/tests/identifiers"
 	"github.com/test-network-function/test-network-function-claim/pkg/claim"
@@ -23,7 +24,7 @@ var (
 
 	resultsDB = map[string]claim.Result{}
 
-	labelsExprEvaluator LabelsExprEvaluator
+	labelsExprEvaluator labels.LabelsExprEvaluator
 )
 
 type AbortPanicMsg string
@@ -252,7 +253,7 @@ func InitLabelsExprEvaluator(labelsFilter string) error {
 		labelsFilter = strings.Join(allTags, ",")
 	}
 
-	eval, err := newLabelsExprEvaluator(labelsFilter)
+	eval, err := labels.NewLabelsExprEvaluator(labelsFilter)
 	if err != nil {
 		return fmt.Errorf("could not create a label evaluator, err: %v", err)
 	}

--- a/pkg/claimhelper/claimhelper.go
+++ b/pkg/claimhelper/claimhelper.go
@@ -148,6 +148,11 @@ func (c *ClaimBuilder) Build(outputFile string) {
 	log.Info("Claim file created at %s", outputFile)
 }
 
+func (c *ClaimBuilder) GetClaimResults() *claim.Root {
+	c.claimRoot.Claim.Results = checksdb.GetReconciledResults()
+	return c.claimRoot
+}
+
 //nolint:funlen
 func populateXMLFromClaim(c claim.Claim, startTime, endTime time.Time) TestSuitesXML {
 	const (
@@ -302,11 +307,7 @@ func ReadClaimFile(claimFileName string) (data []byte, err error) {
 	if err != nil {
 		log.Error("ReadFile failed with err: %v", err)
 	}
-	path, err := os.Getwd()
-	if err != nil {
-		log.Error("Getwd failed with err: %v", err)
-	}
-	log.Info("Reading claim file at path: %s", path)
+	log.Info("Reading claim file at path: %s", claimFileName)
 	return data, nil
 }
 
@@ -340,6 +341,7 @@ func MarshalClaimOutput(claimRoot *claim.Root) []byte {
 
 // WriteClaimOutput writes the output payload to the claim file.  In the event of an error, this method fatally fails.
 func WriteClaimOutput(claimOutputFile string, payload []byte) {
+	log.Info("Writing claim data to %s", claimOutputFile)
 	err := os.WriteFile(claimOutputFile, payload, claimFilePermissions)
 	if err != nil {
 		log.Fatal("Error writing claim data:\n%s", string(payload))
@@ -373,4 +375,31 @@ func CreateClaimRoot() *claim.Root {
 			},
 		},
 	}
+}
+
+func SanitizeClaimFile(claimFileName, labelsFilter string) (string, error) {
+	log.Info("Sanitizing claim file %s", claimFileName)
+	data, err := ReadClaimFile(claimFileName)
+	if err != nil {
+		log.Error("ReadClaimFile failed with err: %v", err)
+		return "", err
+	}
+	var aRoot claim.Root
+	UnmarshalClaim(data, &aRoot)
+
+	// Remove the results that do not match the labels filter
+	for testID := range aRoot.Claim.Results {
+		if aRoot.Claim.Results[testID].TestID.Id != labelsFilter {
+			log.Info("Removing test ID: %s from the claim", testID)
+			delete(aRoot.Claim.Results, testID)
+		}
+	}
+
+	log.Info("Number of results after sanitizing: %d", len(aRoot.Claim.Results))
+	if len(aRoot.Claim.Results) == 1 {
+		log.Info("Sanitized claim file contains only one test case: %s", labelsFilter)
+	}
+
+	WriteClaimOutput(claimFileName, MarshalClaimOutput(&aRoot))
+	return claimFileName, nil
 }

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -106,6 +106,7 @@ type TestParameters struct {
 	DaemonsetCPULim               string
 	DaemonsetMemReq               string
 	DaemonsetMemLim               string
+	SanitizeClaim                 bool
 	TnfImageRepo                  string
 	TnfDebugImage                 string
 	NonIntrusiveOnly              bool

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -1,4 +1,4 @@
-package checksdb
+package labels
 
 import (
 	"fmt"
@@ -18,7 +18,7 @@ type labelsExprParser struct {
 	astRootNode ast.Expr
 }
 
-func newLabelsExprEvaluator(labelsExpr string) (LabelsExprEvaluator, error) {
+func NewLabelsExprEvaluator(labelsExpr string) (LabelsExprEvaluator, error) {
 	goLikeExpr := strings.ReplaceAll(labelsExpr, "-", "_")
 	goLikeExpr = strings.ReplaceAll(goLikeExpr, ",", "||")
 

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -1,4 +1,4 @@
-package checksdb
+package labels
 
 import (
 	"testing"
@@ -124,7 +124,7 @@ func TestIsWordInExpr(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Get labels expr evaluator
-			labelsExprEvaluator, err := newLabelsExprEvaluator(tt.args.expr)
+			labelsExprEvaluator, err := NewLabelsExprEvaluator(tt.args.expr)
 			assert.NotNil(t, labelsExprEvaluator)
 			assert.Nil(t, err)
 


### PR DESCRIPTION
Adds a flag `--sanitize-claim` which defaults to false.  This is mostly used for QE.

Modifies the `NewLabelsExprEvaluator` and related functions to its own package named `labels`.