### PR TITLE
Add claimhelper pkg unit tests

### DIFF
--- a/pkg/claimhelper/claimhelper.go
+++ b/pkg/claimhelper/claimhelper.go
@@ -108,6 +108,12 @@ type ClaimBuilder struct {
 }
 
 func NewClaimBuilder() (*ClaimBuilder, error) {
+	if os.Getenv("UNIT_TEST") == "true" {
+		return &ClaimBuilder{
+			claimRoot: CreateClaimRoot(),
+		}, nil
+	}
+
 	log.Debug("Creating claim file builder.")
 	configurations, err := MarshalConfigurations()
 	if err != nil {
@@ -302,11 +308,7 @@ func ReadClaimFile(claimFileName string) (data []byte, err error) {
 	if err != nil {
 		log.Error("ReadFile failed with err: %v", err)
 	}
-	path, err := os.Getwd()
-	if err != nil {
-		log.Error("Getwd failed with err: %v", err)
-	}
-	log.Info("Reading claim file at path: %s", path)
+	log.Info("Reading claim file at path: %s", claimFileName)
 	return data, nil
 }
 

--- a/pkg/claimhelper/claimhelper_test.go
+++ b/pkg/claimhelper/claimhelper_test.go
@@ -17,6 +17,7 @@
 package claimhelper
 
 import (
+	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -116,4 +117,194 @@ func TestPopulateXMLFromClaim(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, int(expectedTimeFloat), int(actualTimeFloat))
 	}
+}
+
+func TestToJUnitXML(t *testing.T) {
+	testCases := []struct {
+		testResults       map[string]claim.Result
+		expectedXMLResult string
+	}{
+		{
+			testResults: map[string]claim.Result{
+				"test-case1": {
+					TestID: &claim.Identifier{
+						Id:    "test-case1",
+						Suite: "test-suite1",
+					},
+					State:              "failed",
+					SkipReason:         "my custom failure message",
+					StartTime:          "2023-12-20 14:51:33 -0600 MST",
+					EndTime:            "2023-12-20 14:51:34 -0600 MST",
+					CheckDetails:       "",
+					CapturedTestOutput: "test output",
+					CategoryClassification: &claim.CategoryClassification{
+						Extended: "false",
+						FarEdge:  "false",
+						NonTelco: "false",
+						Telco:    "true",
+					},
+				},
+			},
+			expectedXMLResult: "<testsuites tests=\"1\" disabled=\"0\" errors=\"0\" failures=\"1\" time=\"1.00000\">",
+		},
+		{
+			testResults: map[string]claim.Result{
+				"test-case1": {
+					TestID: &claim.Identifier{
+						Id:    "test-case1",
+						Suite: "test-suite1",
+					},
+					State:              "passed",
+					SkipReason:         "",
+					StartTime:          "2023-12-20 14:51:33 -0600 MST",
+					EndTime:            "2023-12-20 14:51:34 -0600 MST",
+					CheckDetails:       "",
+					CapturedTestOutput: "test output",
+					CategoryClassification: &claim.CategoryClassification{
+						Extended: "false",
+						FarEdge:  "false",
+						NonTelco: "false",
+						Telco:    "true",
+					},
+				},
+			},
+			expectedXMLResult: "<testsuites tests=\"1\" disabled=\"0\" errors=\"0\" failures=\"0\" time=\"1.00000\">",
+		},
+	}
+
+	t.Setenv("UNIT_TEST", "true")
+	defer os.Remove("testfile.xml")
+	defer os.Unsetenv("UNIT_TEST")
+
+	for _, tc := range testCases {
+		// Build some 1 minute duration start and end time
+		startTime, err := time.Parse(DateTimeFormatDirective, "2023-12-20 14:51:33 -0600 MST")
+		assert.Nil(t, err)
+		endTime, err := time.Parse(DateTimeFormatDirective, "2023-12-20 14:51:34 -0600 MST")
+		assert.Nil(t, err)
+
+		testClaimBuilder, err := NewClaimBuilder()
+		assert.Nil(t, err)
+
+		testClaimBuilder.claimRoot.Claim.Results = make(map[string]claim.Result)
+		testClaimBuilder.claimRoot.Claim.Results = tc.testResults
+
+		testClaimBuilder.ToJUnitXML("testfile.xml", startTime, endTime)
+
+		// read the file and compare the contents
+		outputFile, err := os.ReadFile("testfile.xml")
+		assert.Nil(t, err)
+
+		xmlResult := string(outputFile)
+
+		// Compare the values in the XML
+		assert.Contains(t, xmlResult, tc.expectedXMLResult)
+		os.Remove("testfile.xml")
+	}
+}
+
+func TestMarshalClaimOutput(t *testing.T) {
+	testClaimRoot := &claim.Root{
+		Claim: &claim.Claim{
+			Metadata: &claim.Metadata{
+				StartTime: "2023-12-20 14:51:33 -0600 MST",
+				EndTime:   "2023-12-20 14:51:34 -0600 MST",
+			},
+			Versions: &claim.Versions{
+				Tnf: "1.0.0",
+			},
+			Results: map[string]claim.Result{
+				"test-case1": {
+					TestID: &claim.Identifier{
+						Id:    "test-case1",
+						Suite: "test-suite1",
+					},
+					State: "failed",
+				},
+			},
+		},
+	}
+
+	output := MarshalClaimOutput(testClaimRoot)
+	assert.NotNil(t, output)
+
+	// Check if the output is a valid JSON
+	//nolint:lll
+	assert.Contains(t, string(output), "{\n  \"claim\": {\n    \"configurations\": null,\n    \"metadata\": {\n      \"endTime\": \"2023-12-20 14:51:34 -0600 MST\",\n      \"startTime\": \"2023-12-20 14:51:33 -0600 MST\"\n    },\n    \"nodes\": null,\n    \"results\": {\n      \"test-case1\": {\n        \"capturedTestOutput\": \"\",\n        \"catalogInfo\": null,\n        \"categoryClassification\": null,\n        \"checkDetails\": \"\",\n        \"duration\": 0,\n        \"failureLineContent\": \"\",\n        \"failureLocation\": \"\",\n        \"skipReason\": \"\",\n        \"startTime\": \"\",\n        \"state\": \"failed\",\n        \"testID\": {\n          \"id\": \"test-case1\",\n          \"suite\": \"test-suite1\",\n          \"tags\": \"\"\n        }\n      }\n    },\n    \"versions\": {\n      \"claimFormat\": \"\",\n      \"k8s\": \"\",\n      \"ocClient\": \"\",\n      \"ocp\": \"\",\n      \"tnf\": \"1.0.0\",\n      \"tnfGitCommit\": \"\"\n    }\n  }\n}")
+}
+
+func TestWriteClaimOutput(t *testing.T) {
+	testClaimRoot := &claim.Root{
+		Claim: &claim.Claim{
+			Metadata: &claim.Metadata{
+				StartTime: "2023-12-20 14:51:33 -0600 MST",
+				EndTime:   "2023-12-20 14:51:34 -0600 MST",
+			},
+			Versions: &claim.Versions{
+				Tnf: "1.0.0",
+			},
+			Results: map[string]claim.Result{
+				"test-case1": {
+					TestID: &claim.Identifier{
+						Id:    "test-case1",
+						Suite: "test-suite1",
+					},
+					State: "failed",
+				},
+			},
+		},
+	}
+
+	outputFile := "testfile_writeclaimoutput.json"
+	claimOutput := MarshalClaimOutput(testClaimRoot)
+	WriteClaimOutput(outputFile, claimOutput)
+	defer os.Remove(outputFile)
+
+	// read the file and compare the contents
+	output, err := os.ReadFile(outputFile)
+	assert.Nil(t, err)
+
+	// Check if the output is a valid JSON
+	//nolint:lll
+	assert.Contains(t, string(output), "{\n  \"claim\": {\n    \"configurations\": null,\n    \"metadata\": {\n      \"endTime\": \"2023-12-20 14:51:34 -0600 MST\",\n      \"startTime\": \"2023-12-20 14:51:33 -0600 MST\"\n    },\n    \"nodes\": null,\n    \"results\": {\n      \"test-case1\": {\n        \"capturedTestOutput\": \"\",\n        \"catalogInfo\": null,\n        \"categoryClassification\": null,\n        \"checkDetails\": \"\",\n        \"duration\": 0,\n        \"failureLineContent\": \"\",\n        \"failureLocation\": \"\",\n        \"skipReason\": \"\",\n        \"startTime\": \"\",\n        \"state\": \"failed\",\n        \"testID\": {\n          \"id\": \"test-case1\",\n          \"suite\": \"test-suite1\",\n          \"tags\": \"\"\n        }\n      }\n    },\n    \"versions\": {\n      \"claimFormat\": \"\",\n      \"k8s\": \"\",\n      \"ocClient\": \"\",\n      \"ocp\": \"\",\n      \"tnf\": \"1.0.0\",\n      \"tnfGitCommit\": \"\"\n    }\n  }\n}")
+
+	// Assert the file permissions are 0644
+	fileInfo, err := os.Stat(outputFile)
+	assert.Nil(t, err)
+	assert.Equal(t, "-rw-r--r--", fileInfo.Mode().String())
+}
+
+func TestReadClaimFile(t *testing.T) {
+	testClaimRoot := &claim.Root{
+		Claim: &claim.Claim{
+			Metadata: &claim.Metadata{
+				StartTime: "2023-12-20 14:51:33 -0600 MST",
+				EndTime:   "2023-12-20 14:51:34 -0600 MST",
+			},
+			Versions: &claim.Versions{
+				Tnf: "1.0.0",
+			},
+			Results: map[string]claim.Result{
+				"test-case1": {
+					TestID: &claim.Identifier{
+						Id:    "test-case1",
+						Suite: "test-suite1",
+					},
+					State: "failed",
+				},
+			},
+		},
+	}
+
+	outputFile := "testfile_readclaimfile.json"
+	claimOutput := MarshalClaimOutput(testClaimRoot)
+	WriteClaimOutput(outputFile, claimOutput)
+	defer os.Remove(outputFile)
+
+	// read the file and compare the contents
+	output, err := ReadClaimFile(outputFile)
+	assert.Nil(t, err)
+
+	// Check if the output is a valid JSON
+	assert.Contains(t, string(output), "test-case1")
 }


### PR DESCRIPTION
Cover more functionality in the `claimhelper` package with unit tests.